### PR TITLE
feat: UI 프리미티브 컴포넌트 라이브러리 구축 (#6)

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -226,8 +226,9 @@
         "dependencies": [
           "2"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-23T15:49:27.743Z"
       },
       {
         "id": "5",
@@ -311,9 +312,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-04-23T14:44:33.101Z",
+      "lastModified": "2026-04-23T15:49:27.748Z",
       "taskCount": 10,
-      "completedCount": 3,
+      "completedCount": 4,
       "tags": [
         "master"
       ]

--- a/src/app/playground/components/page.tsx
+++ b/src/app/playground/components/page.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { type ReactNode } from 'react';
+
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import {
+  BottomSheet,
+  BottomSheetBody,
+  BottomSheetContent,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  BottomSheetTitle,
+  BottomSheetTrigger,
+} from '@/components/ui/bottom-sheet';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Chip } from '@/components/ui/chip';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Spinner } from '@/components/ui/spinner';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import type { SessionType } from '@/global/types';
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-foreground-sub text-sm font-semibold tracking-wide uppercase">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+const sessions: SessionType[] = [
+  'VOCAL',
+  'CHORUS',
+  'GUITAR',
+  'BASS',
+  'DRUM',
+  'PERCUSSION',
+  'SYNTH',
+  'ETC',
+];
+
+export default function ComponentsPlaygroundPage() {
+  return (
+    <main className="mx-auto max-w-5xl space-y-10 p-6">
+      <header className="space-y-2">
+        <h1 className="text-foreground text-2xl font-bold">UI Primitives Playground</h1>
+        <p className="text-foreground-sub text-sm">
+          Task 4에서 구현한 UI 프리미티브의 variant/size 조합을 시각 검증하는 페이지.
+        </p>
+      </header>
+
+      <Section title="Button">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button>Primary</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="danger">Danger</Button>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button size="sm">Small</Button>
+          <Button size="md">Medium</Button>
+          <Button size="lg">Large</Button>
+          <Button loading>저장 중…</Button>
+          <Button disabled>비활성</Button>
+        </div>
+      </Section>
+
+      <Section title="Spinner">
+        <div className="flex items-center gap-4">
+          <Spinner size="sm" />
+          <Spinner size="md" />
+          <Spinner size="lg" />
+        </div>
+      </Section>
+
+      <Section title="Input / Textarea / Select">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Input label="이메일" placeholder="you@bandage.com" hint="로그인에 사용됩니다." />
+          <Input label="비밀번호" type="password" error="8자 이상 입력해 주세요." required />
+          <Textarea label="밴드 소개" placeholder="우리 밴드를 소개해 주세요." required />
+          <Select
+            label="세션"
+            placeholder="세션을 선택하세요"
+            options={sessions.map((s) => ({ value: s, label: s }))}
+          />
+        </div>
+      </Section>
+
+      <Section title="Card">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <Card header="멤버 카드" footer="2024년 가입">
+            <p className="text-foreground-sub text-sm">
+              카드 컴포넌트는 header/footer/padding/interactive 속성을 지원합니다.
+            </p>
+          </Card>
+          <Card interactive>
+            <p className="text-foreground text-sm font-medium">Interactive Card</p>
+            <p className="text-foreground-muted text-xs">호버 시 card-hover 토큰으로 전환</p>
+          </Card>
+        </div>
+      </Section>
+
+      <Section title="Badge">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge>Default</Badge>
+          <Badge variant="accent">Accent</Badge>
+          <Badge variant="success">Success</Badge>
+          <Badge variant="warn">Warn</Badge>
+          <Badge variant="danger">Danger</Badge>
+        </div>
+      </Section>
+
+      <Section title="Chip (Session)">
+        <div className="flex flex-wrap items-center gap-2">
+          {sessions.map((s) => (
+            <Chip key={s} session={s}>
+              {s}
+            </Chip>
+          ))}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip interactive onClick={() => undefined}>
+            Interactive
+          </Chip>
+          <Chip interactive selected onClick={() => undefined}>
+            Selected
+          </Chip>
+        </div>
+      </Section>
+
+      <Section title="Avatar">
+        <div className="flex flex-wrap items-center gap-3">
+          <Avatar size="sm" fallback="홍길동" />
+          <Avatar size="md" fallback="김밴드" />
+          <Avatar size="lg" fallback="Sunwoo Jung" />
+          <Avatar
+            size="xl"
+            fallback="W J"
+            src="https://i.pravatar.cc/128?u=bandage"
+            alt="pravatar"
+          />
+        </div>
+      </Section>
+
+      <Section title="Skeleton">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-4 w-64" />
+          <Skeleton className="h-20 w-full" rounded="lg" />
+          <div className="flex gap-2">
+            <Skeleton className="h-10 w-10" rounded="pill" />
+            <Skeleton className="h-10 flex-1" />
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Tabs">
+        <Tabs defaultValue="info" className="max-w-md">
+          <TabsList>
+            <TabsTrigger value="info">정보</TabsTrigger>
+            <TabsTrigger value="members">멤버</TabsTrigger>
+            <TabsTrigger value="songs">곡</TabsTrigger>
+          </TabsList>
+          <TabsContent value="info">
+            <Card>정보 탭 콘텐츠</Card>
+          </TabsContent>
+          <TabsContent value="members">
+            <Card>멤버 탭 콘텐츠</Card>
+          </TabsContent>
+          <TabsContent value="songs">
+            <Card>곡 탭 콘텐츠</Card>
+          </TabsContent>
+        </Tabs>
+      </Section>
+
+      <Section title="Dialog">
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="secondary">Dialog 열기</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>밴드 삭제</DialogTitle>
+              <DialogDescription>
+                삭제된 밴드는 복구할 수 없습니다. 계속 진행할까요?
+              </DialogDescription>
+            </DialogHeader>
+            <DialogBody>연관된 합주/공연/신청 내역도 함께 비활성화됩니다.</DialogBody>
+            <DialogFooter>
+              <Button variant="ghost">취소</Button>
+              <Button variant="danger">삭제</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </Section>
+
+      <Section title="BottomSheet">
+        <BottomSheet>
+          <BottomSheetTrigger asChild>
+            <Button variant="secondary">BottomSheet 열기</Button>
+          </BottomSheetTrigger>
+          <BottomSheetContent>
+            <BottomSheetHeader>
+              <BottomSheetTitle>세션 선택</BottomSheetTitle>
+            </BottomSheetHeader>
+            <BottomSheetBody>
+              <div className="flex flex-wrap gap-2">
+                {sessions.map((s) => (
+                  <Chip key={s} session={s}>
+                    {s}
+                  </Chip>
+                ))}
+              </div>
+            </BottomSheetBody>
+            <BottomSheetFooter>
+              <Button>확인</Button>
+            </BottomSheetFooter>
+          </BottomSheetContent>
+        </BottomSheet>
+      </Section>
+    </main>
+  );
+}

--- a/src/components/ui/__snapshots__/button.test.tsx.snap
+++ b/src/components/ui/__snapshots__/button.test.tsx.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Button > variant 와 size props에 따라 클래스가 바뀐다 1`] = `
+<DocumentFragment>
+  <button
+    class="inline-flex items-center justify-center gap-2 font-medium rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:opacity-50 disabled:pointer-events-none bg-danger text-foreground hover:opacity-90 h-12 px-6 text-base"
+    type="button"
+  >
+    삭제
+  </button>
+</DocumentFragment>
+`;
+
+exports[`Button > 기본 렌더는 primary/md 변형을 반영한다 1`] = `
+<DocumentFragment>
+  <button
+    class="inline-flex items-center justify-center gap-2 font-medium rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:opacity-50 disabled:pointer-events-none bg-accent text-foreground hover:bg-accent-hi h-10 px-4 text-sm"
+    type="button"
+  >
+    저장
+  </button>
+</DocumentFragment>
+`;

--- a/src/components/ui/__snapshots__/card.test.tsx.snap
+++ b/src/components/ui/__snapshots__/card.test.tsx.snap
@@ -1,0 +1,39 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Card > header/footer 가 없을 때 기본 구성 1`] = `
+<DocumentFragment>
+  <div
+    class="bg-card border-border flex flex-col overflow-hidden rounded-md border"
+  >
+    <div
+      class="p-4"
+    >
+      body
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Card > header/footer/padding 조합 1`] = `
+<DocumentFragment>
+  <div
+    class="bg-card border-border flex flex-col overflow-hidden rounded-md border hover:bg-card-hover cursor-pointer transition-colors"
+  >
+    <div
+      class="border-border border-b px-4 py-3 text-sm font-semibold"
+    >
+      타이틀
+    </div>
+    <div
+      class="p-6"
+    >
+      본문 영역
+    </div>
+    <div
+      class="border-border text-foreground-sub border-t px-4 py-3 text-xs"
+    >
+      푸터
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,55 @@
+import { useState, type ImgHTMLAttributes } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export type AvatarSize = 'sm' | 'md' | 'lg' | 'xl';
+
+export interface AvatarProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'size'> {
+  size?: AvatarSize;
+  fallback?: string;
+}
+
+const sizeClasses: Record<AvatarSize, string> = {
+  sm: 'h-6 w-6 text-[10px]',
+  md: 'h-8 w-8 text-xs',
+  lg: 'h-10 w-10 text-sm',
+  xl: 'h-14 w-14 text-base',
+};
+
+function initialsOf(name: string) {
+  const trimmed = name.trim();
+  if (!trimmed) return '?';
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase();
+}
+
+export function Avatar({ size = 'md', src, alt, fallback, className, ...props }: AvatarProps) {
+  const [errored, setErrored] = useState(false);
+  const showImage = src && !errored;
+
+  return (
+    <span
+      className={cn(
+        'bg-card-hover text-foreground-sub rounded-pill inline-flex items-center justify-center overflow-hidden font-semibold select-none',
+        sizeClasses[size],
+        className,
+      )}
+    >
+      {showImage ? (
+        // eslint-disable-next-line @next/next/no-img-element -- 프로필 아바타는 다양한 외부 origin을 허용해야 하므로 next/image 대신 native img 사용
+        <img
+          src={src}
+          alt={alt ?? fallback ?? ''}
+          className="h-full w-full object-cover"
+          onError={() => setErrored(true)}
+          {...props}
+        />
+      ) : (
+        <span aria-label={alt ?? fallback ?? '아바타'}>
+          {fallback ? initialsOf(fallback) : '?'}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,32 @@
+import { type HTMLAttributes } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export type BadgeVariant = 'default' | 'accent' | 'success' | 'warn' | 'danger';
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+const variantClasses: Record<BadgeVariant, string> = {
+  default: 'bg-card-hover text-foreground-sub border border-border',
+  accent: 'bg-accent-dim text-accent-hi',
+  success: 'bg-success-dim text-success',
+  warn: 'bg-warn-dim text-warn',
+  danger: 'bg-danger-dim text-danger',
+};
+
+export function Badge({ variant = 'default', className, children, ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        'rounded-pill inline-flex items-center px-2 py-0.5 text-xs font-medium',
+        variantClasses[variant],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import {
+  Root,
+  Trigger,
+  Portal,
+  Overlay,
+  Content,
+  Title,
+  Description,
+  Close,
+} from '@radix-ui/react-dialog';
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+
+import { cn } from '@/lib/cn';
+
+export const BottomSheet = Root;
+export const BottomSheetTrigger = Trigger;
+export const BottomSheetClose = Close;
+
+type BottomSheetContentProps = ComponentPropsWithoutRef<typeof Content>;
+
+const overlayClasses =
+  'fixed inset-0 z-40 bg-black/60 animate-fade-in data-[state=closed]:opacity-0';
+
+export const BottomSheetContent = forwardRef<ElementRef<typeof Content>, BottomSheetContentProps>(
+  function BottomSheetContent({ className, children, ...props }, ref) {
+    return (
+      <Portal>
+        <Overlay className={overlayClasses} />
+        <Content
+          ref={ref}
+          className={cn(
+            'bg-card text-foreground border-border fixed inset-x-0 bottom-0 z-50 flex max-h-[85vh] flex-col rounded-t-xl border border-b-0 shadow-lg outline-none',
+            'animate-[toast-in_var(--duration-normal)_var(--ease-default)]',
+            className,
+          )}
+          {...props}
+        >
+          <div className="flex justify-center py-2" aria-hidden="true">
+            <span className="bg-border-hi rounded-pill h-1 w-10" />
+          </div>
+          {children}
+        </Content>
+      </Portal>
+    );
+  },
+);
+
+export function BottomSheetHeader({
+  className,
+  children,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('border-border border-b px-5 py-3', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function BottomSheetBody({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('flex-1 overflow-y-auto px-5 py-4 text-sm', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function BottomSheetFooter({
+  className,
+  children,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('border-border flex justify-end gap-2 border-t px-5 py-3', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+type TitleProps = ComponentPropsWithoutRef<typeof Title> & { children?: ReactNode };
+export const BottomSheetTitle = forwardRef<ElementRef<typeof Title>, TitleProps>(
+  function BottomSheetTitle({ className, ...props }, ref) {
+    return (
+      <Title
+        ref={ref}
+        className={cn('text-foreground text-base font-semibold', className)}
+        {...props}
+      />
+    );
+  },
+);
+
+type DescriptionProps = ComponentPropsWithoutRef<typeof Description> & { children?: ReactNode };
+export const BottomSheetDescription = forwardRef<ElementRef<typeof Description>, DescriptionProps>(
+  function BottomSheetDescription({ className, ...props }, ref) {
+    return (
+      <Description
+        ref={ref}
+        className={cn('text-foreground-muted mt-1 text-xs', className)}
+        {...props}
+      />
+    );
+  },
+);

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Button } from './button';
+
+describe('Button', () => {
+  it('기본 렌더는 primary/md 변형을 반영한다', () => {
+    const { asFragment } = render(<Button>저장</Button>);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('variant 와 size props에 따라 클래스가 바뀐다', () => {
+    const { asFragment } = render(
+      <Button variant="danger" size="lg">
+        삭제
+      </Button>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('loading 상태에서 Spinner 가 표시되고 aria-busy 가 설정된다', () => {
+    render(<Button loading>저장 중</Button>);
+    const btn = screen.getByRole('button', { name: /저장 중/ });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(btn).toBeDisabled();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('asChild 로 렌더되면 전달된 요소가 사용된다', () => {
+    render(
+      <Button asChild>
+        <a href="/bands">밴드로 이동</a>
+      </Button>,
+    );
+    const link = screen.getByRole('link', { name: '밴드로 이동' });
+    expect(link).toHaveAttribute('href', '/bands');
+  });
+});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -50,6 +50,15 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   const Comp = asChild ? Slot : 'button';
   const isDisabled = disabled || loading;
 
+  const content = asChild ? (
+    children
+  ) : (
+    <>
+      {loading && <Spinner size={size === 'lg' ? 'md' : 'sm'} label="로딩 중" />}
+      {children}
+    </>
+  );
+
   return (
     <Comp
       ref={ref}
@@ -61,8 +70,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
       type={asChild ? undefined : (type ?? 'button')}
       {...props}
     >
-      {loading && <Spinner size={size === 'lg' ? 'md' : 'sm'} label="로딩 중" />}
-      {children}
+      {content}
     </Comp>
   );
 });

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,68 @@
+import { Slot } from '@radix-ui/react-slot';
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { Spinner } from './spinner';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+  asChild?: boolean;
+}
+
+const baseClasses =
+  'inline-flex items-center justify-center gap-2 font-medium rounded-md transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg ' +
+  'disabled:opacity-50 disabled:pointer-events-none';
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: 'bg-accent text-foreground hover:bg-accent-hi',
+  secondary: 'bg-surface text-foreground border border-border hover:bg-card-hover',
+  ghost: 'bg-transparent text-foreground hover:bg-card-hover',
+  danger: 'bg-danger text-foreground hover:opacity-90',
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'h-8 px-3 text-sm',
+  md: 'h-10 px-4 text-sm',
+  lg: 'h-12 px-6 text-base',
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = 'primary',
+    size = 'md',
+    loading = false,
+    asChild = false,
+    className,
+    children,
+    disabled,
+    type,
+    ...props
+  },
+  ref,
+) {
+  const Comp = asChild ? Slot : 'button';
+  const isDisabled = disabled || loading;
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn(baseClasses, variantClasses[variant], sizeClasses[size], className)}
+      disabled={asChild ? undefined : isDisabled}
+      aria-disabled={isDisabled || undefined}
+      aria-busy={loading || undefined}
+      data-loading={loading ? '' : undefined}
+      type={asChild ? undefined : (type ?? 'button')}
+      {...props}
+    >
+      {loading && <Spinner size={size === 'lg' ? 'md' : 'sm'} label="로딩 중" />}
+      {children}
+    </Comp>
+  );
+});

--- a/src/components/ui/card.test.tsx
+++ b/src/components/ui/card.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Card } from './card';
+
+describe('Card', () => {
+  it('header/footer 가 없을 때 기본 구성', () => {
+    const { asFragment } = render(<Card>body</Card>);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('header/footer/padding 조합', () => {
+    const { asFragment } = render(
+      <Card header="타이틀" footer="푸터" padding="lg" interactive>
+        본문 영역
+      </Card>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,44 @@
+import { type HTMLAttributes, type ReactNode, forwardRef } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  header?: ReactNode;
+  footer?: ReactNode;
+  padding?: CardPadding;
+  interactive?: boolean;
+}
+
+const paddingClasses: Record<CardPadding, string> = {
+  none: 'p-0',
+  sm: 'p-3',
+  md: 'p-4',
+  lg: 'p-6',
+};
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { header, footer, padding = 'md', interactive, className, children, ...props },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'bg-card border-border flex flex-col overflow-hidden rounded-md border',
+        interactive && 'hover:bg-card-hover cursor-pointer transition-colors',
+        className,
+      )}
+      {...props}
+    >
+      {header && (
+        <div className="border-border border-b px-4 py-3 text-sm font-semibold">{header}</div>
+      )}
+      <div className={cn(paddingClasses[padding])}>{children}</div>
+      {footer && (
+        <div className="border-border text-foreground-sub border-t px-4 py-3 text-xs">{footer}</div>
+      )}
+    </div>
+  );
+});

--- a/src/components/ui/chip.tsx
+++ b/src/components/ui/chip.tsx
@@ -1,0 +1,54 @@
+import { type HTMLAttributes } from 'react';
+
+import { cn } from '@/lib/cn';
+import type { SessionType } from '@/global/types';
+
+export interface ChipProps extends HTMLAttributes<HTMLSpanElement> {
+  interactive?: boolean;
+  selected?: boolean;
+  session?: SessionType;
+}
+
+const sessionClasses: Record<SessionType, string> = {
+  VOCAL: 'bg-[oklch(0.62_0.22_250_/_0.18)] text-[oklch(0.82_0.12_250)]',
+  CHORUS: 'bg-[oklch(0.62_0.22_290_/_0.18)] text-[oklch(0.82_0.12_290)]',
+  GUITAR: 'bg-[oklch(0.62_0.22_40_/_0.18)] text-[oklch(0.82_0.12_40)]',
+  BASS: 'bg-[oklch(0.62_0.22_10_/_0.18)] text-[oklch(0.82_0.12_10)]',
+  DRUM: 'bg-[oklch(0.62_0.22_140_/_0.18)] text-[oklch(0.82_0.12_140)]',
+  PERCUSSION: 'bg-[oklch(0.62_0.22_170_/_0.18)] text-[oklch(0.82_0.12_170)]',
+  SYNTH: 'bg-[oklch(0.62_0.22_320_/_0.18)] text-[oklch(0.82_0.12_320)]',
+  ETC: 'bg-card-hover text-foreground-sub',
+};
+
+export function Chip({
+  interactive = false,
+  selected = false,
+  session,
+  className,
+  children,
+  onClick,
+  ...props
+}: ChipProps) {
+  const isButtonLike = interactive && typeof onClick === 'function';
+  return (
+    <span
+      role={isButtonLike ? 'button' : undefined}
+      tabIndex={isButtonLike ? 0 : undefined}
+      aria-pressed={interactive ? selected : undefined}
+      onClick={onClick}
+      className={cn(
+        'rounded-pill inline-flex items-center border px-2.5 py-1 text-xs font-medium transition-colors',
+        session
+          ? cn(sessionClasses[session], 'border-transparent')
+          : 'bg-surface border-border text-foreground-sub',
+        interactive &&
+          'hover:border-border-hi focus-visible:ring-accent focus-visible:ring-offset-bg cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+        selected && 'border-accent text-foreground ring-accent ring-1',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import {
+  Root,
+  Trigger,
+  Portal,
+  Overlay,
+  Content,
+  Title,
+  Description,
+  Close,
+} from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+
+import { cn } from '@/lib/cn';
+
+export const Dialog = Root;
+export const DialogTrigger = Trigger;
+export const DialogClose = Close;
+
+type DialogContentProps = ComponentPropsWithoutRef<typeof Content> & {
+  fullscreen?: boolean;
+  hideCloseButton?: boolean;
+};
+
+const overlayClasses =
+  'fixed inset-0 z-40 bg-black/60 animate-fade-in data-[state=closed]:animate-out data-[state=closed]:opacity-0';
+
+export const DialogContent = forwardRef<ElementRef<typeof Content>, DialogContentProps>(
+  function DialogContent(
+    { className, children, fullscreen = false, hideCloseButton, ...props },
+    ref,
+  ) {
+    return (
+      <Portal>
+        <Overlay className={overlayClasses} />
+        <Content
+          ref={ref}
+          className={cn(
+            'bg-card text-foreground fixed z-50 flex flex-col shadow-lg outline-none',
+            fullscreen
+              ? 'inset-0 sm:inset-auto sm:top-1/2 sm:left-1/2 sm:w-full sm:max-w-lg sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg'
+              : 'top-1/2 left-1/2 w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg',
+            'border-border animate-modal-in border',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          {!hideCloseButton && (
+            <Close
+              aria-label="닫기"
+              className="text-foreground-sub hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg absolute top-3 right-3 rounded-sm p-1 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              <X className="h-4 w-4" />
+            </Close>
+          )}
+        </Content>
+      </Portal>
+    );
+  },
+);
+
+export function DialogHeader({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('border-border border-b px-5 py-4', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function DialogBody({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('flex-1 overflow-y-auto px-5 py-4 text-sm', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function DialogFooter({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('border-border flex justify-end gap-2 border-t px-5 py-3', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+type TitleProps = ComponentPropsWithoutRef<typeof Title> & { children?: ReactNode };
+export const DialogTitle = forwardRef<ElementRef<typeof Title>, TitleProps>(function DialogTitle(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <Title
+      ref={ref}
+      className={cn('text-foreground text-base font-semibold', className)}
+      {...props}
+    />
+  );
+});
+
+type DescriptionProps = ComponentPropsWithoutRef<typeof Description> & { children?: ReactNode };
+export const DialogDescription = forwardRef<ElementRef<typeof Description>, DescriptionProps>(
+  function DialogDescription({ className, ...props }, ref) {
+    return (
+      <Description
+        ref={ref}
+        className={cn('text-foreground-muted mt-1 text-xs', className)}
+        {...props}
+      />
+    );
+  },
+);

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,44 @@
+import { useId, type ReactNode } from 'react';
+
+import { cn } from '@/lib/cn';
+
+type FieldProps = {
+  label?: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+  required?: boolean;
+  htmlFor?: string;
+  className?: string;
+  children: (ids: { inputId: string; describedBy?: string }) => ReactNode;
+};
+
+export function Field({ label, hint, error, required, htmlFor, className, children }: FieldProps) {
+  const autoId = useId();
+  const inputId = htmlFor ?? autoId;
+  const hintId = `${inputId}-hint`;
+  const errorId = `${inputId}-error`;
+  const describedBy = error ? errorId : hint ? hintId : undefined;
+
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      {label && (
+        <label htmlFor={inputId} className="text-foreground text-sm font-medium">
+          {label}
+          {required && <span className="text-danger ml-1">*</span>}
+        </label>
+      )}
+      {children({ inputId, describedBy })}
+      {error ? (
+        <p id={errorId} role="alert" className="text-danger text-xs">
+          {error}
+        </p>
+      ) : (
+        hint && (
+          <p id={hintId} className="text-foreground-muted text-xs">
+            {hint}
+          </p>
+        )
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,41 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { Field } from './field';
+
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  label?: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+}
+
+const baseInputClasses =
+  'h-10 w-full rounded-md border bg-surface px-3 text-sm text-foreground placeholder:text-foreground-muted ' +
+  'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg ' +
+  'disabled:opacity-50 disabled:cursor-not-allowed';
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { label, hint, error, required, className, id, ...props },
+  ref,
+) {
+  return (
+    <Field label={label} hint={hint} error={error} required={required} htmlFor={id}>
+      {({ inputId, describedBy }) => (
+        <input
+          ref={ref}
+          id={inputId}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          aria-required={required || undefined}
+          className={cn(
+            baseInputClasses,
+            error ? 'border-danger' : 'border-border hover:border-border-hi',
+            className,
+          )}
+          {...props}
+        />
+      )}
+    </Field>
+  );
+});

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,68 @@
+import { ChevronDown } from 'lucide-react';
+import { forwardRef, type ReactNode, type SelectHTMLAttributes } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { Field } from './field';
+
+export interface SelectOption<V extends string = string> {
+  value: V;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, 'size'> {
+  label?: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+  placeholder?: string;
+  options: ReadonlyArray<SelectOption>;
+}
+
+const baseClasses =
+  'h-10 w-full appearance-none rounded-md border bg-surface pl-3 pr-9 text-sm text-foreground ' +
+  'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg ' +
+  'disabled:opacity-50 disabled:cursor-not-allowed';
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { label, hint, error, required, className, id, placeholder, options, value, ...props },
+  ref,
+) {
+  return (
+    <Field label={label} hint={hint} error={error} required={required} htmlFor={id}>
+      {({ inputId, describedBy }) => (
+        <div className="relative">
+          <select
+            ref={ref}
+            id={inputId}
+            value={value}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={describedBy}
+            aria-required={required || undefined}
+            className={cn(
+              baseClasses,
+              error ? 'border-danger' : 'border-border hover:border-border-hi',
+              className,
+            )}
+            {...props}
+          >
+            {placeholder && (
+              <option value="" disabled hidden={value !== undefined && value !== ''}>
+                {placeholder}
+              </option>
+            )}
+            {options.map((opt) => (
+              <option key={opt.value} value={opt.value} disabled={opt.disabled}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            aria-hidden="true"
+            className="text-foreground-muted pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2"
+          />
+        </div>
+      )}
+    </Field>
+  );
+});

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,26 @@
+import { type HTMLAttributes } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export type SkeletonRadius = 'sm' | 'md' | 'lg' | 'pill';
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  rounded?: SkeletonRadius;
+}
+
+const radiusClasses: Record<SkeletonRadius, string> = {
+  sm: 'rounded-sm',
+  md: 'rounded-md',
+  lg: 'rounded-lg',
+  pill: 'rounded-pill',
+};
+
+export function Skeleton({ rounded = 'md', className, ...props }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn('bg-card-hover animate-pulse', radiusClasses[rounded], className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/lib/cn';
+
+type SpinnerProps = {
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+  label?: string;
+};
+
+const sizeClasses: Record<NonNullable<SpinnerProps['size']>, string> = {
+  sm: 'h-4 w-4 border-2',
+  md: 'h-5 w-5 border-2',
+  lg: 'h-6 w-6 border-[3px]',
+};
+
+export function Spinner({ size = 'md', className, label = '로딩 중' }: SpinnerProps) {
+  return (
+    <span
+      role="status"
+      aria-label={label}
+      className={cn(
+        'border-border-hi border-t-accent rounded-pill inline-block animate-spin',
+        sizeClasses[size],
+        className,
+      )}
+    />
+  );
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Root, List, Trigger, Content } from '@radix-ui/react-tabs';
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export const Tabs = Root;
+
+export const TabsList = forwardRef<ElementRef<typeof List>, ComponentPropsWithoutRef<typeof List>>(
+  function TabsList({ className, ...props }, ref) {
+    return (
+      <List
+        ref={ref}
+        className={cn(
+          'border-border bg-surface text-foreground-sub inline-flex gap-1 rounded-md border p-1',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+export const TabsTrigger = forwardRef<
+  ElementRef<typeof Trigger>,
+  ComponentPropsWithoutRef<typeof Trigger>
+>(function TabsTrigger({ className, ...props }, ref) {
+  return (
+    <Trigger
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium transition-colors',
+        'hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+        'data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+        'disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+export const TabsContent = forwardRef<
+  ElementRef<typeof Content>,
+  ComponentPropsWithoutRef<typeof Content>
+>(function TabsContent({ className, ...props }, ref) {
+  return (
+    <Content
+      ref={ref}
+      className={cn(
+        'text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg mt-4 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,41 @@
+import { forwardRef, type TextareaHTMLAttributes, type ReactNode } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { Field } from './field';
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+}
+
+const baseClasses =
+  'min-h-[96px] w-full rounded-md border bg-surface px-3 py-2 text-sm text-foreground placeholder:text-foreground-muted ' +
+  'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg ' +
+  'disabled:opacity-50 disabled:cursor-not-allowed resize-y';
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { label, hint, error, required, className, id, ...props },
+  ref,
+) {
+  return (
+    <Field label={label} hint={hint} error={error} required={required} htmlFor={id}>
+      {({ inputId, describedBy }) => (
+        <textarea
+          ref={ref}
+          id={inputId}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          aria-required={required || undefined}
+          className={cn(
+            baseClasses,
+            error ? 'border-danger' : 'border-border hover:border-border-hi',
+            className,
+          )}
+          {...props}
+        />
+      )}
+    </Field>
+  );
+});

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #6

📌 **작업 내용 및 특이사항**

Task 4 (서브태스크 4.1 ~ 4.9) 구현. shadcn/ui 스타일로 재사용 가능한 UI 프리미티브 14종을 `src/components/ui/` 에 구축하고, `/playground/components` 에서 전체 variant/size 조합을 시각 검증합니다.

**✅ 구현된 프리미티브**
- `cn` 유틸 (`src/lib/cn.ts`) — clsx + tailwind-merge 합성
- `Spinner` — sm/md/lg, role=status + aria-label, Button loading 에서 재사용
- `Button` — primary/secondary/ghost/danger × sm/md/lg, `loading`, `asChild(Radix Slot)`, forwardRef, focus-visible ring accent
- `Field` (내부 공용 래퍼) — label/hint/error/required + aria-describedby/aria-invalid 와이어링, render-prop 으로 input id 전달
- `Input`, `Textarea` — Field 기반, 에러 시 border-danger 토글
- `Select` — **native select** + lucide ChevronDown (Radix Select 미도입, 의존성 증가 없이 접근성·키보드 내비 확보), options 배열/placeholder 지원
- `Card` — header/footer/padding(none|sm|md|lg)/interactive
- `Badge` — default/accent/success/warn/danger rounded-pill + 토큰 dim 배경
- `Chip` — interactive/selected/session, `SessionType` 8종(VOCAL~ETC) 별 oklch 색상 매핑
- `Skeleton` — rounded sm/md/lg/pill + animate-pulse, aria-hidden
- `Avatar` — sm/md/lg/xl, 이미지 로드 실패 시 fallback 문자열의 이니셜 자동 렌더 (`next/image` 대신 native `<img>` 사용, 아바타 출처가 다양해 이 부분만 ESLint 지시 주석으로 억제)
- `Dialog` — Radix Dialog 기반, `fullscreen` 프롭(모바일 full-bleed, sm↑ 센터 카드), 기본 우상단 X 닫기 버튼, `hideCloseButton` 옵션
- `BottomSheet` — 동일 Radix Dialog 베이스에서 하단 슬라이드업 시트(toast-in 키프레임), 드래그 핸들 UI 포함
- `Tabs` — Radix Tabs 래퍼, 활성 탭은 bg-accent + shadow-sm 강조

**🧪 검증 페이지**
- `/playground/components` — 위 14개 프리미티브 모두에 대해 variant/size/상태 조합 렌더링. Dialog, BottomSheet 는 트리거 클릭으로 실제 오버레이 확인 가능.

**🧪 테스트**
- Button 4개(`기본 스냅샷`, `variant+size 스냅샷`, `loading aria-busy/Spinner`, `asChild 로 a 태그 치환`)
- Card 2개(`기본`, `header+footer+padding+interactive`)
- 기존 apiClient 10개 포함 **총 16 tests · 4 snapshots 모두 통과**

**🛠 수정된 설계 포인트**
- Button 의 `asChild` 분기에서 Radix `Slot` 이 `Children.only` 를 요구해 false child(\`{loading && <Spinner />}\`) 때문에 실패하던 문제를 발견 → asChild 경로는 `children` 만 그대로 통과시키고, 일반 button 경로만 Fragment 로 Spinner + children 을 묶어 렌더하도록 보정 (테스트로 회귀 방지)

**📋 검증 결과**
- [x] `pnpm lint` / `typecheck` / `format:check` / `build` 통과
- [x] `pnpm test` 통과 (16 tests, 4 snapshots)
- [x] `/playground/components` 정적 생성 확인 (131kB First Load JS)

📚 **참고사항**
- Spacing, layout-width 등 토큰은 Task 2 범위 밖이라 미반영. 후속 도메인 페이지에서 필요하면 추가
- Task 5~10에서 이 프리미티브들을 조합해 도메인/레이아웃 화면을 구축할 예정