### PR TITLE
feat: 합주(Practice) 및 합주곡(Practice-Song) 도메인 구현 (#10)

### DIFF
--- a/.taskmaster/report/practice-song-api-verification-2026-04-24.md
+++ b/.taskmaster/report/practice-song-api-verification-2026-04-24.md
@@ -1,0 +1,197 @@
+# Practice / Practice-Song API 프론트 연동 검증 리포트 (Task 8 / Issue #10)
+
+- 작성일: 2026-04-24 (Asia/Seoul)
+- 검증 주체: 프론트엔드 (Bandage-FE-Web, branch `feat/#10-practice-song`)
+- 백엔드 기동 URL: `http://localhost:8080`
+- 검증 도구: `curl` 직접 호출. 재현용 페이로드 `/tmp/bandage-practice-test/*`
+- 검증 범위: `src/domain/practice/api/*` 11개 + `src/domain/practice-song/api/*` 2개 = 총 13개 엔드포인트 호출
+- 검증 결과 요약: **블로커 1건(합주곡 생성 엔드포인트 부재)** 때문에 13개 중 **9개가 실경로 재현 불가** 상태. 나머지 4개는 호출 형태만 확인 가능 (엔드포인트 미구현 또는 선결 조건 필요).
+
+---
+
+## 1. 테스트한 API 목록
+
+| # | Path | Method | FE 함수 | 판정 |
+| --- | --- | --- | --- | --- |
+| 1 | `/api/v1/practices?bandId=...&pageSize=...` | GET | `getPractices` | **미구현** (HTTP 401 + `Allow: POST`) |
+| 2 | `/api/v1/practices` | POST | `createPractice` | 경로 존재 확인. 유효 songId 없어 실성공 불가 — 404 "요청한 합주 곡 정보를 찾을 수 없습니다." |
+| 3 | `/api/v1/practices/{practiceId}` | GET | `getPractice` | 유효 practiceId 없어 경로 형태만 확인 (블로커 1) |
+| 4 | `/api/v1/practices/{practiceId}` | DELETE | `deletePractice` | 동상 (블로커 1) |
+| 5 | `/api/v1/practices/{practiceId}/schedule` | PATCH | `updateSchedule` | 동상 |
+| 6 | `/api/v1/practices/{practiceId}/venue` | PATCH | `updateVenue` | 동상 |
+| 7 | `/api/v1/practices/{practiceId}/sessions` | POST | `createSession` | 동상 |
+| 8 | `/api/v1/practices/{practiceId}/sessions/{sessionId}` | DELETE | `deleteSession` | 동상 |
+| 9 | `/api/v1/practices/{practiceId}/participants` | POST | `addParticipant` | 동상 |
+| 10 | `/api/v1/practices/{practiceId}/sessions/{sessionId}/assignment` | PATCH | `assignSession` | 동상 |
+| 11 | `/api/v1/practices/{practiceId}/sessions/{sessionId}/assignment` | DELETE | `unassignSession` | 동상 |
+| 12 | `/api/v1/practice-songs/{songId}/ref-link` | PUT | `upsertRefLink` | 경로 존재. 존재하지 않는 songId 로 호출 시 404 "요청한 합주 곡 정보를 찾을 수 없습니다." ("upsert" 시맨틱 아님 — 기존 곡 전제) |
+| 13 | `/api/v1/practice-songs/{songId}/ref-link` | DELETE | `deleteRefLink` | 동상 (블로커 2) |
+
+---
+
+## 2. 케이스별 실제 요청/응답 값
+
+### 2-1. 인증 셋업
+
+```bash
+# 신규 유저 등록/로그인 후 Bearer 확보
+POST /api/v1/members/join → 200 { id: 8, email: "practice-<ts>@bandage.test" }
+POST /api/v1/auth/login  → 200 + Set-Cookie refreshToken + accessToken (len 196)
+```
+
+이전 Task 6/7 리포트와 동일하게 **인증 단계 자체는 정상** 동작. 모든 후속 호출에 `Authorization: Bearer <token>` 첨부.
+
+### 2-2. GET `/api/v1/practices` — 목록 엔드포인트 미구현
+
+요청
+```http
+GET /api/v1/practices?pageSize=5 HTTP/1.1
+Authorization: Bearer <token>
+```
+응답 (HTTP 401)
+```http
+Allow: POST
+WWW-Authenticate: Bearer error="invalid_token"
+```
+```json
+{"success":false,"message":"인증되지 않은 회원입니다.","data":null,"timestamp":"..."}
+```
+판정: `Allow: POST` 헤더가 **"이 경로는 POST 만 지원"** 을 의미하므로 GET 핸들러가 구현되지 않은 상태. Spring Security 필터가 인증 오류를 우선 던지면서 405 대신 401 로 표면화됨. FE `usePractices` 훅은 `ApiError` 로 변환되어 목록 페이지의 `ErrorState` 경로로 폴백.
+
+### 2-3. POST `/api/v1/practices` — 유효 songId 없이 404
+
+요청
+```json
+{
+  "title": "QA Practice Test",
+  "song": "550e8400-e29b-41d4-a716-446655440000",
+  "venue": "홍대 스튜디오",
+  "startAt": "2026-12-15 18:00",
+  "durationMinutes": 60
+}
+```
+응답 (HTTP 404)
+```json
+{
+  "success": false,
+  "message": "요청한 합주 곡 정보를 찾을 수 없습니다.",
+  "data": null,
+  "timestamp": "2026-04-24T13:33:52.918859"
+}
+```
+판정: 경로 자체는 정상 매핑됨. 프론트가 보내는 요청 shape 또한 정확히 수용됨(NotFound 가 검증 오류가 아님을 확인). **블로커 1 — 존재하는 songId 가 있어야 실성공 가능**.
+
+### 2-4. PUT `/api/v1/practice-songs/{songId}/ref-link` — 기존 Song 전제
+
+요청
+```http
+PUT /api/v1/practice-songs/019dbd8a-7777-7777-7777-777777777777/ref-link
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{"refLink":"https://www.youtube.com/watch?v=test"}
+```
+응답 (HTTP 404) — 동일 메시지 "요청한 합주 곡 정보를 찾을 수 없습니다."
+
+판정: "upsert" 라는 이름이지만 **존재하지 않는 song 을 새로 만들어 주지 않음**. 이름과 실제 동작이 일치하지 않아 혼동의 소지가 있음.
+
+### 2-5. Song 생성/조회 엔드포인트 탐색 — 모두 401
+
+아래 모든 경로에 Bearer 를 담아 호출해도 401 반환 (실제로는 미구현인 경로에 대해 Spring Security 가 401 로 감싸는 것으로 추정):
+
+| 경로 | HTTP |
+| --- | --- |
+| `POST /api/v1/songs` | 401 |
+| `GET /api/v1/songs` | 401 |
+| `POST /api/v1/practice-songs` | 401 |
+| `GET /api/v1/practice-songs` | 401 |
+
+결론: **공개된 합주곡(Song) 생성/조회 엔드포인트가 API_SPEC 어디에도 등재되어 있지 않으며, 실제 서버에도 존재하지 않는 것으로 보임.** 이 때문에 Practice 생성/세션·참여자·일정·장소·삭제 전 플로우를 실제로 돌려볼 수 없음.
+
+---
+
+## 3. 권장 조치 내용 및 검토 필요 사항
+
+### A. (Backend, 최우선) Song 생성/조회 API 도입 — 블로커 해제
+
+**현상**: Practice 생성(`POST /practices`) 은 이미 존재하는 `songId` 를 받아야 하고, `PUT /practice-songs/{songId}/ref-link` 는 이미 존재하는 song 에만 동작. 하지만 **song 을 처음부터 등록하는 공식 경로가 없음**. 운영 환경에서는 물론 개발/QA 에서도 첫 Practice 를 만들 방법이 차단됨.
+
+**요청 (권장안, 택 1)**
+- **A-1**: `POST /api/v1/practice-songs` (title/artist 필수, refLink 선택) + 응답에 `songId` 반환. 프론트의 "합주 만들기" 폼을 "곡 검색 / 없으면 새로 추가" UX 로 확장 가능.
+- **A-2**: `PUT /api/v1/practice-songs/{songId}/ref-link` 를 진짜 upsert 로 변경. 응답 바디에 생성/갱신된 song 정보 포함. (이름과 실 동작 일치)
+
+현재 프론트는 `CreatePracticeRequest.song` 을 UUID 문자열로 받고 있어서, 어느 쪽이든 백엔드가 반환하는 `songId` 를 그대로 전달 가능.
+
+### B. (Backend) `GET /api/v1/practices` 목록 엔드포인트 추가
+
+**현상**: `Allow: POST` 로 GET 미구현 상태. Performance 6-2 는 동일 패턴 목록을 제공하고 있어 Practice 도 동일 스타일로 등재 가능.
+
+**요청 (권장 shape)**
+- `GET /api/v1/practices`
+- Query: `bandId?`(UUID, 특정 밴드 소속만), `lastId?`(커서), `pageSize?`(기본 10, 1~100)
+- Response: `CursorResponse<PracticeListItemResponse, UUID>` — `PracticeListItemResponse` 는 상세(`4-2`) 의 축약본(제목/시작시각/소요분/장소/song 요약) 권장
+
+미구현 상태에서 프론트는 `/practices` 페이지의 `ErrorState` 경로로 폴백하며 `백엔드 목록 엔드포인트가 아직 제공되지 않을 수 있습니다.` 문구를 노출 중.
+
+### C. (Backend) "인증 불필요" API_SPEC 표기와 실제 인가 동작 불일치
+
+**현상**: API_SPEC 4-1 (합주 생성) · 4-2 (합주 상세 조회) · 5-1/5-2 (refLink upsert/delete) 는 모두 **"인증 불필요 (TODO: 인증 추가 예정)"** 라고 명시되어 있으나 실제로는 Bearer 없이는 401.
+
+**요청**: API_SPEC 을 "인증 필요" 로 일괄 갱신 (또는 실제 SecurityFilterChain 을 의도대로 `permitAll()` 정렬). Task 7 리포트의 §3-A 와 동일한 스펙 드리프트 성격.
+
+### D. (Backend, 중기) 일관성 — 미존재 리소스 접근 시 401 대신 404
+
+**현상**: 미구현 경로(예: `GET /api/v1/songs`) 에 Bearer 유효 토큰을 담아 호출해도 401 반환. `WWW-Authenticate` 헤더 없음. 실사용자 관점에서는 "토큰이 왜 거부되지?" 로 혼동 유발.
+
+**요청**: 경로 자체가 없으면 **404 Not Found** 또는 405 Method Not Allowed 로 분기. Task 6 리포트 §3-C 의 "인증 실패 401 / 권한 부족 403 분리" 와 맥락이 비슷한 이슈.
+
+### E. (Frontend, 현재는 무조치) Practice 생성 폼 UX 개선 여지
+
+- 현재 `PracticeCreateForm.client.tsx` 는 `songId` UUID 를 텍스트 입력으로 받고 있음 (hint 로 안내). 백엔드 §3-A 해결 후 "곡 검색/선택" UX 로 교체 예정.
+- Session 배정은 API_SPEC 4-6/4-7 이 **본인만 배정/해제 가능**하도록 제한되어 있어 "나를 배정 / 해제" 토글로만 구현. 다른 참여자를 세션에 배정해야 할 요구가 생기면 백엔드에 별도 엔드포인트(예: `PATCH /sessions/{id}/assignment?participantId=...`) 추가 필요.
+
+---
+
+## 4. 검증된 동작 (긍정 신호)
+
+- `POST /api/v1/practices` 의 요청 shape 수용: 프론트가 보낸 `{title, song, venue, startAt(yyyy-MM-dd HH:mm), durationMinutes}` 를 수용해 404(NotFound) 로 진행. 스키마 불일치 400 이 아님 → **요청 형태는 일치**.
+- `Authorization: Bearer <token>` 전체 검증 경로 정상 (Task 6/7 에서 지적된 JwtAuthenticationFilter MalformedJwtException 이슈는 여기서도 재발 없음).
+- 401 응답은 `WWW-Authenticate: Bearer error="invalid_token"` 헤더 + `{success:false, message, data:null, timestamp}` 표준 바디를 유지 (프론트 `ApiError` 매핑 정상).
+
+---
+
+## 5. 프론트 관련 구현 지점
+
+```text
+src/domain/practice/types/{req,res,schema,index}.ts      # DTO + zod 스키마 6개
+src/domain/practice/api/*.ts                              # 11개 함수 (createPractice ~ unassignSession)
+src/domain/practice/hooks/*.ts                            # 10개 Mutation/Query 훅 (낙관적 업데이트 포함)
+src/domain/practice/components/*.tsx                      # PracticeCard / PracticeScheduleBadge / PracticeVenueInline(client) / SessionRow / SessionCreateForm(client) / SongRefLinkEditor(client)
+src/domain/practice-song/api/*.ts                         # upsertRefLink / deleteRefLink
+src/domain/practice-song/hooks/*.ts                       # useUpsertSongRefLink / useDeleteSongRefLink
+src/app/(main)/practices/page.tsx + PracticesList.client.tsx           # 무한 스크롤 목록 + FAB
+src/app/(main)/practices/new/page.tsx + PracticeCreateForm.client.tsx  # 생성 폼
+src/app/(main)/practices/[practiceId]/page.tsx + PracticeDetailContent.client.tsx  # 상세 (일정/장소/세션/참여자/곡 링크/삭제)
+```
+
+§3-A 해결 후 `PracticeCreateForm` 을 "곡 선택 UI" 로 확장하면 외에는 추가 프론트 수정 불필요. §3-B 해결 시 `usePractices` 가 실동작하면서 `/practices` 페이지 EmptyState/정상 목록 분기 모두 검증 가능해짐.
+
+---
+
+## 6. 재현용 페이로드 위치
+
+```text
+/tmp/bandage-practice-test/
+  ├── state.env       # TOKEN, MEMBER_ID
+  ├── join.json / login.json
+  ├── cookies.txt
+  ├── create.json     # Practice 생성 요청 (song=랜덤 UUID)
+  └── ref_link.json   # refLink 업서트 요청
+```
+
+---
+
+## 7. 다음 단계 제안
+
+1. 백엔드에 **§3-A (Song 생성 엔드포인트)** 반영 요청. 반영 후 이 리포트에 "2차 검증" 추가하여 Practice/Session/Participant/Schedule/Venue/Delete/RefLink 전 플로우를 확정 검증.
+2. 그 전까지 프론트는 현재 구현 그대로 PR 병합하여도 회귀는 없으나 실제 API 호출 경로는 **백엔드 A/B 해제 전까지 사용자에게는 비활성** 에 가까움. PR 본문 및 ROUTES.md 에 "API 의존 대기 중" 명시 권장.

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -462,7 +462,7 @@
         "dependencies": [
           "7"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -524,7 +524,8 @@
             "testStrategy": "합주 생성 → 세션 3개 추가 → 2명이 각각 세션 배정 → 장소 변경 → 곡 링크 추가/수정 → 삭제 플로우 수동 테스트. 세션 배정 낙관적 업데이트 즉시 반영 확인. 삭제 확인 다이얼로그 동작 확인.",
             "parentId": "undefined"
           }
-        ]
+        ],
+        "updatedAt": "2026-04-24T04:52:41.897Z"
       },
       {
         "id": "9",
@@ -675,9 +676,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-04-24T01:54:21.138Z",
+      "lastModified": "2026-04-24T04:52:41.903Z",
       "taskCount": 10,
-      "completedCount": 7,
+      "completedCount": 8,
       "tags": [
         "master"
       ]

--- a/src/app/(main)/practices/PracticesList.client.tsx
+++ b/src/app/(main)/practices/PracticesList.client.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { Music, Plus } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { ErrorState } from '@/components/feedback/error-state';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PracticeCard } from '@/domain/practice/components/PracticeCard';
+import { usePractices } from '@/domain/practice/hooks/usePractices';
+import { ROUTES } from '@/global/config/routes';
+
+export function PracticesList() {
+  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    usePractices(undefined, 20);
+
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!hasNextPage || !loadMoreRef.current) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting && !isFetchingNextPage) fetchNextPage();
+    });
+    observer.observe(loadMoreRef.current);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20 w-full" rounded="md" />
+        <Skeleton className="h-20 w-full" rounded="md" />
+        <Skeleton className="h-20 w-full" rounded="md" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorState
+        description="합주 목록을 불러오지 못했습니다. 백엔드 목록 엔드포인트가 아직 제공되지 않을 수 있습니다."
+        onRetry={() => refetch()}
+      />
+    );
+  }
+
+  const practices = data?.pages.flatMap((p) => p.content) ?? [];
+
+  return (
+    <div className="space-y-4">
+      {practices.length === 0 ? (
+        <EmptyState
+          icon={Music}
+          title="등록된 합주가 없습니다"
+          description="첫 번째 합주를 만들어 세션을 편성해 보세요."
+        />
+      ) : (
+        <>
+          <div className="space-y-3">
+            {practices.map((p) => (
+              <PracticeCard key={p.practiceId} practice={p} />
+            ))}
+          </div>
+          {hasNextPage && <div ref={loadMoreRef} className="h-4" aria-hidden="true" />}
+          {isFetchingNextPage && <Skeleton className="h-20 w-full" rounded="md" />}
+        </>
+      )}
+
+      <Link
+        href={ROUTES.PRACTICE_NEW}
+        aria-label="합주 만들기"
+        className="bg-accent text-foreground hover:bg-accent-hi focus-visible:ring-accent focus-visible:ring-offset-bg rounded-pill fixed right-4 bottom-20 z-10 flex h-14 w-14 items-center justify-center shadow-lg transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      >
+        <Plus className="h-6 w-6" />
+      </Link>
+    </div>
+  );
+}

--- a/src/app/(main)/practices/[practiceId]/PracticeDetailContent.client.tsx
+++ b/src/app/(main)/practices/[practiceId]/PracticeDetailContent.client.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Music, Trash2, UserPlus } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { ErrorState } from '@/components/feedback/error-state';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PracticeScheduleBadge } from '@/domain/practice/components/PracticeScheduleBadge';
+import { PracticeVenueInline } from '@/domain/practice/components/PracticeVenueInline.client';
+import { SessionCreateForm } from '@/domain/practice/components/SessionCreateForm.client';
+import { SessionRow } from '@/domain/practice/components/SessionRow';
+import { SongRefLinkEditor } from '@/domain/practice/components/SongRefLinkEditor.client';
+import { useAddParticipant } from '@/domain/practice/hooks/useAddParticipant';
+import { useDeletePractice } from '@/domain/practice/hooks/useDeletePractice';
+import { usePractice } from '@/domain/practice/hooks/usePractice';
+import { useUpdateSchedule } from '@/domain/practice/hooks/useUpdateSchedule';
+import { addParticipantSchema, type AddParticipantSchema } from '@/domain/practice/types';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+function toDatetimeLocal(kst: string) {
+  // "yyyy-MM-dd HH:mm" -> "YYYY-MM-DDTHH:mm"
+  return kst.replace(' ', 'T');
+}
+function fromDatetimeLocal(dt: string) {
+  return dt.replace('T', ' ').slice(0, 16);
+}
+
+export function PracticeDetailContent({ practiceId }: { practiceId: string }) {
+  const router = useRouter();
+  const toast = useToast();
+  const { data: practice, isLoading, isError, refetch } = usePractice(practiceId);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const scheduleForm = useForm<{ startAt: string; durationMinutes: number }>({
+    defaultValues: { startAt: '', durationMinutes: 60 },
+  });
+
+  const updateScheduleMutation = useUpdateSchedule(practiceId, {
+    onSuccess: () => {
+      toast.success('일정이 변경되었습니다.');
+      setScheduleOpen(false);
+    },
+    onError: (err) => toast.error(err.message || '일정 변경에 실패했습니다.'),
+  });
+
+  const deleteMutation = useDeletePractice(practiceId, {
+    onSuccess: () => {
+      toast.success('합주가 삭제되었습니다.');
+      router.replace(ROUTES.PRACTICES);
+    },
+    onError: (err) => toast.error(err.message || '합주 삭제에 실패했습니다.'),
+  });
+
+  const addParticipantForm = useForm<AddParticipantSchema>({
+    resolver: zodResolver(addParticipantSchema),
+    defaultValues: { memberId: undefined as unknown as number },
+  });
+  const addParticipantMutation = useAddParticipant(practiceId, {
+    onSuccess: () => {
+      toast.success('참여자가 추가되었습니다.');
+      addParticipantForm.reset({ memberId: undefined as unknown as number });
+    },
+    onError: (err) => toast.error(err.message || '참여자 추가에 실패했습니다.'),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-32 w-full" rounded="lg" />
+        <Skeleton className="h-10 w-1/2" />
+      </div>
+    );
+  }
+
+  if (isError || !practice) {
+    return <ErrorState title="합주를 찾을 수 없습니다" onRetry={() => refetch()} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card padding="lg">
+        <div className="space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <h1 className="text-foreground text-xl font-bold">{practice.title}</h1>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="text-danger hover:opacity-80"
+              onClick={() => setDeleteOpen(true)}
+            >
+              <Trash2 className="h-4 w-4" />
+              삭제
+            </Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <PracticeScheduleBadge
+              startAt={practice.startAt}
+              durationMinutes={practice.durationMinutes}
+            />
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                scheduleForm.reset({
+                  startAt: toDatetimeLocal(practice.startAt),
+                  durationMinutes: practice.durationMinutes,
+                });
+                setScheduleOpen(true);
+              }}
+            >
+              일정 변경
+            </Button>
+          </div>
+          <PracticeVenueInline practiceId={practiceId} venue={practice.venue} />
+        </div>
+      </Card>
+
+      <Card header="합주곡" padding="md">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Music className="text-foreground-muted h-4 w-4" aria-hidden="true" />
+            <span className="text-foreground text-sm font-medium">
+              {practice.song.title} — {practice.song.artist}
+            </span>
+          </div>
+          <SongRefLinkEditor
+            practiceId={practiceId}
+            songId={practice.song.songId}
+            refLink={practice.song.refLink ?? null}
+          />
+        </div>
+      </Card>
+
+      <Card header="세션" padding="md">
+        <div className="space-y-4">
+          <SessionCreateForm practiceId={practiceId} />
+          {practice.sessions.length === 0 ? (
+            <EmptyState title="등록된 세션이 없습니다" />
+          ) : (
+            <div>
+              {practice.sessions.map((s) => (
+                <SessionRow key={s.sessionId} practiceId={practiceId} session={s} />
+              ))}
+            </div>
+          )}
+        </div>
+      </Card>
+
+      <Card header="참여자" padding="md">
+        <div className="space-y-4">
+          <form
+            className="flex items-end gap-2"
+            onSubmit={addParticipantForm.handleSubmit((values) =>
+              addParticipantMutation.mutate(values),
+            )}
+            noValidate
+          >
+            <Input
+              label="멤버 ID"
+              type="number"
+              placeholder="예: 3"
+              className="max-w-xs"
+              error={addParticipantForm.formState.errors.memberId?.message}
+              {...addParticipantForm.register('memberId', { valueAsNumber: true })}
+            />
+            <Button type="submit" loading={addParticipantMutation.isPending}>
+              <UserPlus className="h-4 w-4" />
+              추가
+            </Button>
+          </form>
+          {practice.participants.length === 0 ? (
+            <EmptyState title="참여자가 없습니다" />
+          ) : (
+            <ul className="space-y-2">
+              {practice.participants.map((p) => (
+                <li key={p.participantId} className="text-foreground-sub text-sm">
+                  Member #{p.memberId}
+                  <span className="text-foreground-muted ml-2 text-xs">{p.participantId}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </Card>
+
+      <Dialog open={scheduleOpen} onOpenChange={setScheduleOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>일정 변경</DialogTitle>
+          </DialogHeader>
+          <form
+            onSubmit={scheduleForm.handleSubmit((values) =>
+              updateScheduleMutation.mutate({
+                startAt: fromDatetimeLocal(values.startAt),
+                durationMinutes: Number(values.durationMinutes),
+              }),
+            )}
+          >
+            <DialogBody>
+              <div className="space-y-3">
+                <Input
+                  label="시작 시각"
+                  type="datetime-local"
+                  {...scheduleForm.register('startAt')}
+                />
+                <Input
+                  label="소요 시간 (분)"
+                  type="number"
+                  min={15}
+                  max={480}
+                  step={15}
+                  {...scheduleForm.register('durationMinutes', { valueAsNumber: true })}
+                />
+              </div>
+            </DialogBody>
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={() => setScheduleOpen(false)}>
+                취소
+              </Button>
+              <Button type="submit" loading={updateScheduleMutation.isPending}>
+                저장
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>합주 삭제</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <p className="text-foreground-sub text-sm">
+              삭제된 합주는 복구할 수 없습니다. 세션과 참여자 정보도 함께 제거됩니다.
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteOpen(false)}>
+              취소
+            </Button>
+            <Button
+              variant="danger"
+              loading={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate()}
+            >
+              삭제
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/(main)/practices/[practiceId]/page.tsx
+++ b/src/app/(main)/practices/[practiceId]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+import { PracticeDetailContent } from './PracticeDetailContent.client';
+
+export const metadata: Metadata = {
+  title: '합주 상세 | Bandage',
+};
+
+type PageProps = {
+  params: Promise<{ practiceId: string }>;
+};
+
+export default async function PracticeDetailPage({ params }: PageProps) {
+  const { practiceId } = await params;
+  return <PracticeDetailContent practiceId={practiceId} />;
+}

--- a/src/app/(main)/practices/new/PracticeCreateForm.client.tsx
+++ b/src/app/(main)/practices/new/PracticeCreateForm.client.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useCreatePractice } from '@/domain/practice/hooks/useCreatePractice';
+import { createPracticeSchema, type CreatePracticeSchema } from '@/domain/practice/types';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+/**
+ * datetime-local 값("YYYY-MM-DDTHH:mm") 을 API 요구 형식("yyyy-MM-dd HH:mm") 으로 변환.
+ * 빈 문자열은 그대로 반환해 zod 검증에서 걸러지도록 함.
+ */
+function toKstDatetime(datetimeLocal: string) {
+  if (!datetimeLocal) return datetimeLocal;
+  return datetimeLocal.replace('T', ' ').slice(0, 16);
+}
+
+export function PracticeCreateForm() {
+  const router = useRouter();
+  const toast = useToast();
+
+  const form = useForm<CreatePracticeSchema>({
+    resolver: zodResolver(createPracticeSchema),
+    defaultValues: { title: '', song: '', venue: '', startAt: '', durationMinutes: 60 },
+  });
+
+  const mutation = useCreatePractice({
+    onSuccess: (data) => {
+      toast.success('합주가 생성되었습니다.');
+      router.replace(ROUTES.PRACTICE_DETAIL(data.practiceId));
+    },
+    onError: (err) => toast.error(err.message || '합주 생성에 실패했습니다.'),
+  });
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={form.handleSubmit((values) =>
+        mutation.mutate({
+          title: values.title,
+          song: values.song,
+          venue: values.venue,
+          startAt: values.startAt,
+          durationMinutes: values.durationMinutes,
+        }),
+      )}
+      noValidate
+    >
+      <Input
+        label="제목 (선택)"
+        placeholder="예: TuNA 정기공연 1주차 합주"
+        error={form.formState.errors.title?.message}
+        {...form.register('title')}
+      />
+      <Input
+        label="합주곡 ID"
+        placeholder="songId (UUID)"
+        required
+        hint="백엔드 합주곡 목록이 구축될 때까지는 songId 를 직접 입력합니다."
+        error={form.formState.errors.song?.message}
+        {...form.register('song')}
+      />
+      <Input
+        label="장소 (선택)"
+        placeholder="예: 홍대 스튜디오"
+        error={form.formState.errors.venue?.message}
+        {...form.register('venue')}
+      />
+      <Input
+        label="시작 시각"
+        type="datetime-local"
+        required
+        hint="Asia/Seoul 기준 yyyy-MM-dd HH:mm 형식으로 저장됩니다."
+        error={form.formState.errors.startAt?.message}
+        {...form.register('startAt', {
+          setValueAs: (v) => toKstDatetime(String(v ?? '')),
+        })}
+      />
+      <Input
+        label="소요 시간 (분)"
+        type="number"
+        min={15}
+        max={480}
+        step={15}
+        required
+        error={form.formState.errors.durationMinutes?.message}
+        {...form.register('durationMinutes', { valueAsNumber: true })}
+      />
+      <Button type="submit" className="w-full" loading={mutation.isPending}>
+        합주 만들기
+      </Button>
+    </form>
+  );
+}

--- a/src/app/(main)/practices/new/page.tsx
+++ b/src/app/(main)/practices/new/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+
+import { PageTitle } from '@/components/layout/page-title';
+
+import { PracticeCreateForm } from './PracticeCreateForm.client';
+
+export const metadata: Metadata = {
+  title: '합주 만들기 | Bandage',
+};
+
+export default function PracticeNewPage() {
+  return (
+    <div className="space-y-6">
+      <PageTitle
+        title="합주 만들기"
+        description="합주할 곡과 일정을 설정하세요. 세션·참여자는 생성 후 편집할 수 있습니다."
+      />
+      <PracticeCreateForm />
+    </div>
+  );
+}

--- a/src/app/(main)/practices/page.tsx
+++ b/src/app/(main)/practices/page.tsx
@@ -1,10 +1,18 @@
+import type { Metadata } from 'next';
+
 import { PageTitle } from '@/components/layout/page-title';
+
+import { PracticesList } from './PracticesList.client';
+
+export const metadata: Metadata = {
+  title: '합주 | Bandage',
+};
 
 export default function PracticesPage() {
   return (
     <div className="space-y-6">
-      <PageTitle title="합주" description="합주 세션 목록" />
-      <p className="text-foreground-sub text-sm">합주 도메인은 Task 8에서 구현됩니다.</p>
+      <PageTitle title="합주" description="예정된 합주 일정과 세션 편성을 확인하세요." />
+      <PracticesList />
     </div>
   );
 }

--- a/src/domain/practice-song/api/deleteRefLink.ts
+++ b/src/domain/practice-song/api/deleteRefLink.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function deleteRefLink(songId: string): Promise<void> {
+  await apiClient.delete<null>(`/api/v1/practice-songs/${songId}/ref-link`);
+}

--- a/src/domain/practice-song/api/upsertRefLink.ts
+++ b/src/domain/practice-song/api/upsertRefLink.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function upsertRefLink(songId: string, refLink: string): Promise<void> {
+  await apiClient.put<null>(`/api/v1/practice-songs/${songId}/ref-link`, { refLink });
+}

--- a/src/domain/practice-song/hooks/useDeleteSongRefLink.ts
+++ b/src/domain/practice-song/hooks/useDeleteSongRefLink.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteRefLink } from '../api/deleteRefLink';
+import { queryKeys } from '@/global/config/queryKeys';
+
+type Options = {
+  practiceId?: string;
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDeleteSongRefLink(songId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => deleteRefLink(songId),
+    onSuccess: () => {
+      if (options?.practiceId) {
+        queryClient.invalidateQueries({
+          queryKey: [...queryKeys.practice.detail(options.practiceId)],
+        });
+      }
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/practice-song/hooks/useUpsertSongRefLink.ts
+++ b/src/domain/practice-song/hooks/useUpsertSongRefLink.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { upsertRefLink } from '../api/upsertRefLink';
+import { queryKeys } from '@/global/config/queryKeys';
+
+type Options = {
+  practiceId?: string;
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useUpsertSongRefLink(songId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (refLink) => upsertRefLink(songId, refLink),
+    onSuccess: () => {
+      if (options?.practiceId) {
+        queryClient.invalidateQueries({
+          queryKey: [...queryKeys.practice.detail(options.practiceId)],
+        });
+      }
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/practice/api/addParticipant.ts
+++ b/src/domain/practice/api/addParticipant.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { AddParticipantRequest, AddParticipantResponse } from '../types';
+
+export async function addParticipant(
+  practiceId: string,
+  req: AddParticipantRequest,
+): Promise<AddParticipantResponse> {
+  const data = await apiClient.post<AddParticipantResponse>(
+    `/api/v1/practices/${practiceId}/participants`,
+    req,
+  );
+  if (!data) throw new Error('참여자 추가 응답이 비어 있습니다.');
+  return data;
+}

--- a/src/domain/practice/api/assignSession.ts
+++ b/src/domain/practice/api/assignSession.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/global/api/apiClient';
+
+/**
+ * 본인을 해당 세션에 배정합니다. (API_SPEC 4-6)
+ * PATCH /api/v1/practices/{practiceId}/sessions/{sessionId}/assignment
+ */
+export async function assignSession(practiceId: string, sessionId: string): Promise<void> {
+  await apiClient.patch<null>(`/api/v1/practices/${practiceId}/sessions/${sessionId}/assignment`);
+}

--- a/src/domain/practice/api/createPractice.ts
+++ b/src/domain/practice/api/createPractice.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { CreatePracticeRequest, CreatePracticeResponse } from '../types';
+
+export async function createPractice(req: CreatePracticeRequest): Promise<CreatePracticeResponse> {
+  const data = await apiClient.post<CreatePracticeResponse>('/api/v1/practices', req);
+  if (!data) throw new Error('합주 생성 응답이 비어 있습니다.');
+  return data;
+}

--- a/src/domain/practice/api/createSession.ts
+++ b/src/domain/practice/api/createSession.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { CreateSessionRequest, CreateSessionResponse } from '../types';
+
+export async function createSession(
+  practiceId: string,
+  req: CreateSessionRequest,
+): Promise<CreateSessionResponse> {
+  const data = await apiClient.post<CreateSessionResponse>(
+    `/api/v1/practices/${practiceId}/sessions`,
+    req,
+  );
+  if (!data) throw new Error('세션 생성 응답이 비어 있습니다.');
+  return data;
+}

--- a/src/domain/practice/api/deletePractice.ts
+++ b/src/domain/practice/api/deletePractice.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function deletePractice(practiceId: string): Promise<void> {
+  await apiClient.delete<null>(`/api/v1/practices/${practiceId}`);
+}

--- a/src/domain/practice/api/deleteSession.ts
+++ b/src/domain/practice/api/deleteSession.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function deleteSession(practiceId: string, sessionId: string): Promise<void> {
+  await apiClient.delete<null>(`/api/v1/practices/${practiceId}/sessions/${sessionId}`);
+}

--- a/src/domain/practice/api/getPractice.ts
+++ b/src/domain/practice/api/getPractice.ts
@@ -1,0 +1,7 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { PracticeDetailResponse } from '../types';
+
+export async function getPractice(practiceId: string): Promise<PracticeDetailResponse | null> {
+  return apiClient.get<PracticeDetailResponse | null>(`/api/v1/practices/${practiceId}`);
+}

--- a/src/domain/practice/api/getPractices.ts
+++ b/src/domain/practice/api/getPractices.ts
@@ -1,0 +1,33 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { PracticeListItemResponse } from '../types';
+
+type GetPracticesParams = {
+  bandId?: string;
+  lastId?: string;
+  pageSize: number;
+};
+
+/**
+ * 합주 목록 (커서 페이징).
+ * NOTE: API_SPEC v1 에는 정식 등재되지 않은 추측 엔드포인트. Performance 목록(6-2) 과 동일 패턴을 가정.
+ *   - 실제 경로: GET /api/v1/practices?bandId=...&lastId=...&pageSize=...
+ *   - 백엔드 미구현 시 apiClient 가 404/HTTP 에러로 ApiError 를 throw 하므로
+ *     호출부(useInfiniteCursor 래퍼)에서 ErrorState 로 안전하게 처리.
+ */
+export async function getPractices(
+  params: GetPracticesParams,
+): Promise<CursorResponse<PracticeListItemResponse, string>> {
+  const data = await apiClient.get<CursorResponse<PracticeListItemResponse, string> | null>(
+    '/api/v1/practices',
+    {
+      query: {
+        bandId: params.bandId,
+        lastId: params.lastId,
+        pageSize: params.pageSize,
+      },
+    },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/practice/api/unassignSession.ts
+++ b/src/domain/practice/api/unassignSession.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/global/api/apiClient';
+
+/**
+ * 본인의 세션 배정을 해제합니다. (API_SPEC 4-7)
+ * DELETE /api/v1/practices/{practiceId}/sessions/{sessionId}/assignment
+ */
+export async function unassignSession(practiceId: string, sessionId: string): Promise<void> {
+  await apiClient.delete<null>(`/api/v1/practices/${practiceId}/sessions/${sessionId}/assignment`);
+}

--- a/src/domain/practice/api/updateSchedule.ts
+++ b/src/domain/practice/api/updateSchedule.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { UpdateScheduleRequest } from '../types';
+
+export async function updateSchedule(
+  practiceId: string,
+  req: UpdateScheduleRequest,
+): Promise<void> {
+  await apiClient.patch<null>(`/api/v1/practices/${practiceId}/schedule`, req);
+}

--- a/src/domain/practice/api/updateVenue.ts
+++ b/src/domain/practice/api/updateVenue.ts
@@ -1,0 +1,7 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { UpdateVenueRequest } from '../types';
+
+export async function updateVenue(practiceId: string, req: UpdateVenueRequest): Promise<void> {
+  await apiClient.patch<null>(`/api/v1/practices/${practiceId}/venue`, req);
+}

--- a/src/domain/practice/components/PracticeCard.tsx
+++ b/src/domain/practice/components/PracticeCard.tsx
@@ -1,0 +1,41 @@
+import { MapPin, Music } from 'lucide-react';
+import Link from 'next/link';
+
+import { Card } from '@/components/ui/card';
+import { ROUTES } from '@/global/config/routes';
+
+import { PracticeScheduleBadge } from './PracticeScheduleBadge';
+import type { PracticeListItemResponse } from '../types';
+
+export function PracticeCard({ practice }: { practice: PracticeListItemResponse }) {
+  return (
+    <Link
+      href={ROUTES.PRACTICE_DETAIL(practice.practiceId)}
+      className="focus-visible:ring-accent focus-visible:ring-offset-bg block rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+    >
+      <Card interactive padding="md">
+        <div className="space-y-2">
+          <p className="text-foreground line-clamp-1 text-base font-semibold">{practice.title}</p>
+          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <PracticeScheduleBadge
+              startAt={practice.startAt}
+              durationMinutes={practice.durationMinutes}
+            />
+            {practice.venue && (
+              <span className="text-foreground-sub inline-flex items-center gap-1">
+                <MapPin className="h-3 w-3" aria-hidden="true" />
+                {practice.venue}
+              </span>
+            )}
+            {practice.song && (
+              <span className="text-foreground-sub inline-flex items-center gap-1">
+                <Music className="h-3 w-3" aria-hidden="true" />
+                {practice.song.title} — {practice.song.artist}
+              </span>
+            )}
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}

--- a/src/domain/practice/components/PracticeScheduleBadge.tsx
+++ b/src/domain/practice/components/PracticeScheduleBadge.tsx
@@ -1,0 +1,24 @@
+import { Calendar } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { parseKst, formatKst } from '@/lib/date';
+
+type Props = {
+  startAt: string;
+  durationMinutes: number;
+};
+
+export function PracticeScheduleBadge({ startAt, durationMinutes }: Props) {
+  let label = startAt;
+  try {
+    label = formatKst(parseKst(startAt), 'M월 d일 HH:mm');
+  } catch {
+    // fallback to raw string
+  }
+  return (
+    <Badge variant="accent">
+      <Calendar className="mr-1 h-3 w-3" aria-hidden="true" />
+      {label} ({durationMinutes}분)
+    </Badge>
+  );
+}

--- a/src/domain/practice/components/PracticeVenueInline.client.tsx
+++ b/src/domain/practice/components/PracticeVenueInline.client.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Check, MapPin, Pencil, X } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useUpdateVenue } from '@/domain/practice/hooks/useUpdateVenue';
+import { useToast } from '@/hooks/useToast';
+
+type Props = {
+  practiceId: string;
+  venue?: string | null;
+};
+
+export function PracticeVenueInline({ practiceId, venue }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(venue ?? '');
+  const toast = useToast();
+
+  const mutation = useUpdateVenue(practiceId, {
+    onSuccess: () => {
+      toast.success('장소가 수정되었습니다.');
+      setEditing(false);
+    },
+    onError: (err) => toast.error(err.message || '장소 수정에 실패했습니다.'),
+  });
+
+  if (!editing) {
+    return (
+      <div className="flex items-center gap-2">
+        <MapPin className="text-foreground-muted h-4 w-4" aria-hidden="true" />
+        <span className="text-foreground text-sm">{venue ?? '장소 미지정'}</span>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            setValue(venue ?? '');
+            setEditing(true);
+          }}
+        >
+          <Pencil className="h-3 w-3" />
+          수정
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="장소"
+        className="max-w-xs"
+      />
+      <Button
+        size="sm"
+        onClick={() => mutation.mutate({ venue: value.trim() })}
+        loading={mutation.isPending}
+        disabled={value.trim().length === 0}
+      >
+        <Check className="h-3 w-3" />
+      </Button>
+      <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>
+        <X className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}

--- a/src/domain/practice/components/SessionCreateForm.client.tsx
+++ b/src/domain/practice/components/SessionCreateForm.client.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { useCreateSession } from '@/domain/practice/hooks/useCreateSession';
+import { createSessionSchema, type CreateSessionSchema } from '@/domain/practice/types';
+import { useToast } from '@/hooks/useToast';
+
+const SESSION_TYPE_OPTIONS = [
+  { value: 'VOCAL', label: 'VOCAL' },
+  { value: 'CHORUS', label: 'CHORUS' },
+  { value: 'GUITAR', label: 'GUITAR' },
+  { value: 'BASS', label: 'BASS' },
+  { value: 'DRUM', label: 'DRUM' },
+  { value: 'PERCUSSION', label: 'PERCUSSION' },
+  { value: 'SYNTH', label: 'SYNTH' },
+  { value: 'ETC', label: 'ETC' },
+] as const;
+
+export function SessionCreateForm({
+  practiceId,
+  onCreated,
+}: {
+  practiceId: string;
+  onCreated?: () => void;
+}) {
+  const toast = useToast();
+
+  const form = useForm<CreateSessionSchema>({
+    resolver: zodResolver(createSessionSchema),
+    defaultValues: { label: '', type: 'GUITAR' },
+  });
+
+  const mutation = useCreateSession(practiceId, {
+    onSuccess: () => {
+      toast.success('세션이 추가되었습니다.');
+      form.reset({ label: '', type: 'GUITAR' });
+      onCreated?.();
+    },
+    onError: (err) => toast.error(err.message || '세션 추가에 실패했습니다.'),
+  });
+
+  return (
+    <form
+      className="flex flex-col gap-3 sm:flex-row sm:items-end"
+      onSubmit={form.handleSubmit((values) => mutation.mutate(values))}
+      noValidate
+    >
+      <Input
+        label="라벨"
+        placeholder="예: Guitar 2"
+        error={form.formState.errors.label?.message}
+        className="sm:flex-1"
+        {...form.register('label')}
+      />
+      <Select
+        label="타입"
+        options={SESSION_TYPE_OPTIONS}
+        error={form.formState.errors.type?.message}
+        className="sm:w-40"
+        {...form.register('type')}
+      />
+      <Button type="submit" loading={mutation.isPending}>
+        추가
+      </Button>
+    </form>
+  );
+}

--- a/src/domain/practice/components/SessionRow.tsx
+++ b/src/domain/practice/components/SessionRow.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { Trash2, UserPlus, UserX } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Chip } from '@/components/ui/chip';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useAssignSession } from '@/domain/practice/hooks/useAssignSession';
+import { useDeleteSession } from '@/domain/practice/hooks/useDeleteSession';
+import { useUnassignSession } from '@/domain/practice/hooks/useUnassignSession';
+import { useToast } from '@/hooks/useToast';
+
+import type { PracticeSessionResponse } from '../types';
+
+type Props = {
+  practiceId: string;
+  session: PracticeSessionResponse;
+};
+
+export function SessionRow({ practiceId, session }: Props) {
+  const toast = useToast();
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const assignMutation = useAssignSession(practiceId, {
+    onError: (err) => toast.error(err.message || '세션 배정에 실패했습니다.'),
+  });
+  const unassignMutation = useUnassignSession(practiceId, {
+    onError: (err) => toast.error(err.message || '배정 해제에 실패했습니다.'),
+  });
+  const deleteMutation = useDeleteSession(practiceId, {
+    onSuccess: () => {
+      toast.success('세션을 삭제했습니다.');
+      setConfirmDelete(false);
+    },
+    onError: (err) => toast.error(err.message || '세션 삭제에 실패했습니다.'),
+  });
+
+  const isAssigned = session.participant !== null;
+
+  return (
+    <div className="border-border flex items-center justify-between gap-3 border-b py-3 last:border-b-0">
+      <div className="flex min-w-0 items-center gap-3">
+        <Chip session={session.type}>{session.type}</Chip>
+        <span className="text-foreground truncate text-sm font-medium">{session.label}</span>
+        {isAssigned ? (
+          <span className="text-foreground-sub truncate text-xs">
+            담당: Member #{session.participant!.memberId}
+          </span>
+        ) : (
+          <span className="text-foreground-muted truncate text-xs">담당 없음</span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {isAssigned ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => unassignMutation.mutate(session.sessionId)}
+            loading={unassignMutation.isPending}
+          >
+            <UserX className="h-4 w-4" />
+            해제
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => assignMutation.mutate(session.sessionId)}
+            loading={assignMutation.isPending}
+          >
+            <UserPlus className="h-4 w-4" />
+            나를 배정
+          </Button>
+        )}
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-danger hover:opacity-80"
+          onClick={() => setConfirmDelete(true)}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>세션 삭제</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <p className="text-foreground-sub text-sm">
+              &apos;{session.label}&apos; 세션을 삭제합니다. 배정된 담당자가 있다면 함께 해제됩니다.
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setConfirmDelete(false)}>
+              취소
+            </Button>
+            <Button
+              variant="danger"
+              loading={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate(session.sessionId)}
+            >
+              삭제
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/domain/practice/components/SongRefLinkEditor.client.tsx
+++ b/src/domain/practice/components/SongRefLinkEditor.client.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { Check, ExternalLink, Pencil, Trash2, X } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useDeleteSongRefLink } from '@/domain/practice-song/hooks/useDeleteSongRefLink';
+import { useUpsertSongRefLink } from '@/domain/practice-song/hooks/useUpsertSongRefLink';
+import { useToast } from '@/hooks/useToast';
+
+type Props = {
+  practiceId: string;
+  songId: string;
+  refLink?: string | null;
+};
+
+export function SongRefLinkEditor({ practiceId, songId, refLink }: Props) {
+  const toast = useToast();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(refLink ?? '');
+
+  const upsertMutation = useUpsertSongRefLink(songId, {
+    practiceId,
+    onSuccess: () => {
+      toast.success('참조 링크가 저장되었습니다.');
+      setEditing(false);
+    },
+    onError: (err) => toast.error(err.message || '참조 링크 저장에 실패했습니다.'),
+  });
+
+  const deleteMutation = useDeleteSongRefLink(songId, {
+    practiceId,
+    onSuccess: () => toast.success('참조 링크가 삭제되었습니다.'),
+    onError: (err) => toast.error(err.message || '참조 링크 삭제에 실패했습니다.'),
+  });
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2">
+        <Input
+          placeholder="https://..."
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="flex-1"
+        />
+        <Button
+          size="sm"
+          onClick={() => upsertMutation.mutate(value.trim())}
+          loading={upsertMutation.isPending}
+          disabled={value.trim().length === 0}
+        >
+          <Check className="h-3 w-3" />
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>
+          <X className="h-3 w-3" />
+        </Button>
+      </div>
+    );
+  }
+
+  if (refLink) {
+    return (
+      <div className="flex items-center gap-2">
+        <a
+          href={refLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent-hi inline-flex items-center gap-1 text-sm hover:underline"
+        >
+          <ExternalLink className="h-3 w-3" />
+          <span className="truncate">{refLink}</span>
+        </a>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            setValue(refLink);
+            setEditing(true);
+          }}
+        >
+          <Pencil className="h-3 w-3" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-danger hover:opacity-80"
+          onClick={() => deleteMutation.mutate()}
+          loading={deleteMutation.isPending}
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="secondary"
+      onClick={() => {
+        setValue('');
+        setEditing(true);
+      }}
+    >
+      참조 링크 추가
+    </Button>
+  );
+}

--- a/src/domain/practice/hooks/useAddParticipant.ts
+++ b/src/domain/practice/hooks/useAddParticipant.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { addParticipant } from '../api/addParticipant';
+import type { AddParticipantRequest, AddParticipantResponse } from '../types';
+
+type Options = {
+  onSuccess?: (data: AddParticipantResponse) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useAddParticipant(practiceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<AddParticipantResponse, Error, AddParticipantRequest>({
+    mutationFn: (req) => addParticipant(practiceId, req),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.practice.detail(practiceId)] });
+      options?.onSuccess?.(data);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/practice/hooks/useAssignSession.ts
+++ b/src/domain/practice/hooks/useAssignSession.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { assignSession } from '../api/assignSession';
+import { queryKeys } from '@/global/config/queryKeys';
+import { useAuthStore } from '@/global/store/authStore';
+
+import type { PracticeDetailResponse } from '../types';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+type Context = { previous?: PracticeDetailResponse | null };
+
+/**
+ * 본인을 세션에 배정합니다. (낙관적 업데이트)
+ * NOTE: memberId 확보를 위해 별도 API 가 아닌 useAuthStore 에 저장된 값을 활용하지 않고,
+ *   일단 낙관 업데이트에서는 participantId 를 알 수 없으므로 "placeholder 배정" 으로만 표시하고
+ *   성공 시 invalidate 로 정확한 participantId 를 재조회합니다.
+ */
+export function useAssignSession(practiceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  const queryKey = [...queryKeys.practice.detail(practiceId)];
+
+  return useMutation<void, Error, string, Context>({
+    mutationFn: (sessionId) => assignSession(practiceId, sessionId),
+    onMutate: async (sessionId) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<PracticeDetailResponse | null>(queryKey);
+      if (previous) {
+        // 로컬 시각적 피드백용 임시 participant (실제 id 는 서버에서 확정)
+        const placeholder = {
+          participantId: '__pending__',
+          memberId: Number(useAuthStore.getState().accessToken ? 0 : 0),
+        };
+        queryClient.setQueryData<PracticeDetailResponse>(queryKey, {
+          ...previous,
+          sessions: previous.sessions.map((s) =>
+            s.sessionId === sessionId ? { ...s, participant: placeholder } : s,
+          ),
+        });
+      }
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(queryKey, ctx.previous);
+      options?.onError?.(err);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onSuccess: () => options?.onSuccess?.(),
+  });
+}

--- a/src/domain/practice/hooks/useCreatePractice.ts
+++ b/src/domain/practice/hooks/useCreatePractice.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { createPractice } from '../api/createPractice';
+import type { CreatePracticeRequest, CreatePracticeResponse } from '../types';
+
+type UseCreatePracticeOptions = {
+  onSuccess?: (data: CreatePracticeResponse) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useCreatePractice(options?: UseCreatePracticeOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<CreatePracticeResponse, Error, CreatePracticeRequest>({
+    mutationFn: createPractice,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.practice.all] });
+      options?.onSuccess?.(data);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/practice/hooks/useCreateSession.ts
+++ b/src/domain/practice/hooks/useCreateSession.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { createSession } from '../api/createSession';
+import type { CreateSessionRequest, CreateSessionResponse } from '../types';
+
+type Options = {
+  onSuccess?: (data: CreateSessionResponse) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useCreateSession(practiceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<CreateSessionResponse, Error, CreateSessionRequest>({
+    mutationFn: (req) => createSession(practiceId, req),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.practice.detail(practiceId)] });
+      options?.onSuccess?.(data);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/practice/hooks/useDeletePractice.ts
+++ b/src/domain/practice/hooks/useDeletePractice.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deletePractice } from '../api/deletePractice';
+
+type UseDeletePracticeOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDeletePractice(practiceId: string, options?: UseDeletePracticeOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => deletePractice(practiceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.practice.all] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/practice/hooks/useDeleteSession.ts
+++ b/src/domain/practice/hooks/useDeleteSession.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deleteSession } from '../api/deleteSession';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDeleteSession(practiceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (sessionId) => deleteSession(practiceId, sessionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.practice.detail(practiceId)] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/practice/hooks/usePractice.ts
+++ b/src/domain/practice/hooks/usePractice.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getPractice } from '../api/getPractice';
+import type { PracticeDetailResponse } from '../types';
+
+export function usePractice(practiceId: string, options?: { enabled?: boolean }) {
+  return useQuery<PracticeDetailResponse | null, Error>({
+    queryKey: [...queryKeys.practice.detail(practiceId)],
+    queryFn: () => getPractice(practiceId),
+    enabled: (options?.enabled ?? true) && !!practiceId,
+  });
+}

--- a/src/domain/practice/hooks/usePractices.ts
+++ b/src/domain/practice/hooks/usePractices.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useInfiniteCursor } from '@/hooks/useInfiniteCursor';
+
+import { getPractices } from '../api/getPractices';
+import type { PracticeListItemResponse } from '../types';
+
+export function usePractices(bandId?: string, pageSize: number = 20) {
+  return useInfiniteCursor<PracticeListItemResponse, string>(
+    [...queryKeys.practice.list(bandId), pageSize],
+    ({ lastId, pageSize: size }) => getPractices({ bandId, lastId, pageSize: size }),
+    pageSize,
+  );
+}

--- a/src/domain/practice/hooks/useUnassignSession.ts
+++ b/src/domain/practice/hooks/useUnassignSession.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { unassignSession } from '../api/unassignSession';
+import type { PracticeDetailResponse } from '../types';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+type Context = { previous?: PracticeDetailResponse | null };
+
+export function useUnassignSession(practiceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  const queryKey = [...queryKeys.practice.detail(practiceId)];
+
+  return useMutation<void, Error, string, Context>({
+    mutationFn: (sessionId) => unassignSession(practiceId, sessionId),
+    onMutate: async (sessionId) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<PracticeDetailResponse | null>(queryKey);
+      if (previous) {
+        queryClient.setQueryData<PracticeDetailResponse>(queryKey, {
+          ...previous,
+          sessions: previous.sessions.map((s) =>
+            s.sessionId === sessionId ? { ...s, participant: null } : s,
+          ),
+        });
+      }
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(queryKey, ctx.previous);
+      options?.onError?.(err);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onSuccess: () => options?.onSuccess?.(),
+  });
+}

--- a/src/domain/practice/hooks/useUpdateSchedule.ts
+++ b/src/domain/practice/hooks/useUpdateSchedule.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateSchedule } from '../api/updateSchedule';
+import type { PracticeDetailResponse, UpdateScheduleRequest } from '../types';
+
+type UseUpdateScheduleOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+type Context = { previous?: PracticeDetailResponse | null };
+
+export function useUpdateSchedule(practiceId: string, options?: UseUpdateScheduleOptions) {
+  const queryClient = useQueryClient();
+  const queryKey = [...queryKeys.practice.detail(practiceId)];
+
+  return useMutation<void, Error, UpdateScheduleRequest, Context>({
+    mutationFn: (req) => updateSchedule(practiceId, req),
+    onMutate: async (req) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<PracticeDetailResponse | null>(queryKey);
+      if (previous) {
+        queryClient.setQueryData<PracticeDetailResponse>(queryKey, {
+          ...previous,
+          startAt: req.startAt,
+          durationMinutes: req.durationMinutes,
+        });
+      }
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(queryKey, ctx.previous);
+      options?.onError?.(err);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onSuccess: () => options?.onSuccess?.(),
+  });
+}

--- a/src/domain/practice/hooks/useUpdateVenue.ts
+++ b/src/domain/practice/hooks/useUpdateVenue.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateVenue } from '../api/updateVenue';
+import type { PracticeDetailResponse, UpdateVenueRequest } from '../types';
+
+type UseUpdateVenueOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+type Context = { previous?: PracticeDetailResponse | null };
+
+export function useUpdateVenue(practiceId: string, options?: UseUpdateVenueOptions) {
+  const queryClient = useQueryClient();
+  const queryKey = [...queryKeys.practice.detail(practiceId)];
+
+  return useMutation<void, Error, UpdateVenueRequest, Context>({
+    mutationFn: (req) => updateVenue(practiceId, req),
+    onMutate: async (req) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<PracticeDetailResponse | null>(queryKey);
+      if (previous) {
+        queryClient.setQueryData<PracticeDetailResponse>(queryKey, {
+          ...previous,
+          venue: req.venue,
+        });
+      }
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(queryKey, ctx.previous);
+      options?.onError?.(err);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onSuccess: () => options?.onSuccess?.(),
+  });
+}

--- a/src/domain/practice/types/index.ts
+++ b/src/domain/practice/types/index.ts
@@ -1,0 +1,33 @@
+export type {
+  CreatePracticeRequest,
+  UpdateScheduleRequest,
+  UpdateVenueRequest,
+  CreateSessionRequest,
+  AddParticipantRequest,
+} from './req';
+export type {
+  CreatePracticeResponse,
+  PracticeSongResponse,
+  PracticeParticipantResponse,
+  PracticeSessionResponse,
+  PracticeDetailResponse,
+  PracticeListItemResponse,
+  CreateSessionResponse,
+  AddParticipantResponse,
+} from './res';
+export {
+  createPracticeSchema,
+  updateScheduleSchema,
+  updateVenueSchema,
+  createSessionSchema,
+  addParticipantSchema,
+  upsertRefLinkSchema,
+} from './schema';
+export type {
+  CreatePracticeSchema,
+  UpdateScheduleSchema,
+  UpdateVenueSchema,
+  CreateSessionSchema,
+  AddParticipantSchema,
+  UpsertRefLinkSchema,
+} from './schema';

--- a/src/domain/practice/types/req.ts
+++ b/src/domain/practice/types/req.ts
@@ -1,0 +1,27 @@
+import type { SessionType } from '@/global/types';
+
+export interface CreatePracticeRequest {
+  title?: string;
+  song: string;
+  venue?: string;
+  startAt: string;
+  durationMinutes: number;
+}
+
+export interface UpdateScheduleRequest {
+  startAt: string;
+  durationMinutes: number;
+}
+
+export interface UpdateVenueRequest {
+  venue: string;
+}
+
+export interface CreateSessionRequest {
+  label: string;
+  type: SessionType;
+}
+
+export interface AddParticipantRequest {
+  memberId: number;
+}

--- a/src/domain/practice/types/res.ts
+++ b/src/domain/practice/types/res.ts
@@ -1,0 +1,49 @@
+import type { SessionType } from '@/global/types';
+
+export interface CreatePracticeResponse {
+  practiceId: string;
+  practiceTitle: string;
+}
+
+export interface PracticeSongResponse {
+  songId: string;
+  title: string;
+  artist: string;
+  refLink?: string | null;
+}
+
+export interface PracticeParticipantResponse {
+  participantId: string;
+  memberId: number;
+}
+
+export interface PracticeSessionResponse {
+  sessionId: string;
+  label: string;
+  type: SessionType;
+  participant: PracticeParticipantResponse | null;
+}
+
+export interface PracticeDetailResponse {
+  practiceId: string;
+  title: string;
+  venue?: string | null;
+  startAt: string;
+  durationMinutes: number;
+  song: PracticeSongResponse;
+  sessions: PracticeSessionResponse[];
+  participants: PracticeParticipantResponse[];
+}
+
+export interface PracticeListItemResponse {
+  practiceId: string;
+  title: string;
+  venue?: string | null;
+  startAt: string;
+  durationMinutes: number;
+  song?: PracticeSongResponse | null;
+}
+
+export type CreateSessionResponse = PracticeSessionResponse;
+
+export type AddParticipantResponse = PracticeParticipantResponse;

--- a/src/domain/practice/types/schema.ts
+++ b/src/domain/practice/types/schema.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+const KST_DATETIME = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
+
+export const createPracticeSchema = z.object({
+  title: z
+    .string()
+    .max(100, '제목은 100자 이하로 입력해 주세요.')
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+  song: z.string().min(1, '합주곡 ID 를 입력해 주세요.'),
+  venue: z
+    .string()
+    .max(200, '장소는 200자 이하로 입력해 주세요.')
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+  startAt: z.string().regex(KST_DATETIME, '시작 시각은 yyyy-MM-dd HH:mm 형식이어야 합니다.'),
+  durationMinutes: z
+    .number({ message: '소요 시간을 숫자로 입력해 주세요.' })
+    .int('정수로 입력해 주세요.')
+    .min(15, '최소 15분 이상이어야 합니다.')
+    .max(480, '최대 480분(8시간)까지 입력 가능합니다.'),
+});
+export type CreatePracticeSchema = z.infer<typeof createPracticeSchema>;
+
+export const updateScheduleSchema = z.object({
+  startAt: z.string().regex(KST_DATETIME, '시작 시각은 yyyy-MM-dd HH:mm 형식이어야 합니다.'),
+  durationMinutes: z.number().int().min(15).max(480),
+});
+export type UpdateScheduleSchema = z.infer<typeof updateScheduleSchema>;
+
+export const updateVenueSchema = z.object({
+  venue: z.string().min(1, '장소를 입력해 주세요.').max(200, '장소는 200자 이하로 입력해 주세요.'),
+});
+export type UpdateVenueSchema = z.infer<typeof updateVenueSchema>;
+
+export const createSessionSchema = z.object({
+  label: z
+    .string()
+    .min(1, '세션 이름을 입력해 주세요.')
+    .max(50, '세션 이름은 50자 이하로 입력해 주세요.'),
+  type: z.enum(['VOCAL', 'CHORUS', 'GUITAR', 'BASS', 'DRUM', 'PERCUSSION', 'SYNTH', 'ETC']),
+});
+export type CreateSessionSchema = z.infer<typeof createSessionSchema>;
+
+export const addParticipantSchema = z.object({
+  memberId: z.number({ message: '멤버 ID 를 숫자로 입력해 주세요.' }).int().positive(),
+});
+export type AddParticipantSchema = z.infer<typeof addParticipantSchema>;
+
+export const upsertRefLinkSchema = z.object({
+  refLink: z.string().url('올바른 URL 을 입력해 주세요.'),
+});
+export type UpsertRefLinkSchema = z.infer<typeof upsertRefLinkSchema>;


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #10

📌 **작업 내용 및 특이사항**

Task 8 (서브태스크 8.1 ~ 8.5) 구현. 합주/합주곡 도메인의 타입·API·훅·UI 컬포넌트·페이지(`/practices`, `/practices/new`, `/practices/[practiceId]`) 전체. 낙관적 업데이트를 schedule/venue/session 배정에 적용했습니다.

### 구현 파일
- 도메인 레이어 — `domain/practice/{types,api,hooks,components}/*`, `domain/practice-song/{api,hooks}/*`
  - types: 요청 DTO 5개 · 응답 DTO(CreatePractice · PracticeDetail · Session · Participant · PracticeSong · PracticeListItem) · zod 스키마 6개 (startAt `yyyy-MM-dd HH:mm` 정규식, durationMinutes 15~480)
  - api: 13개 함수 (createPractice · getPractice · getPractices · deletePractice · updateSchedule · updateVenue · createSession · deleteSession · addParticipant · assignSession · unassignSession + upsertRefLink · deleteRefLink)
  - hooks: 낙관적 업데이트 적용(useUpdateSchedule · useUpdateVenue · useAssignSession · useUnassignSession — onMutate 에서 setQueryData, onError 롤백, onSettled invalidate)
  - components: PracticeCard · PracticeScheduleBadge · PracticeVenueInline(client) · SessionRow · SessionCreateForm(client) · SongRefLinkEditor(client)
- 페이지
  - `/practices`: usePractices 무한 스크롤 + FAB → /practices/new. 목록 엔드포인트 미제공 시 ErrorState 로 폴백
  - `/practices/new`: rhf + zodResolver(createPracticeSchema). datetime-local 입력을 `yyyy-MM-dd HH:mm` 으로 변환 후 전송
  - `/practices/[practiceId]`: usePractice 로딩/에러 처리 + 헤더/합주곡/세션/참여자 카드 섹션. 일정 변경 Dialog, 장소 인라인 편집, 세션 추가·배정·해제·삭제, 참여자 추가(memberId), refLink 편집, 합주 삭제 Dialog

### API_SPEC 정합 조정
- Session 배정/해제 경로: API_SPEC 4-6/4-7 의 `/assignment` 사용. 본인만 배정·해제 가능 (task 스펙의 "참여자 선택 드롭다운" 은 API 제약상 미지원 — 토글 버튼으로 단순화)
- Practice 목록 엔드포인트(`GET /api/v1/practices`) 는 API_SPEC 미등재. Performance 6-2 와 동일 shape 을 가정해 추측 구현, 미구현 시 ErrorState 로 안전 폴백

### 로컬 검증
- [x] `pnpm lint` / `typecheck` / `format:check` / `build` 통과
- [x] `pnpm test` 16/16 (기존 테스트 유지)
- [x] 새 라우트: `/practices`(173kB), `/practices/new`(161kB), `/practices/[practiceId]`(dynamic, 197kB)

### 실서버 검증 (CLAUDE.md §6)
로컬 백엔드(`http://localhost:8080`) 에 curl 로 13개 엔드포인트 호출. **블로커 1건** 으로 9개가 실경로 재현 불가. 상세 리포트:

> [.taskmaster/report/practice-song-api-verification-2026-04-24.md](./.taskmaster/report/practice-song-api-verification-2026-04-24.md)

요약 — 백엔드 수정 권장:
1. (최우선) Song 생성 엔드포인트 부재 — 유효 `songId` 가 없어 `POST /api/v1/practices` 가 404 로 막힘. `POST /api/v1/practice-songs` 추가 또는 `PUT /ref-link` 를 진짜 upsert 로 변경 필요
2. `GET /api/v1/practices` 목록 미구현 (Allow: POST 만 노출됨) — Performance 6-2 와 동일 스타일 추가 필요
3. API_SPEC 4-1/4-2/5-1/5-2 의 "인증 불필요" 표기와 실제 401 동작 불일치 — 스펙/필터 중 하나로 정렬
4. 미구현 경로의 401 대신 404/405 분기 (WWW-Authenticate 헤더 조건부 첨부)

프론트 구현 자체는 백엔드 #1, #2 해결 시 코드 변경 없이 정상 동작 예정.

📚 **참고사항**
- 합주곡 선택 UX: §3-A 해결 전까지 `PracticeCreateForm` 은 songId UUID 를 텍스트로 직접 입력받음 (hint 명시)
- 이 PR 은 Task 7(#24, `16274cc`) 머지 후 develop 에 rebase 된 상태에서 분기