### PR TITLE
feat: 밴드(Band) 도메인 구현 (#9)

### DIFF
--- a/.taskmaster/report/band-api-verification-2026-04-24.md
+++ b/.taskmaster/report/band-api-verification-2026-04-24.md
@@ -1,0 +1,212 @@
+# Band API 프론트 연동 검증 리포트 (Task 7 / Issue #9)
+
+- 작성일: 2026-04-24 (Asia/Seoul)
+- 검증 주체: 프론트엔드 (Bandage-FE-Web, branch `feat/#9-band`)
+- 백엔드 기동 URL: `http://localhost:8080`
+- 검증 도구: `curl` 직접 호출. 재현용 스크립트/페이로드 `/tmp/bandage-band-test/*`
+- 검증 범위: `src/domain/band/api/*` 의 10개 함수 + 역할 기반 UI 가드 보조 동작
+- 선행 컨텍스트: 이전 Task 6 검증 리포트(`.taskmaster/report/auth-member-api-verification-2026-04-24.md`) 에서 지적된 JWT 필터 관련 이슈가 **대부분 해소**된 것으로 관측됨 (401 정상 반환 + `WWW-Authenticate` 헤더)
+
+---
+
+## 1. 테스트한 API 목록
+
+| # | Path | Method | 인증 | 프론트 호출 | 판정 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `/api/v1/bands` | POST | Bearer | `domain/band/api/createBand.ts` | 정상 |
+| 2 | `/api/v1/bands/{bandId}` | GET | Bearer | `getBandDetail.ts` | 정상 (응답 shape API_SPEC 과 일치) |
+| 3 | `/api/v1/bands?pageSize=N` | GET | Bearer | `getBands.ts` | 정상 (`CursorResponse` shape 일치) |
+| 4 | `/api/v1/bands/{bandId}/members` | GET | Bearer | `getBandMembers.ts` | 정상 |
+| 5 | `/api/v1/bands/{bandId}/applications` | POST | Bearer | `applyBand.ts` | 정상 (요청 바디 없음, 200 응답) |
+| 6 | `/api/v1/bands/{bandId}/applications?status=...&pageSize=N` | GET | Bearer | `getBandApplications.ts` | 정상 (status 필터 동작: PENDING / APPROVED / REJECTED / WITHDRAWN 확인) |
+| 7 | `/api/v1/bands/{bandId}/applications/{id}?status=APPROVED\|REJECTED` | PATCH | Bearer | `decideApplication.ts` | 정상 (query param 전달 동작) |
+| 8 | `/api/v1/bands/{bandId}/applications/me` | PATCH | Bearer | `withdrawApplication.ts` | 정상 (본인 PENDING 신청 → WITHDRAWN 전환) |
+| 9 | `/api/v1/bands/{bandId}/members/{bandMemberId}/role` | PATCH | Bearer | `delegateLeader.ts` | 정상 (LEADER → 위임 후 역할 교체 확인) |
+| 10 | `/api/v1/bands/{bandId}/members/me` | DELETE | Bearer | `leaveBand.ts` | 정상 (탈퇴 후 멤버 목록에서 제거) |
+
+검증 시나리오는 다음 상태 전이 전부를 한 시나리오로 커버:
+userA(LEADER) 밴드 생성 → userB 신청 → APPROVED → userC 신청 → REJECTED → userD 신청 → WITHDRAWN(본인 철회) → A → B 리더 위임 → userA 탈퇴.
+
+---
+
+## 2. 케이스별 실제 요청/응답 값
+
+아래는 원문 인용 (재현 보장). 시간대 `KST = UTC+9`, timestamp 는 백엔드 서버 시계 기준.
+
+### 2-1. POST `/api/v1/bands` — 밴드 생성
+
+요청
+```http
+POST /api/v1/bands HTTP/1.1
+Authorization: Bearer <tokenA>
+Content-Type: application/json
+
+{"name":"QA Test Band","description":"밴드 도메인 API 검증용","profileImg":"https://i.pravatar.cc/128?u=qaband"}
+```
+응답 (200)
+```json
+{
+  "success": true, "message": null,
+  "data": { "bandId": "019dbd8a-205b-7cf9-ba27-6aff00369979", "bandName": "QA Test Band" },
+  "timestamp": "2026-04-24T12:30:39.399156"
+}
+```
+판정: `CreateBandResponse` 타입과 정확히 일치. 생성자는 자동으로 LEADER 로 등록(후속 멤버 목록 조회에서 확인됨).
+
+### 2-2. GET `/api/v1/bands/{bandId}`
+
+응답 (200) — `BandInfoResponse` 완전 일치
+```json
+{ "success": true, "message": null,
+  "data": { "bandId": "019dbd8a-...", "bandName": "QA Test Band",
+            "description": "밴드 도메인 API 검증용",
+            "profileImg": "https://i.pravatar.cc/128?u=qaband" },
+  "timestamp": "2026-04-24T12:30:49.874452" }
+```
+
+### 2-3. GET `/api/v1/bands?pageSize=10`
+
+응답 (200) — `CursorResponse<BandInfoResponse, string>`
+```json
+{ "data": {
+    "content": [ { "bandId": "019dbd8a-...", "bandName": "QA Test Band", ... } ],
+    "nextCursor": "019dbd8a-205b-7cf9-ba27-6aff00369979",
+    "hasNext": false
+  }, ... }
+```
+관찰: `hasNext:false` 인데 `nextCursor` 가 null 이 아님 (마지막 페이지의 마지막 id 가 그대로 들어옴). 프론트 `useInfiniteCursor` 는 `hasNext ? (nextCursor ?? undefined) : undefined` 로 가드해 문제 없음.
+
+### 2-4. GET `/api/v1/bands/{bandId}/members`
+
+LEADER 생성 직후
+```json
+{ "data": { "content": [ { "bandMemberId": "019dbd8a-2065-...", "memberId": 3, "role": "LEADER" } ],
+            "nextCursor": "019dbd8a-2065-...", "hasNext": false }, ... }
+```
+userB 승인 후
+```json
+{ "data": { "content": [
+    { "bandMemberId": "019dbd8a-c1cc-...", "memberId": 4, "role": "MEMBER" },
+    { "bandMemberId": "019dbd8a-2065-...", "memberId": 3, "role": "LEADER" }
+  ], "nextCursor": "019dbd8a-2065-...", "hasNext": false }, ... }
+```
+판정: `BandMemberInfoResponse` (bandMemberId/memberId/role) 일치.
+
+### 2-5. POST `/api/v1/bands/{bandId}/applications` — 가입 신청
+
+요청 바디 없음. 응답 (200, `data: null`).
+```json
+{ "success": true, "data": null, "timestamp": "2026-04-24T12:31:08.561006" }
+```
+판정: 프론트 `applyBand.ts` 가 body 없이 POST 하는 구현과 일치.
+
+### 2-6. GET `/api/v1/bands/{bandId}/applications?status=PENDING`
+
+```json
+{ "data": { "content": [
+    { "bandApplicationId": "019dbd8a-927f-...", "memberId": 4, "status": "PENDING" }
+  ], ... } }
+```
+판정: `BandApplicationInfoResponse` 일치. status=REJECTED / WITHDRAWN / APPROVED 필터도 각각 정상 분리되어 반환됨을 같은 시나리오 내에서 재검증.
+
+### 2-7. PATCH `/api/v1/bands/{bandId}/applications/{id}?status=APPROVED|REJECTED`
+
+두 decision 모두 200 정상. 응답 body `data:null`. 이후 `GET ...?status=APPROVED|REJECTED` 필터 목록에 정확히 반영됨.
+
+### 2-8. PATCH `/api/v1/bands/{bandId}/applications/me` — 본인 철회
+
+200, `data:null`. 이후 해당 신청이 `status=WITHDRAWN` 필터 목록에 노출됨. 시나리오 상 PENDING 상태에서만 호출했으며 이미 APPROVED 된 경우의 반응은 별도 검증 안 함.
+
+### 2-9. PATCH `/api/v1/bands/{bandId}/members/{bandMemberId}/role` — 리더 위임
+
+200, `data:null`. 직후 `GET /members` 에서 역할 교체 확인
+```json
+{ "content": [
+  { "memberId": 4, "role": "LEADER" },   // B (승격)
+  { "memberId": 3, "role": "MEMBER" }    // A (강등)
+] }
+```
+
+### 2-10. DELETE `/api/v1/bands/{bandId}/members/me`
+
+200, `data:null`. 탈퇴 후 `GET /members` 결과에서 해당 멤버가 사라짐을 확인.
+
+### 2-11. 에러 / 경계 케이스 응답
+
+| 케이스 | HTTP | body message (있는 경우) |
+| --- | --- | --- |
+| Bearer 누락 | 401 | `"인증되지 않은 회원입니다."` + `WWW-Authenticate: Bearer error="invalid_token"` |
+| 존재하지 않는 bandId 조회 | 404 | (body 본문 생략 — 실사용 영향 없음) |
+| 빈 `name` 으로 밴드 생성 (`@NotBlank`) | 400 | 유효성 에러 (프론트 zod 로 선검증하므로 보통 이 단계까지 안 옴) |
+| LEADER 가 본인 밴드에 재신청 | 409 | 중복 상태 위반 |
+| 비리더가 리더 위임 시도 | 401 | `Bearer error="invalid_token"` — 후술 (§3-B) |
+| 이미 탈퇴한 사용자가 재탈퇴 | 404 | 멤버 미존재 |
+
+---
+
+## 3. 권장 조치 내용 및 검토 필요 사항
+
+### A. (Backend) API_SPEC 과 실제 인증 요구 불일치
+
+- API_SPEC 3-2/3-3/3-4/3-5 는 **"인증 불필요"** 로 명시 (밴드 단건/목록/멤버 단건/멤버 목록 조회)
+- 실제 동작: Bearer 없이 호출하면 **401 + "인증되지 않은 회원입니다."** 반환. 즉 모두 인증 필요
+- 둘 중 하나로 맞춰야 함:
+  - (A-1) SecurityFilterChain 에서 해당 GET 경로를 `permitAll()` 로 복원해 **공개 API 로 유지**
+  - (A-2) API_SPEC 을 "인증 필요" 로 수정 + 프론트는 이미 Bearer 를 늘 첨부하므로 코드 변동 없음
+- 우선순위: 스펙 드리프트 성격 — 어느 방향이든 빠르게 정렬 필요
+
+### B. (Backend) 권한 부족(403 상당) 을 401 로 반환
+
+- 비리더인 userC 가 `PATCH .../members/{id}/role` (리더 위임) 시도 → **401** + `WWW-Authenticate: Bearer error="invalid_token"`
+- userC 토큰은 정상 유효 상태 (동일 토큰으로 다른 공개 읽기 가능). 실제로는 **권한 부족(403)** 이 맞는 상황인데 401 로 리턴
+- RFC 7235 기준: 토큰 없음/무효/만료 = 401, 인증되었으나 해당 리소스에 대한 권한 없음 = 403
+- 프론트 apiClient 의 401 인터셉터가 이 응답을 "토큰 무효" 로 오인해 `/auth/refresh` 호출을 시도할 수 있음 (refresh 성공 후 재시도해도 여전히 401 → 결국 `handleAuthFailure` 로 떨어져 강제 로그아웃 가능)
+- 권장: 인가(authorization) 실패는 403 으로 분리. `WWW-Authenticate` 헤더는 401 에만 첨부
+- 프론트 측 임시 우회(선택): 메시지 본문이 `"인증되지 않은 회원입니다."` 인 경우만 refresh 시도 — 다만 근본 해결은 백엔드 분리
+
+### C. (Backend, 경미) `CursorResponse.nextCursor` 가 `hasNext=false` 일 때도 마지막 아이템 id 로 채워짐
+
+- 관측: `{ "content":[...], "nextCursor":"019dbd...", "hasNext":false }`
+- 일관성 기준으로는 `hasNext:false` 일 때 `nextCursor:null` 이 자연스러움
+- 프론트 영향 없음(가드 처리됨). 우선순위 낮음 — API 스타일 일관성 차원에서만 검토 권고
+
+### D. (Frontend 현재는 무조치) `useBandRole` 비효율 개선 여지
+
+- 현재 구현: `useMe().id` 로 현재 memberId 확보 → `/bands/{bandId}/members` pageSize=100, 최대 10페이지 순회하여 매칭
+- 큰 밴드(>1000명) 에서는 페이지 순회 비용이 큼
+- 근본 개선: 백엔드가 `BandInfoResponse` 에 `myRole` 필드를 추가하거나 `GET /bands/{bandId}/me` 전용 엔드포인트 제공. 그러면 프론트는 단일 쿼리로 교체 가능
+- 지금은 소규모 밴드 전제 하 수용 가능 — 실사용 시 대형 밴드 등장 시점에 재평가
+
+---
+
+## 4. 프론트 관련 구현 지점
+
+```text
+src/domain/band/types/{req,res,schema,index}.ts   # DTO + zod 스키마
+src/domain/band/api/*.ts                           # 10개 API 함수
+src/domain/band/hooks/*.ts                         # TanStack Query/Mutation 래퍼
+src/domain/band/components/*.tsx                   # BandCard/RoleBadge/MemberRow/ApplicationRow/CreateForm
+src/global/auth/useBandRole.ts                     # 역할 판정 훅 (§3-D)
+src/global/auth/RoleGuard.tsx                      # 역할 기반 UI 가드
+src/app/(main)/bands/page.tsx + BandsList.client.tsx              # 목록 + 무한 스크롤 + FAB
+src/app/(main)/bands/new/page.tsx                                 # 생성 폼
+src/app/(main)/bands/[bandId]/page.tsx + BandDetailContent.client.tsx  # 상세 3탭
+```
+
+§3-A 가 (A-2) 로 해결되면 프론트 추가 수정 없음. (A-1) 이라면 현재도 인증 헤더 자동 첨부라 무영향. §3-B 는 백엔드 수정 후 프론트 변경 불필요. §3-D 는 백엔드 스키마 확장 시 useBandRole 단순화.
+
+---
+
+## 5. 재현용 페이로드 위치
+
+```text
+/tmp/bandage-band-test/
+  ├── state.env          # EMAIL_A~D, PASS, TOKEN_A, BAND_ID, MEMBER_B_ID, BAND_MEMBER_ID_B
+  ├── join_{a,b,c,d}.json / .resp
+  ├── login_{a,b,c,d}.json / .resp
+  ├── cookies_{a,b,c,d}.txt
+  ├── create_band.json
+  ├── bad_create.json    # 14b 빈 name 검증용
+```
+
+재현 시 이메일은 `band-{a,b,c,d}-<timestamp>@bandage.test` 로 유일해지니 동일 스크립트 재실행 시 timestamp 만 갱신.

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -387,7 +387,7 @@
         "dependencies": [
           "6"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -449,7 +449,8 @@
             "testStrategy": "밴드 생성 → 상세 조회 → 다른 계정으로 가입 신청 → 리더가 승인 → 멤버 목록에 반영 → 리더 위임 → 탈퇴 플로우 전체 수동 테스트. 무한 스크롤이 올바르게 작동하는지 확인.",
             "parentId": "undefined"
           }
-        ]
+        ],
+        "updatedAt": "2026-04-24T01:54:21.134Z"
       },
       {
         "id": "8",
@@ -674,9 +675,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-04-23T22:14:29.769Z",
+      "lastModified": "2026-04-24T01:54:21.138Z",
       "taskCount": 10,
-      "completedCount": 6,
+      "completedCount": 7,
       "tags": [
         "master"
       ]

--- a/src/app/(main)/bands/BandsList.client.tsx
+++ b/src/app/(main)/bands/BandsList.client.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Plus, Users } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { ErrorState } from '@/components/feedback/error-state';
+import { Skeleton } from '@/components/ui/skeleton';
+import { BandCard } from '@/domain/band/components/BandCard';
+import { useBandList } from '@/domain/band/hooks/useBandList';
+import { ROUTES } from '@/global/config/routes';
+
+export function BandsList() {
+  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useBandList(20);
+
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!hasNextPage || !loadMoreRef.current) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting && !isFetchingNextPage) fetchNextPage();
+    });
+    observer.observe(loadMoreRef.current);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20 w-full" rounded="md" />
+        <Skeleton className="h-20 w-full" rounded="md" />
+        <Skeleton className="h-20 w-full" rounded="md" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState description="밴드 목록을 불러오지 못했습니다." onRetry={() => refetch()} />;
+  }
+
+  const bands = data?.pages.flatMap((p) => p.content) ?? [];
+
+  return (
+    <div className="space-y-4">
+      {bands.length === 0 ? (
+        <EmptyState
+          icon={Users}
+          title="아직 밴드가 없습니다"
+          description="첫 번째 밴드를 만들어 보세요."
+          action={{ label: '밴드 만들기', onClick: () => undefined }}
+        />
+      ) : (
+        <>
+          <div className="space-y-3">
+            {bands.map((b) => (
+              <BandCard key={b.bandId} band={b} />
+            ))}
+          </div>
+          {hasNextPage && <div ref={loadMoreRef} className="h-4" aria-hidden="true" />}
+          {isFetchingNextPage && <Skeleton className="h-20 w-full" rounded="md" />}
+        </>
+      )}
+
+      <Link
+        href={ROUTES.BAND_NEW}
+        aria-label="밴드 만들기"
+        className="bg-accent text-foreground hover:bg-accent-hi focus-visible:ring-accent focus-visible:ring-offset-bg rounded-pill fixed right-4 bottom-20 z-10 flex h-14 w-14 items-center justify-center shadow-lg transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      >
+        <Plus className="h-6 w-6" />
+      </Link>
+    </div>
+  );
+}

--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { LogOut, UserPlus } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { ErrorState } from '@/components/feedback/error-state';
+import { Avatar } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { BandApplicationRow } from '@/domain/band/components/BandApplicationRow';
+import { BandMemberRow } from '@/domain/band/components/BandMemberRow';
+import { useApplyBand } from '@/domain/band/hooks/useApplyBand';
+import { useBandApplications } from '@/domain/band/hooks/useBandApplications';
+import { useBandDetail } from '@/domain/band/hooks/useBandDetail';
+import { useBandMembers } from '@/domain/band/hooks/useBandMembers';
+import { useLeaveBand } from '@/domain/band/hooks/useLeaveBand';
+import { RoleGuard, hasRole } from '@/global/auth/RoleGuard';
+import { useBandRole } from '@/global/auth/useBandRole';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+export function BandDetailContent({ bandId }: { bandId: string }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [leaveOpen, setLeaveOpen] = useState(false);
+
+  const { data: band, isLoading, isError, refetch } = useBandDetail(bandId);
+  const { data: myRole } = useBandRole(bandId);
+
+  const applyMutation = useApplyBand(bandId, {
+    onSuccess: () => toast.success('가입 신청을 보냈습니다. 승인을 기다려 주세요.'),
+    onError: (err) => toast.error(err.message || '가입 신청에 실패했습니다.'),
+  });
+
+  const leaveMutation = useLeaveBand(bandId, {
+    onSuccess: () => {
+      toast.success('밴드에서 탈퇴했습니다.');
+      router.replace(ROUTES.BANDS);
+    },
+    onError: (err) => toast.error(err.message || '탈퇴에 실패했습니다.'),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-32 w-full" rounded="lg" />
+        <Skeleton className="h-10 w-1/2" />
+      </div>
+    );
+  }
+
+  if (isError || !band) {
+    return <ErrorState title="밴드를 찾을 수 없습니다" onRetry={() => refetch()} />;
+  }
+
+  const isMember = myRole !== null && myRole !== undefined;
+  const canSeeApplications = hasRole(myRole, 'ADMIN');
+
+  return (
+    <div className="space-y-6">
+      <Card padding="lg">
+        <div className="flex items-start gap-4">
+          <Avatar
+            size="xl"
+            src={band.profileImg}
+            fallback={band.bandName}
+            alt={`${band.bandName} 프로필`}
+          />
+          <div className="min-w-0 flex-1">
+            <h1 className="text-foreground text-xl font-bold">{band.bandName}</h1>
+            {band.description && (
+              <p className="text-foreground-sub mt-1 text-sm">{band.description}</p>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">개요</TabsTrigger>
+          <TabsTrigger value="members">멤버</TabsTrigger>
+          {canSeeApplications && <TabsTrigger value="applications">가입 신청</TabsTrigger>}
+        </TabsList>
+
+        <TabsContent value="overview">
+          <Card padding="lg">
+            <div className="space-y-3">
+              <p className="text-foreground-sub text-sm">
+                {band.description ?? '소개가 등록되지 않았습니다.'}
+              </p>
+              <div className="flex gap-2">
+                {!isMember && (
+                  <Button onClick={() => applyMutation.mutate()} loading={applyMutation.isPending}>
+                    <UserPlus className="h-4 w-4" />
+                    가입 신청
+                  </Button>
+                )}
+                {isMember && (
+                  <Button
+                    variant="ghost"
+                    className="text-danger hover:opacity-80"
+                    onClick={() => setLeaveOpen(true)}
+                  >
+                    <LogOut className="h-4 w-4" />
+                    밴드 탈퇴
+                  </Button>
+                )}
+              </div>
+            </div>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="members">
+          <MembersTab bandId={bandId} />
+        </TabsContent>
+
+        {canSeeApplications && (
+          <TabsContent value="applications">
+            <RoleGuard
+              bandId={bandId}
+              role="ADMIN"
+              fallback={<EmptyState title="접근 권한이 없습니다" />}
+            >
+              <ApplicationsTab bandId={bandId} />
+            </RoleGuard>
+          </TabsContent>
+        )}
+      </Tabs>
+
+      <Dialog open={leaveOpen} onOpenChange={setLeaveOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>밴드에서 탈퇴하시겠어요?</DialogTitle>
+            <DialogDescription>
+              탈퇴 후에는 밴드의 합주 · 공연 · 신청 이력에 접근할 수 없습니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <p className="text-foreground-sub text-sm">
+              LEADER 인 경우 먼저 리더 권한을 다른 멤버에게 위임해야 할 수 있습니다.
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setLeaveOpen(false)}>
+              취소
+            </Button>
+            <Button
+              variant="danger"
+              loading={leaveMutation.isPending}
+              onClick={() => leaveMutation.mutate()}
+            >
+              탈퇴하기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function MembersTab({ bandId }: { bandId: string }) {
+  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useBandMembers(bandId, 20);
+
+  if (isLoading) return <Skeleton className="h-16 w-full" />;
+  if (isError) return <ErrorState onRetry={() => refetch()} />;
+
+  const members = data?.pages.flatMap((p) => p.content) ?? [];
+  if (members.length === 0) return <EmptyState title="멤버가 없습니다" />;
+
+  return (
+    <div>
+      {members.map((m) => (
+        <BandMemberRow key={m.bandMemberId} bandId={bandId} member={m} />
+      ))}
+      {hasNextPage && (
+        <div className="mt-3 flex justify-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => fetchNextPage()}
+            loading={isFetchingNextPage}
+          >
+            더 불러오기
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ApplicationsTab({ bandId }: { bandId: string }) {
+  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useBandApplications(bandId, 'PENDING', 20);
+
+  if (isLoading) return <Skeleton className="h-16 w-full" />;
+  if (isError) return <ErrorState onRetry={() => refetch()} />;
+
+  const apps = data?.pages.flatMap((p) => p.content) ?? [];
+  if (apps.length === 0) return <EmptyState title="대기 중인 가입 신청이 없습니다" />;
+
+  return (
+    <div>
+      {apps.map((a) => (
+        <BandApplicationRow key={a.bandApplicationId} bandId={bandId} application={a} />
+      ))}
+      {hasNextPage && (
+        <div className="mt-3 flex justify-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => fetchNextPage()}
+            loading={isFetchingNextPage}
+          >
+            더 불러오기
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/bands/[bandId]/page.tsx
+++ b/src/app/(main)/bands/[bandId]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+import { BandDetailContent } from './BandDetailContent.client';
+
+export const metadata: Metadata = {
+  title: '밴드 상세 | Bandage',
+};
+
+type PageProps = {
+  params: Promise<{ bandId: string }>;
+};
+
+export default async function BandDetailPage({ params }: PageProps) {
+  const { bandId } = await params;
+  return <BandDetailContent bandId={bandId} />;
+}

--- a/src/app/(main)/bands/new/page.tsx
+++ b/src/app/(main)/bands/new/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+
+import { PageTitle } from '@/components/layout/page-title';
+import { BandCreateForm } from '@/domain/band/components/BandCreateForm.client';
+
+export const metadata: Metadata = {
+  title: '밴드 만들기 | Bandage',
+};
+
+export default function BandNewPage() {
+  return (
+    <div className="space-y-6">
+      <PageTitle title="밴드 만들기" description="새 밴드의 기본 정보를 입력하세요." />
+      <BandCreateForm />
+    </div>
+  );
+}

--- a/src/app/(main)/bands/page.tsx
+++ b/src/app/(main)/bands/page.tsx
@@ -1,10 +1,18 @@
+import type { Metadata } from 'next';
+
 import { PageTitle } from '@/components/layout/page-title';
+
+import { BandsList } from './BandsList.client';
+
+export const metadata: Metadata = {
+  title: '밴드 | Bandage',
+};
 
 export default function BandsPage() {
   return (
     <div className="space-y-6">
-      <PageTitle title="밴드" description="참여 중인 밴드 목록" />
-      <p className="text-foreground-sub text-sm">밴드 도메인은 Task 7에서 구현됩니다.</p>
+      <PageTitle title="밴드" description="참여 중인 밴드를 확인하거나 새 밴드를 만드세요." />
+      <BandsList />
     </div>
   );
 }

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -27,12 +27,14 @@ describe('Button', () => {
   });
 
   it('asChild 로 렌더되면 전달된 요소가 사용된다', () => {
+    // href 는 Next.js 내부 페이지 라우트를 피하도록 외부 URL 로 지정
+    // (no-html-link-for-pages 룰은 실제 app 라우트 경로에만 반응하므로 외부 URL 은 무해)
     render(
       <Button asChild>
-        <a href="/bands">밴드로 이동</a>
+        <a href="https://example.com/bands">밴드로 이동</a>
       </Button>,
     );
     const link = screen.getByRole('link', { name: '밴드로 이동' });
-    expect(link).toHaveAttribute('href', '/bands');
+    expect(link).toHaveAttribute('href', 'https://example.com/bands');
   });
 });

--- a/src/domain/band/api/applyBand.ts
+++ b/src/domain/band/api/applyBand.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function applyBand(bandId: string): Promise<void> {
+  await apiClient.post<null>(`/api/v1/bands/${bandId}/applications`);
+}

--- a/src/domain/band/api/createBand.ts
+++ b/src/domain/band/api/createBand.ts
@@ -1,0 +1,11 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { CreateBandRequest, CreateBandResponse } from '../types';
+
+export async function createBand(req: CreateBandRequest): Promise<CreateBandResponse> {
+  const data = await apiClient.post<CreateBandResponse>('/api/v1/bands', req);
+  if (!data) {
+    throw new Error('밴드 생성 응답이 비어 있습니다.');
+  }
+  return data;
+}

--- a/src/domain/band/api/decideApplication.ts
+++ b/src/domain/band/api/decideApplication.ts
@@ -1,0 +1,17 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { BandApplicationDecision } from '../types';
+
+/**
+ * 리더가 밴드 가입 신청을 승인/거절합니다.
+ * API_SPEC 3-9: PATCH /api/v1/bands/{bandId}/applications/{bandApplicationId}?status=APPROVED|REJECTED
+ */
+export async function decideApplication(
+  bandId: string,
+  applicationId: string,
+  decision: BandApplicationDecision,
+): Promise<void> {
+  await apiClient.patch<null>(`/api/v1/bands/${bandId}/applications/${applicationId}`, undefined, {
+    query: { status: decision },
+  });
+}

--- a/src/domain/band/api/delegateLeader.ts
+++ b/src/domain/band/api/delegateLeader.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/global/api/apiClient';
+
+/**
+ * 현재 리더 권한을 지정 멤버에게 양도합니다.
+ * API_SPEC 3-10: PATCH /api/v1/bands/{bandId}/members/{bandMemberId}/role
+ */
+export async function delegateLeader(bandId: string, bandMemberId: string): Promise<void> {
+  await apiClient.patch<null>(`/api/v1/bands/${bandId}/members/${bandMemberId}/role`);
+}

--- a/src/domain/band/api/getBandApplications.ts
+++ b/src/domain/band/api/getBandApplications.ts
@@ -1,0 +1,21 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { ApplicationStatus, CursorResponse } from '@/global/types';
+
+import type { BandApplicationInfoResponse } from '../types';
+
+type GetBandApplicationsParams = {
+  lastId?: string;
+  pageSize: number;
+  status?: ApplicationStatus;
+};
+
+export async function getBandApplications(
+  bandId: string,
+  params: GetBandApplicationsParams,
+): Promise<CursorResponse<BandApplicationInfoResponse, string>> {
+  const data = await apiClient.get<CursorResponse<BandApplicationInfoResponse, string> | null>(
+    `/api/v1/bands/${bandId}/applications`,
+    { query: { lastId: params.lastId, pageSize: params.pageSize, status: params.status } },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/band/api/getBandDetail.ts
+++ b/src/domain/band/api/getBandDetail.ts
@@ -1,0 +1,7 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { BandInfoResponse } from '../types';
+
+export async function getBandDetail(bandId: string): Promise<BandInfoResponse | null> {
+  return apiClient.get<BandInfoResponse | null>(`/api/v1/bands/${bandId}`);
+}

--- a/src/domain/band/api/getBandMembers.ts
+++ b/src/domain/band/api/getBandMembers.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { BandMemberInfoResponse } from '../types';
+
+type GetBandMembersParams = {
+  lastId?: string;
+  pageSize: number;
+};
+
+export async function getBandMembers(
+  bandId: string,
+  params: GetBandMembersParams,
+): Promise<CursorResponse<BandMemberInfoResponse, string>> {
+  const data = await apiClient.get<CursorResponse<BandMemberInfoResponse, string> | null>(
+    `/api/v1/bands/${bandId}/members`,
+    { query: { lastId: params.lastId, pageSize: params.pageSize } },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/band/api/getBands.ts
+++ b/src/domain/band/api/getBands.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { BandInfoResponse } from '../types';
+
+type GetBandsParams = {
+  lastId?: string;
+  pageSize: number;
+};
+
+export async function getBands(
+  params: GetBandsParams,
+): Promise<CursorResponse<BandInfoResponse, string>> {
+  const data = await apiClient.get<CursorResponse<BandInfoResponse, string> | null>(
+    '/api/v1/bands',
+    { query: { lastId: params.lastId, pageSize: params.pageSize } },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/band/api/leaveBand.ts
+++ b/src/domain/band/api/leaveBand.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function leaveBand(bandId: string): Promise<void> {
+  await apiClient.delete<null>(`/api/v1/bands/${bandId}/members/me`);
+}

--- a/src/domain/band/api/withdrawApplication.ts
+++ b/src/domain/band/api/withdrawApplication.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/global/api/apiClient';
+
+/**
+ * PENDING 상태의 본인 신청을 철회합니다.
+ * API_SPEC 3-8: PATCH /api/v1/bands/{bandId}/applications/me
+ */
+export async function withdrawApplication(bandId: string): Promise<void> {
+  await apiClient.patch<null>(`/api/v1/bands/${bandId}/applications/me`);
+}

--- a/src/domain/band/components/BandApplicationRow.tsx
+++ b/src/domain/band/components/BandApplicationRow.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Check, X } from 'lucide-react';
+
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useDecideApplication } from '@/domain/band/hooks/useDecideApplication';
+import { useToast } from '@/hooks/useToast';
+
+import type { BandApplicationInfoResponse } from '../types';
+
+type Props = {
+  bandId: string;
+  application: BandApplicationInfoResponse;
+};
+
+export function BandApplicationRow({ bandId, application }: Props) {
+  const toast = useToast();
+  const mutation = useDecideApplication(bandId, {
+    onSuccess: (vars) =>
+      toast.success(vars.decision === 'APPROVED' ? '가입을 승인했습니다.' : '가입을 거절했습니다.'),
+    onError: (err) => toast.error(err.message || '처리에 실패했습니다.'),
+  });
+
+  const isPending = application.status === 'PENDING';
+
+  return (
+    <div className="border-border flex items-center justify-between gap-3 border-b py-3 last:border-b-0">
+      <div className="flex min-w-0 items-center gap-3">
+        <Avatar size="md" fallback={`M${application.memberId}`} />
+        <div className="min-w-0">
+          <p className="text-foreground truncate text-sm font-medium">
+            Member #{application.memberId}
+          </p>
+          <p className="text-foreground-muted truncate text-xs">{application.bandApplicationId}</p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {isPending ? (
+          <>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() =>
+                mutation.mutate({
+                  applicationId: application.bandApplicationId,
+                  decision: 'APPROVED',
+                })
+              }
+              loading={mutation.isPending}
+            >
+              <Check className="h-4 w-4" />
+              승인
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="text-danger hover:opacity-80"
+              onClick={() =>
+                mutation.mutate({
+                  applicationId: application.bandApplicationId,
+                  decision: 'REJECTED',
+                })
+              }
+              loading={mutation.isPending}
+            >
+              <X className="h-4 w-4" />
+              거절
+            </Button>
+          </>
+        ) : (
+          <Badge>{application.status}</Badge>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/domain/band/components/BandCard.tsx
+++ b/src/domain/band/components/BandCard.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+
+import { Avatar } from '@/components/ui/avatar';
+import { Card } from '@/components/ui/card';
+import { ROUTES } from '@/global/config/routes';
+
+import type { BandInfoResponse } from '../types';
+
+export function BandCard({ band }: { band: BandInfoResponse }) {
+  return (
+    <Link
+      href={ROUTES.BAND_DETAIL(band.bandId)}
+      className="focus-visible:ring-accent focus-visible:ring-offset-bg block rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+    >
+      <Card interactive padding="md">
+        <div className="flex items-start gap-3">
+          <Avatar
+            size="lg"
+            src={band.profileImg}
+            fallback={band.bandName}
+            alt={`${band.bandName} 프로필`}
+          />
+          <div className="min-w-0 flex-1">
+            <p className="text-foreground truncate text-base font-semibold">{band.bandName}</p>
+            {band.description && (
+              <p className="text-foreground-sub mt-1 line-clamp-2 text-sm">{band.description}</p>
+            )}
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}

--- a/src/domain/band/components/BandCreateForm.client.tsx
+++ b/src/domain/band/components/BandCreateForm.client.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useCreateBand } from '@/domain/band/hooks/useCreateBand';
+import { createBandSchema, type CreateBandSchema } from '@/domain/band/types';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+export function BandCreateForm() {
+  const router = useRouter();
+  const toast = useToast();
+
+  const form = useForm<CreateBandSchema>({
+    resolver: zodResolver(createBandSchema),
+    defaultValues: { name: '', description: '', profileImg: '' },
+  });
+
+  const mutation = useCreateBand({
+    onSuccess: (data) => {
+      toast.success('밴드가 생성되었습니다.');
+      router.replace(ROUTES.BAND_DETAIL(data.bandId));
+    },
+    onError: (err) => toast.error(err.message || '밴드 생성에 실패했습니다.'),
+  });
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={form.handleSubmit((values) =>
+        mutation.mutate({
+          name: values.name,
+          description: values.description,
+          profileImg: values.profileImg,
+        }),
+      )}
+      noValidate
+    >
+      <Input
+        label="밴드 이름"
+        placeholder="예: TuNA"
+        required
+        error={form.formState.errors.name?.message}
+        {...form.register('name')}
+      />
+      <Textarea
+        label="소개"
+        placeholder="밴드 소개를 입력하세요 (최대 200자)"
+        error={form.formState.errors.description?.message}
+        {...form.register('description')}
+      />
+      <Input
+        label="프로필 이미지 URL"
+        placeholder="https://..."
+        error={form.formState.errors.profileImg?.message}
+        {...form.register('profileImg')}
+      />
+      <Button type="submit" className="w-full" loading={mutation.isPending}>
+        밴드 만들기
+      </Button>
+    </form>
+  );
+}

--- a/src/domain/band/components/BandMemberRow.tsx
+++ b/src/domain/band/components/BandMemberRow.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { Crown } from 'lucide-react';
+import { useState } from 'react';
+
+import { Avatar } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useDelegateLeader } from '@/domain/band/hooks/useDelegateLeader';
+import { RoleGuard } from '@/global/auth/RoleGuard';
+import { useToast } from '@/hooks/useToast';
+
+import { BandRoleBadge } from './BandRoleBadge';
+import type { BandMemberInfoResponse } from '../types';
+
+type Props = {
+  bandId: string;
+  member: BandMemberInfoResponse;
+};
+
+export function BandMemberRow({ bandId, member }: Props) {
+  const [open, setOpen] = useState(false);
+  const toast = useToast();
+  const delegateMutation = useDelegateLeader(bandId, {
+    onSuccess: () => {
+      toast.success('리더 권한을 위임했습니다.');
+      setOpen(false);
+    },
+    onError: (err) => toast.error(err.message || '리더 위임에 실패했습니다.'),
+  });
+
+  return (
+    <div className="border-border flex items-center justify-between gap-3 border-b py-3 last:border-b-0">
+      <div className="flex min-w-0 items-center gap-3">
+        <Avatar size="md" fallback={`M${member.memberId}`} />
+        <div className="min-w-0">
+          <p className="text-foreground truncate text-sm font-medium">Member #{member.memberId}</p>
+          <p className="text-foreground-muted truncate text-xs">id: {member.bandMemberId}</p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <BandRoleBadge role={member.role} />
+        {member.role !== 'LEADER' && (
+          <RoleGuard bandId={bandId} role="LEADER">
+            <Button size="sm" variant="ghost" onClick={() => setOpen(true)}>
+              <Crown className="h-4 w-4" />
+              리더 위임
+            </Button>
+          </RoleGuard>
+        )}
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>리더 권한 위임</DialogTitle>
+            <DialogDescription>
+              이 멤버에게 리더 권한을 넘깁니다. 위임 후 본인은 일반 멤버로 전환됩니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <p className="text-foreground-sub text-sm">
+              Member #{member.memberId} 에게 리더를 위임하시겠어요? 이 동작은 되돌릴 수 없습니다.
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setOpen(false)}>
+              취소
+            </Button>
+            <Button
+              variant="primary"
+              loading={delegateMutation.isPending}
+              onClick={() => delegateMutation.mutate(member.bandMemberId)}
+            >
+              위임하기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/domain/band/components/BandRoleBadge.tsx
+++ b/src/domain/band/components/BandRoleBadge.tsx
@@ -1,0 +1,18 @@
+import { Badge, type BadgeVariant } from '@/components/ui/badge';
+import type { BandRole } from '@/global/types';
+
+const roleLabel: Record<BandRole, string> = {
+  LEADER: '리더',
+  ADMIN: '관리자',
+  MEMBER: '멤버',
+};
+
+const roleVariant: Record<BandRole, BadgeVariant> = {
+  LEADER: 'accent',
+  ADMIN: 'success',
+  MEMBER: 'default',
+};
+
+export function BandRoleBadge({ role }: { role: BandRole }) {
+  return <Badge variant={roleVariant[role]}>{roleLabel[role]}</Badge>;
+}

--- a/src/domain/band/hooks/useApplyBand.ts
+++ b/src/domain/band/hooks/useApplyBand.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { applyBand } from '../api/applyBand';
+
+type UseApplyBandOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useApplyBand(bandId: string, options?: UseApplyBandOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => applyBand(bandId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/band/hooks/useBandApplications.ts
+++ b/src/domain/band/hooks/useBandApplications.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import type { ApplicationStatus } from '@/global/types';
+import { useInfiniteCursor } from '@/hooks/useInfiniteCursor';
+
+import { getBandApplications } from '../api/getBandApplications';
+import type { BandApplicationInfoResponse } from '../types';
+
+export function useBandApplications(
+  bandId: string,
+  status: ApplicationStatus = 'PENDING',
+  pageSize: number = 20,
+) {
+  return useInfiniteCursor<BandApplicationInfoResponse, string>(
+    [...queryKeys.band.applications(bandId, status), pageSize],
+    ({ lastId, pageSize: size }) => getBandApplications(bandId, { lastId, pageSize: size, status }),
+    pageSize,
+    { enabled: !!bandId },
+  );
+}

--- a/src/domain/band/hooks/useBandDetail.ts
+++ b/src/domain/band/hooks/useBandDetail.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getBandDetail } from '../api/getBandDetail';
+import type { BandInfoResponse } from '../types';
+
+type UseBandDetailOptions = {
+  enabled?: boolean;
+};
+
+export function useBandDetail(bandId: string, options?: UseBandDetailOptions) {
+  return useQuery<BandInfoResponse | null, Error>({
+    queryKey: [...queryKeys.band.detail(bandId)],
+    queryFn: () => getBandDetail(bandId),
+    enabled: (options?.enabled ?? true) && !!bandId,
+  });
+}

--- a/src/domain/band/hooks/useBandList.ts
+++ b/src/domain/band/hooks/useBandList.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useInfiniteCursor } from '@/hooks/useInfiniteCursor';
+
+import { getBands } from '../api/getBands';
+import type { BandInfoResponse } from '../types';
+
+export function useBandList(pageSize: number = 20) {
+  return useInfiniteCursor<BandInfoResponse, string>(
+    [...queryKeys.band.list(), pageSize],
+    ({ lastId, pageSize: size }) => getBands({ lastId, pageSize: size }),
+    pageSize,
+  );
+}

--- a/src/domain/band/hooks/useBandMembers.ts
+++ b/src/domain/band/hooks/useBandMembers.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useInfiniteCursor } from '@/hooks/useInfiniteCursor';
+
+import { getBandMembers } from '../api/getBandMembers';
+import type { BandMemberInfoResponse } from '../types';
+
+export function useBandMembers(bandId: string, pageSize: number = 20) {
+  return useInfiniteCursor<BandMemberInfoResponse, string>(
+    [...queryKeys.band.members(bandId), pageSize],
+    ({ lastId, pageSize: size }) => getBandMembers(bandId, { lastId, pageSize: size }),
+    pageSize,
+    { enabled: !!bandId },
+  );
+}

--- a/src/domain/band/hooks/useCreateBand.ts
+++ b/src/domain/band/hooks/useCreateBand.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { createBand } from '../api/createBand';
+import type { CreateBandRequest, CreateBandResponse } from '../types';
+
+type UseCreateBandOptions = {
+  onSuccess?: (data: CreateBandResponse) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useCreateBand(options?: UseCreateBandOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<CreateBandResponse, Error, CreateBandRequest>({
+    mutationFn: createBand,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.all] });
+      options?.onSuccess?.(data);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/band/hooks/useDecideApplication.ts
+++ b/src/domain/band/hooks/useDecideApplication.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { decideApplication } from '../api/decideApplication';
+import type { BandApplicationDecision } from '../types';
+
+type UseDecideApplicationOptions = {
+  onSuccess?: (vars: { applicationId: string; decision: BandApplicationDecision }) => void;
+  onError?: (error: Error) => void;
+};
+
+type Variables = {
+  applicationId: string;
+  decision: BandApplicationDecision;
+};
+
+export function useDecideApplication(bandId: string, options?: UseDecideApplicationOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, Variables>({
+    mutationFn: ({ applicationId, decision }) => decideApplication(bandId, applicationId, decision),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.applications(bandId)] });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.members(bandId)] });
+      options?.onSuccess?.(variables);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/band/hooks/useDelegateLeader.ts
+++ b/src/domain/band/hooks/useDelegateLeader.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { delegateLeader } from '../api/delegateLeader';
+
+type UseDelegateLeaderOptions = {
+  onSuccess?: (bandMemberId: string) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDelegateLeader(bandId: string, options?: UseDelegateLeaderOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (bandMemberId) => delegateLeader(bandId, bandMemberId),
+    onSuccess: (_, bandMemberId) => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.members(bandId)] });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
+      options?.onSuccess?.(bandMemberId);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/band/hooks/useLeaveBand.ts
+++ b/src/domain/band/hooks/useLeaveBand.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { leaveBand } from '../api/leaveBand';
+
+type UseLeaveBandOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useLeaveBand(bandId: string, options?: UseLeaveBandOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => leaveBand(bandId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.all] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/band/hooks/useWithdrawApplication.ts
+++ b/src/domain/band/hooks/useWithdrawApplication.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { withdrawApplication } from '../api/withdrawApplication';
+
+type UseWithdrawApplicationOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useWithdrawApplication(bandId: string, options?: UseWithdrawApplicationOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => withdrawApplication(bandId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/band/types/index.ts
+++ b/src/domain/band/types/index.ts
@@ -1,0 +1,9 @@
+export type { CreateBandRequest, BandApplicationDecision } from './req';
+export type {
+  CreateBandResponse,
+  BandInfoResponse,
+  BandMemberInfoResponse,
+  BandApplicationInfoResponse,
+} from './res';
+export { createBandSchema } from './schema';
+export type { CreateBandSchema } from './schema';

--- a/src/domain/band/types/req.ts
+++ b/src/domain/band/types/req.ts
@@ -1,0 +1,7 @@
+export interface CreateBandRequest {
+  name: string;
+  description?: string;
+  profileImg?: string;
+}
+
+export type BandApplicationDecision = 'APPROVED' | 'REJECTED';

--- a/src/domain/band/types/res.ts
+++ b/src/domain/band/types/res.ts
@@ -1,0 +1,25 @@
+import type { ApplicationStatus, BandRole } from '@/global/types';
+
+export interface CreateBandResponse {
+  bandId: string;
+  bandName: string;
+}
+
+export interface BandInfoResponse {
+  bandId: string;
+  bandName: string;
+  description?: string;
+  profileImg?: string;
+}
+
+export interface BandMemberInfoResponse {
+  bandMemberId: string;
+  memberId: number;
+  role: BandRole;
+}
+
+export interface BandApplicationInfoResponse {
+  bandApplicationId: string;
+  memberId: number;
+  status: ApplicationStatus;
+}

--- a/src/domain/band/types/schema.ts
+++ b/src/domain/band/types/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const createBandSchema = z.object({
+  name: z
+    .string()
+    .min(1, '밴드 이름을 입력해 주세요.')
+    .max(50, '밴드 이름은 50자 이하로 입력해 주세요.'),
+  description: z
+    .string()
+    .max(200, '소개는 200자 이하로 입력해 주세요.')
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+  profileImg: z
+    .string()
+    .url('올바른 이미지 URL 을 입력해 주세요.')
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+});
+export type CreateBandSchema = z.infer<typeof createBandSchema>;

--- a/src/global/auth/RoleGuard.tsx
+++ b/src/global/auth/RoleGuard.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import type { BandRole } from '@/global/types';
+
+import { useBandRole } from './useBandRole';
+
+const roleHierarchy: Record<BandRole, number> = {
+  LEADER: 3,
+  ADMIN: 2,
+  MEMBER: 1,
+};
+
+type RoleGuardProps = {
+  bandId: string;
+  role: BandRole;
+  children: ReactNode;
+  fallback?: ReactNode;
+};
+
+/**
+ * 지정 밴드에서 현재 유저의 역할이 최소 요구 역할 이상일 때만 children 을 렌더합니다.
+ * 로딩 중에는 fallback 을 반환해 UI 깜빡임을 방지합니다.
+ */
+export function RoleGuard({ bandId, role, children, fallback = null }: RoleGuardProps) {
+  const { data: userRole } = useBandRole(bandId);
+  if (!userRole) return <>{fallback}</>;
+  if (roleHierarchy[userRole] < roleHierarchy[role]) return <>{fallback}</>;
+  return <>{children}</>;
+}
+
+/** 헬퍼: 현재 유저 역할이 최소 요구 역할 이상인지 boolean */
+export function hasRole(userRole: BandRole | null | undefined, minRole: BandRole) {
+  if (!userRole) return false;
+  return roleHierarchy[userRole] >= roleHierarchy[minRole];
+}

--- a/src/global/auth/useBandRole.ts
+++ b/src/global/auth/useBandRole.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getBandMembers } from '@/domain/band/api/getBandMembers';
+import { useMe } from '@/domain/member/hooks/useMe';
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+import type { BandRole } from '@/global/types';
+
+const MAX_PAGE_SIZE = 100;
+
+/**
+ * 현재 로그인한 유저의 해당 밴드 내 역할(BandRole)을 반환합니다.
+ * 미멤버이거나 조회 실패 시 null.
+ *
+ * 구현 주의: 백엔드 BandInfoResponse 에 아직 myRole 필드가 없으므로,
+ *   1) useMe 로 현재 memberId 확보
+ *   2) /bands/{bandId}/members 를 최대 100건 페이지로 조회해 매칭
+ * 방식으로 도출합니다. 백엔드가 myRole 을 제공하기 시작하면 useBandDetail 경유로 단순화 가능.
+ */
+export function useBandRole(bandId: string) {
+  const authenticated = useIsAuthenticated();
+  const { data: me } = useMe({ enabled: authenticated });
+  const memberId = me?.id;
+
+  return useQuery<BandRole | null, Error>({
+    queryKey: [...queryKeys.band.members(bandId), 'my-role', memberId ?? null],
+    queryFn: async () => {
+      if (!memberId) return null;
+      let cursor: string | undefined;
+      let pagesFetched = 0;
+      const maxPages = 10;
+      while (pagesFetched < maxPages) {
+        const page = await getBandMembers(bandId, { lastId: cursor, pageSize: MAX_PAGE_SIZE });
+        const match = page.content.find((m) => m.memberId === memberId);
+        if (match) return match.role;
+        if (!page.hasNext || !page.nextCursor) return null;
+        cursor = page.nextCursor;
+        pagesFetched += 1;
+      }
+      return null;
+    },
+    enabled: !!bandId && authenticated && memberId != null,
+    staleTime: 60 * 1000,
+  });
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #9

📌 **작업 내용 및 특이사항**

Task 7 (서브태스크 7.1 ~ 7.5) 구현. `src/domain/band/*` 도메인 레이어, 역할 기반 UI 가드(`useBandRole` + `RoleGuard`), `/bands` · `/bands/new` · `/bands/[bandId]` 페이지를 포함합니다.

### 구현 파일
- **도메인 레이어** — `domain/band/{types,api,hooks,components}/*`
  - types: CreateBandRequest, BandApplicationDecision, CreateBandResponse, BandInfoResponse, BandMemberInfoResponse, BandApplicationInfoResponse, createBandSchema(zod, name 1~50자, description ≤200자, profileImg URL)
  - api: createBand · getBandDetail · getBands · getBandMembers · applyBand · withdrawApplication · getBandApplications · decideApplication · delegateLeader · leaveBand 10개 함수. API_SPEC 3-1~3-11 경로/메서드/쿼리 파라미터 정합
  - hooks: useBandList · useBandMembers · useBandApplications(useInfiniteCursor), useBandDetail(useQuery), useCreateBand · useApplyBand · useWithdrawApplication · useDecideApplication · useDelegateLeader · useLeaveBand(useMutation, 성공 시 관련 queryKey invalidate)
  - components: BandRoleBadge(LEADER accent / ADMIN success / MEMBER default), BandCard(Avatar+이름+설명 truncate, interactive Card), BandMemberRow(RoleGuard LEADER 로 리더 위임 버튼 + 확인 Dialog), BandApplicationRow(PENDING 에만 승인/거절 버튼, useDecideApplication ?status=...), BandCreateForm.client.tsx (rhf + zodResolver)
- **역할 가드** — `global/auth/useBandRole.ts` + `RoleGuard.tsx`
  - useBandRole: 현재 로그인 유저의 해당 밴드 내 BandRole 을 반환. useMe 로 memberId 확보 후 /bands/{bandId}/members 를 pageSize=100, 최대 10 페이지 순회하여 매칭. 백엔드에 myRole 필드 추가 시 useBandDetail 경유로 단순화 예정(구현 주석 명시)
  - RoleGuard: roleHierarchy(LEADER 3 > ADMIN 2 > MEMBER 1) 기준 최소 요구 역할 미만이면 fallback 렌더. hasRole 헬퍼 부가 export
- **페이지**
  - `/bands`: useBandList 무한 스크롤 + IntersectionObserver prefetch + EmptyState/ErrorState, 우하단 FAB(Link) 밴드 생성 이동
  - `/bands/new`: BandCreateForm 렌더
  - `/bands/[bandId]`: async params 로 bandId 추출. Tabs(개요/멤버/가입신청) 구성. 개요 탭에 비멤버 가입 신청 / 멤버 탈퇴 Dialog, 멤버 탭에 useBandMembers + BandMemberRow, 가입신청 탭은 `RoleGuard role="ADMIN"` 으로 탭 자체 + 본문 이중 가드

### 검증 결과 (로컬)
- [x] `pnpm lint` / `typecheck` / `format:check` / `build` 통과
- [x] `pnpm test` 16/16 (기존 테스트 유지)
- [x] 새 라우트 `/bands`(160kB), `/bands/new`(161kB), `/bands/[bandId]`(178kB, dynamic) 번들 확인

### 실서버 검증 (CLAUDE.md §6 절차 수행)
로컬 백엔드(`http://localhost:8080`) 에 대해 10개 엔드포인트 전수 검증. 전체 시나리오 통과:
userA LEADER → 밴드 생성 → userB 신청 → APPROVED → userC 신청 → REJECTED → userD 신청 → 본인 WITHDRAWN → A→B 리더 위임 → userA 탈퇴.

상세 리포트: [.taskmaster/report/band-api-verification-2026-04-24.md](./.taskmaster/report/band-api-verification-2026-04-24.md)

관측된 백엔드 이슈 3건 (기능 정상 동작이나 정렬/개선 권장):
1. API_SPEC 의 "인증 불필요" 표기와 실제 동작(모든 GET 이 Bearer 요구) 불일치 — 스펙 또는 필터 중 하나로 정렬 필요
2. 권한 부족을 401 + `WWW-Authenticate: Bearer error="invalid_token"` 로 반환 — apiClient refresh 인터셉터 오동작 유발 가능. 인가 실패는 403 분리 권장
3. `CursorResponse.hasNext=false` 일 때 `nextCursor` 가 마지막 id 로 채워지는 일관성 이슈 (프론트 가드 처리되어 영향 없음)

Task 6 에서 지적된 JWT 필터 MalformedJwtException 관련 이슈는 이 검증 시점에 해소되어 있음을 확인 (401 정상 반환, `WWW-Authenticate` 헤더 첨부).

📚 **참고사항**
- useBandRole 의 페이징 순회 방식은 소규모 밴드 전제. 백엔드에 `BandInfoResponse.myRole` 추가되면 단순화 예정
- 이 PR 은 Task 6 (#22, `9cb1574`) 머지 후 develop 에 rebase 된 상태에서 분기