### PR TITLE
feat: 공연(Performance) 도메인 구현 (#11)

### DIFF
--- a/.taskmaster/report/performance-api-verification-2026-04-24.md
+++ b/.taskmaster/report/performance-api-verification-2026-04-24.md
@@ -1,0 +1,208 @@
+# Performance API 프론트 연동 검증 리포트 (Task 9 / Issue #11)
+
+- 작성일: 2026-04-24 (Asia/Seoul)
+- 검증 주체: 프론트엔드 (Bandage-FE-Web, branch `feat/#11-performance`)
+- 백엔드 기동 URL: `http://localhost:8080`
+- 검증 도구: `curl` 직접 호출. 재현용 페이로드 `/tmp/bandage-performance-test/*`
+- 검증 범위: `src/domain/performance/api/*` 의 8개 함수 + `useIsPerformanceManager` 보조 동작
+- 사전 컨텍스트: Task 7 리포트 §3-B 의 "인가 실패를 401 대신 403 으로 분리" 권고가 본 엔드포인트들에 **선반영된 것으로 보임** (§2-5 참조)
+- 요약: 8개 엔드포인트 모두 경로·응답 shape 면에서 프론트 구현과 일치. **PATCH(수정) 부분 업데이트 불가** 1건이 스펙 드리프트로 확인됨.
+
+---
+
+## 1. 테스트한 API 목록
+
+| # | Path | Method | FE 함수 | 판정 |
+| --- | --- | --- | --- | --- |
+| 1 | `/api/v1/performances` | POST | `createPerformance` | 정상 — `data:{performanceId,title}` 반환, 생성자 자동 manager 등록(`managerIds:[9]` 확인) |
+| 2 | `/api/v1/performances?pageSize=N` | GET | `getPerformances` | 정상 — `CursorResponse<PerformanceListItemResponse, string>` 일치 |
+| 3 | `/api/v1/performances/{id}` | GET | `getPerformanceDetail` | 정상 — `bandIds/managerIds/practiceIds` 포함 상세 응답 |
+| 4 | `/api/v1/performances/{id}` | PATCH | `updatePerformance` | **부분 업데이트 불가** — `startAt` 등을 생략하면 400. 전체 필드 전송 시에만 200 |
+| 5 | 비매니저의 PATCH | PATCH | (인가 경계) | 정상 — **403 Forbidden** (권장 스타일로 분리됨) |
+| 6 | `/api/v1/performances/{id}/practices` | POST | `addPerformancePractice` | 경로 정상 — 유효 songId 가 없어 404 "요청한 합주 곡 정보를 찾을 수 없습니다." |
+| 7 | `/api/v1/performances/{id}/practices/batch` | POST | `batchAddPerformancePractices` | 경로 정상 — 랜덤 practiceIds 로 호출 시 404 (Practice 미존재) |
+| 8 | `/api/v1/performances/{id}/practices/{practiceId}` | DELETE | `removePerformancePractice` | 경로 정상 — 랜덤 id 로 404 |
+| 9 | `/api/v1/performances/{id}` | DELETE | `deletePerformance` | 정상 — 200 후 GET 시 404 "공연 정보를 찾을 수 없습니다." |
+
+---
+
+## 2. 케이스별 실제 요청/응답 값
+
+### 2-1. Create `POST /api/v1/performances`
+
+요청
+```json
+{
+  "title": "QA Performance Test",
+  "bandIds": [],
+  "startAt": "2026-12-20 18:00",
+  "durationMinutes": 120,
+  "venue": "Club FF"
+}
+```
+응답 (200)
+```json
+{
+  "success": true,
+  "data": { "performanceId": "019dbdf4-6906-7bdf-9cf3-790745eb7da1", "title": "QA Performance Test" }
+}
+```
+
+### 2-2. List `GET /api/v1/performances?pageSize=5`
+
+```json
+{
+  "data": {
+    "content": [
+      {
+        "performanceId": "019dbdf4-...",
+        "title": "QA Performance Test",
+        "startAt": "2026-12-20 18:00",
+        "durationMinutes": 120,
+        "venue": "Club FF"
+      }
+    ],
+    "nextCursor": "019dbdf4-6906-7bdf-9cf3-790745eb7da1",
+    "hasNext": false
+  }
+}
+```
+관찰: Task 7 §3-C 와 동일하게 `hasNext:false` 인데 `nextCursor` 가 null 이 아님. 프론트 `useInfiniteCursor` 가드로 무영향.
+
+### 2-3. Detail `GET /api/v1/performances/{id}`
+
+```json
+{
+  "data": {
+    "performanceId": "019dbdf4-...",
+    "title": "QA Performance Test",
+    "startAt": "2026-12-20 18:00",
+    "durationMinutes": 120,
+    "venue": "Club FF",
+    "bandIds": [],
+    "managerIds": [9],
+    "practiceIds": []
+  }
+}
+```
+— `PerformanceDetailResponse` 타입 1:1 일치. `managerIds:[9]` 로 생성자 자동 등록 확인.
+
+### 2-4. Update (부분) `PATCH /api/v1/performances/{id}` — **400**
+
+요청 (일부 필드만)
+```json
+{ "title": "QA Performance Test (updated)", "durationMinutes": 150, "venue": "Club FF v2" }
+```
+응답 (400)
+```json
+{
+  "success": false,
+  "message": "JSON parse error: Cannot construct instance of `com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest`, problem: Parameter specified as non-null is null: method com.bandage.v1.domain.performance.dto.req.PerformanceUpdateRequest.<init>, parameter startAt",
+  "data": null
+}
+```
+
+요청 (전체 필드)
+```json
+{ "title": "Updated T", "startAt": "2026-12-25 19:00", "durationMinutes": 150, "venue": "New Venue" }
+```
+응답 (200) — 성공
+
+판정: **API_SPEC 6-4 는 모든 필드를 optional 로 명시**하지만, Kotlin 측 `PerformanceUpdateRequest` 가 `startAt` 을 non-nullable 로 선언해 부분 업데이트가 실패. 스펙 드리프트.
+
+### 2-5. 비매니저 PATCH — **403 (올바름)**
+
+요청 (userB 토큰, 전체 필드 포함)
+응답 (HTTP 403, body 없음)
+
+판정: Task 7 §3-B 리포트에서 요청했던 "인가 실패 401 대신 403 분리" 가 **이 엔드포인트에서는 정확히 적용됨**. 다만 Task 7 의 `delegateLeader` 는 여전히 401 반환 — 백엔드 전 영역에 일괄 적용되지는 않은 듯.
+
+### 2-6~8. Practice 연결 (6-5/6-6/6-7)
+
+세 엔드포인트 모두 경로·메서드·요청 shape 은 백엔드가 정확히 수용. 유효한 songId/practiceId 가 존재하는 계정에서 후속 검증이 필요하며, Task 8 리포트 §3-A (Song 생성 엔드포인트 부재) 해결 전까지는 실경로 완결 검증 불가.
+
+### 2-9. Delete `DELETE /api/v1/performances/{id}`
+
+- 200 성공 후 재조회 → 404 `"요청한 공연 정보를 찾을 수 없습니다."`
+- 정상 동작
+
+---
+
+## 3. 권장 조치 내용 및 검토 필요 사항
+
+### A. (Backend, 최우선) `PATCH /performances/{id}` 의 부분 업데이트 지원
+
+**현상**
+- API_SPEC 6-4 는 `UpdatePerformanceRequest` 의 모든 필드를 optional 로 명시
+- 실제 Kotlin DTO `PerformanceUpdateRequest` 가 `startAt` 을 non-nullable 로 선언해 부분 업데이트가 400 으로 실패
+- 다른 필드(`title`, `durationMinutes`, `venue`) 도 동일하게 required 일 가능성 — 추가 확인 필요
+
+**요청 (택 1)**
+- (A-1) `PerformanceUpdateRequest` 의 모든 필드를 nullable 로 변경해 진짜 부분 업데이트 허용 (API_SPEC 및 프론트 기대 동작과 일치)
+- (A-2) 만약 PUT 시맨틱 유지가 의도라면 **메서드를 PUT 으로 변경** + API_SPEC 갱신
+
+**프론트 측 임시 우회 (백엔드 수정 전)**
+- `useUpdatePerformance` 호출 전에 현재 상세의 전체 필드를 병합해 전송 필요. 현재 EditDialog 는 변경된 필드만 보내므로 일부 케이스에서 400 발생 가능. 백엔드 수정까지는 "일정만 변경" "장소만 변경" 같은 UX 가 작동하지 않음
+- 수정 전까지 EditDialog 에서 제목/시작시각/소요분/장소를 모두 `defaultValues` 로 채우고 변경 여부와 무관하게 모두 제출하도록 변경 가능 (§5 참고)
+
+### B. (Backend, 권장) 401/403 분리 정책을 전 도메인 일괄 적용
+
+- 본 엔드포인트(2-5)는 비매니저 PATCH 를 **403 Forbidden** 으로 올바르게 반환
+- 다만 Task 7 리포트 §3-B 에서 지적한 `/bands/{id}/members/{id}/role` 비리더 호출은 여전히 **401** 반환 (이번 검증 범위 밖이지만 상관관계 주의)
+- 권장: Auth 필터/핸들러 레벨에서 인증(401) vs 인가(403) 매핑을 도메인 구분 없이 통일
+
+### C. (Backend, 경미) `CursorResponse.nextCursor` 일관성 — Task 7 §3-C 와 동일 이슈
+
+- `hasNext:false` 일 때도 `nextCursor` 가 마지막 ID 로 채워짐. 프론트 영향 없음
+
+### D. (Frontend, 선택) 밴드명·합주 제목 상세 노출
+
+- 현재 `PerformanceBandChips` 는 bandId UUID 의 앞 8자만 표시, `PerformancePracticeRow` 는 practiceId 전체를 텍스트로만 표시. 백엔드가 `bands:[{bandId,bandName}]`, `practices:[{practiceId,title,startAt}]` 형태로 요약 필드를 반환하도록 확장하면 단일 쿼리로 더 풍부한 UI 가 가능. 현재는 N+1 호출 비용을 피하기 위해 의도적으로 미확장 상태 (주석 명시).
+
+---
+
+## 4. 검증된 긍정 신호
+
+- `POST /performances` · `GET /performances(?bandId)` · `GET /performances/{id}` · `DELETE /performances/{id}` 4개 주요 경로는 프론트 타입과 완벽 정합
+- 생성자 자동 PerformanceManager 등록 (`managerIds:[9]`) 확인 — `useIsPerformanceManager` 가 의도대로 작동할 조건 충족
+- 비매니저의 수정 차단이 **403 으로 올바르게** 구분됨 (Task 6/7 대비 개선)
+
+---
+
+## 5. 프론트 관련 구현 지점
+
+```text
+src/domain/performance/types/{req,res,schema,index}.ts
+src/domain/performance/api/*.ts                            # 8개 함수
+src/domain/performance/hooks/*.ts                          # useCreate/List/Detail/Update/Delete/AddPractice/BatchAdd/RemovePractice
+src/domain/performance/components/*.tsx                    # PerformanceCard, PerformanceDday, PerformanceBandChips, PerformancePracticeRow
+src/global/auth/useIsPerformanceManager.ts
+src/app/(main)/performances/page.tsx + PerformancesList.client.tsx (Suspense bound)
+src/app/(main)/performances/new/page.tsx + PerformanceCreateForm.client.tsx
+src/app/(main)/performances/[performanceId]/page.tsx + PerformanceDetailContent.client.tsx (EditDialog, AttachDialog)
+```
+
+§3-A 수정 전 임시 워크어라운드가 필요하면 `PerformanceDetailContent.client.tsx` 의 `EditDialog` 를 다음과 같이 보정 가능:
+
+```ts
+mutation.mutate({
+  title: values.title ?? initial.title,
+  startAt: values.startAt ? fromDatetimeLocal(values.startAt) : initial.startAt,
+  durationMinutes: values.durationMinutes ?? initial.durationMinutes,
+  venue: values.venue ?? initial.venue,
+});
+```
+
+(현재는 undefined 필드를 제외해 보내는 API_SPEC 기대 동작. 백엔드 A-1 적용 시 워크어라운드 불필요.)
+
+---
+
+## 6. 재현용 페이로드 위치
+
+```text
+/tmp/bandage-performance-test/
+  ├── state.env                 # TOKEN_A, TOKEN_B, MEMBER_A, MEMBER_B, PERF_ID
+  ├── join_{a,b}.json .resp / login_{a,b}.json
+  ├── create_perf.json / update_perf.json / update_full.json / hack_perf.json / hack_full.json
+  ├── new_practice.json / batch.json
+```

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -537,7 +537,7 @@
         "dependencies": [
           "8"
         ],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -599,7 +599,8 @@
             "testStrategy": "공연 상세 접근 → 정보 확인 → 수정 버튼 클릭(매니저만 표시) → 수정 완료 → 기존 합주 3개 연결 → 합주 목록 확인 → 합주 연결 해제 → 공연 삭제 확인 다이얼로그 → 삭제 후 목록 이동 플로우 수동 테스트",
             "parentId": "undefined"
           }
-        ]
+        ],
+        "updatedAt": "2026-04-24T05:34:54.222Z"
       },
       {
         "id": "10",
@@ -676,9 +677,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-04-24T04:52:41.903Z",
+      "lastModified": "2026-04-24T05:34:54.229Z",
       "taskCount": 10,
-      "completedCount": 8,
+      "completedCount": 9,
       "tags": [
         "master"
       ]

--- a/src/app/(main)/performances/PerformancesList.client.tsx
+++ b/src/app/(main)/performances/PerformancesList.client.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { CalendarDays, Plus } from 'lucide-react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { ErrorState } from '@/components/feedback/error-state';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PerformanceCard } from '@/domain/performance/components/PerformanceCard';
+import { usePerformanceList } from '@/domain/performance/hooks/usePerformanceList';
+import { ROUTES } from '@/global/config/routes';
+
+export function PerformancesList() {
+  const searchParams = useSearchParams();
+  const bandId = searchParams?.get('bandId') ?? undefined;
+
+  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    usePerformanceList(bandId, 20);
+
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!hasNextPage || !loadMoreRef.current) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting && !isFetchingNextPage) fetchNextPage();
+    });
+    observer.observe(loadMoreRef.current);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20 w-full" rounded="md" />
+        <Skeleton className="h-20 w-full" rounded="md" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState description="공연 목록을 불러오지 못했습니다." onRetry={() => refetch()} />;
+  }
+
+  const performances = data?.pages.flatMap((p) => p.content) ?? [];
+
+  return (
+    <div className="space-y-4">
+      {bandId && (
+        <p className="text-foreground-muted text-xs">
+          밴드 필터 활성: <code className="text-foreground-sub">{bandId}</code>
+        </p>
+      )}
+
+      {performances.length === 0 ? (
+        <EmptyState
+          icon={CalendarDays}
+          title="등록된 공연이 없습니다"
+          description="첫 번째 공연을 만들고 합주를 연결해 보세요."
+        />
+      ) : (
+        <>
+          <div className="space-y-3">
+            {performances.map((p) => (
+              <PerformanceCard key={p.performanceId} performance={p} />
+            ))}
+          </div>
+          {hasNextPage && <div ref={loadMoreRef} className="h-4" aria-hidden="true" />}
+          {isFetchingNextPage && <Skeleton className="h-20 w-full" rounded="md" />}
+        </>
+      )}
+
+      <Link
+        href={ROUTES.PERFORMANCE_NEW}
+        aria-label="공연 만들기"
+        className="bg-accent text-foreground hover:bg-accent-hi focus-visible:ring-accent focus-visible:ring-offset-bg rounded-pill fixed right-4 bottom-20 z-10 flex h-14 w-14 items-center justify-center shadow-lg transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      >
+        <Plus className="h-6 w-6" />
+      </Link>
+    </div>
+  );
+}

--- a/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
+++ b/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
@@ -1,0 +1,444 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { CalendarDays, Link2, MapPin, Pencil, Plus, Trash2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { ErrorState } from '@/components/feedback/error-state';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import { PerformanceBandChips } from '@/domain/performance/components/PerformanceBandChips';
+import { PerformanceDday } from '@/domain/performance/components/PerformanceDday';
+import { PerformancePracticeRow } from '@/domain/performance/components/PerformancePracticeRow';
+import { useAddPerformancePractice } from '@/domain/performance/hooks/useAddPerformancePractice';
+import { useBatchAddPerformancePractices } from '@/domain/performance/hooks/useBatchAddPerformancePractices';
+import { useDeletePerformance } from '@/domain/performance/hooks/useDeletePerformance';
+import { usePerformanceDetail } from '@/domain/performance/hooks/usePerformanceDetail';
+import { useUpdatePerformance } from '@/domain/performance/hooks/useUpdatePerformance';
+import {
+  addPerformancePracticeSchema,
+  updatePerformanceSchema,
+  type AddPerformancePracticeSchema,
+  type UpdatePerformanceSchema,
+} from '@/domain/performance/types';
+import { useIsPerformanceManager } from '@/global/auth/useIsPerformanceManager';
+import { ROUTES } from '@/global/config/routes';
+import { formatKst, parseKst } from '@/lib/date';
+import { useToast } from '@/hooks/useToast';
+
+function toDatetimeLocal(kst: string) {
+  return kst.replace(' ', 'T');
+}
+function fromDatetimeLocal(dt: string) {
+  return dt.replace('T', ' ').slice(0, 16);
+}
+
+export function PerformanceDetailContent({ performanceId }: { performanceId: string }) {
+  const router = useRouter();
+  const toast = useToast();
+
+  const { data: perf, isLoading, isError, refetch } = usePerformanceDetail(performanceId);
+  const { isManager } = useIsPerformanceManager(performanceId);
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [attachOpen, setAttachOpen] = useState(false);
+
+  const deleteMutation = useDeletePerformance(performanceId, {
+    onSuccess: () => {
+      toast.success('공연을 삭제했습니다.');
+      router.replace(ROUTES.PERFORMANCES);
+    },
+    onError: (err) => toast.error(err.message || '삭제에 실패했습니다.'),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-32 w-full" rounded="lg" />
+        <Skeleton className="h-10 w-1/2" />
+      </div>
+    );
+  }
+
+  if (isError || !perf) {
+    return <ErrorState title="공연을 찾을 수 없습니다" onRetry={() => refetch()} />;
+  }
+
+  let scheduleLabel = perf.startAt;
+  try {
+    scheduleLabel = formatKst(parseKst(perf.startAt), 'yyyy년 M월 d일 (EEE) HH:mm');
+  } catch {
+    /* keep raw */
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card padding="lg">
+        <div className="space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <h1 className="text-foreground text-xl font-bold">{perf.title}</h1>
+              <PerformanceDday startAt={perf.startAt} />
+            </div>
+            {isManager && (
+              <div className="flex gap-2">
+                <Button size="sm" variant="secondary" onClick={() => setEditOpen(true)}>
+                  <Pencil className="h-4 w-4" />
+                  수정
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-danger hover:opacity-80"
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
+          </div>
+          <div className="text-foreground-sub flex flex-wrap items-center gap-3 text-sm">
+            <span className="inline-flex items-center gap-1">
+              <CalendarDays className="h-4 w-4" aria-hidden="true" />
+              {scheduleLabel} ({perf.durationMinutes}분)
+            </span>
+            {perf.venue && (
+              <span className="inline-flex items-center gap-1">
+                <MapPin className="h-4 w-4" aria-hidden="true" />
+                {perf.venue}
+              </span>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      <Card header="참여 밴드" padding="md">
+        <PerformanceBandChips bandIds={perf.bandIds} />
+      </Card>
+
+      <Card
+        header={
+          <div className="flex items-center justify-between">
+            <span>연결된 합주 ({perf.practiceIds.length})</span>
+            {isManager && (
+              <Button size="sm" onClick={() => setAttachOpen(true)}>
+                <Plus className="h-4 w-4" />
+                합주 연결
+              </Button>
+            )}
+          </div>
+        }
+        padding="md"
+      >
+        {perf.practiceIds.length === 0 ? (
+          <EmptyState title="연결된 합주가 없습니다" />
+        ) : (
+          <div>
+            {perf.practiceIds.map((pid) => (
+              <PerformancePracticeRow key={pid} performanceId={performanceId} practiceId={pid} />
+            ))}
+          </div>
+        )}
+      </Card>
+
+      <EditDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        performanceId={performanceId}
+        initial={{
+          title: perf.title,
+          startAt: perf.startAt,
+          durationMinutes: perf.durationMinutes,
+          venue: perf.venue ?? undefined,
+        }}
+      />
+
+      <AttachDialog open={attachOpen} onOpenChange={setAttachOpen} performanceId={performanceId} />
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>공연 삭제</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <p className="text-foreground-sub text-sm">
+              삭제된 공연은 복구할 수 없으며, 신규 생성으로 연결된 합주도 함께 제거됩니다.
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteOpen(false)}>
+              취소
+            </Button>
+            <Button
+              variant="danger"
+              loading={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate()}
+            >
+              삭제
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function EditDialog({
+  open,
+  onOpenChange,
+  performanceId,
+  initial,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  performanceId: string;
+  initial: {
+    title: string;
+    startAt: string;
+    durationMinutes: number;
+    venue?: string;
+  };
+}) {
+  const toast = useToast();
+  const form = useForm<UpdatePerformanceSchema>({
+    resolver: zodResolver(updatePerformanceSchema),
+    defaultValues: {
+      title: initial.title,
+      startAt: initial.startAt,
+      durationMinutes: initial.durationMinutes,
+      venue: initial.venue,
+    },
+  });
+
+  const mutation = useUpdatePerformance(performanceId, {
+    onSuccess: () => {
+      toast.success('공연 정보가 수정되었습니다.');
+      onOpenChange(false);
+    },
+    onError: (err) => toast.error(err.message || '수정에 실패했습니다.'),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>공연 수정</DialogTitle>
+        </DialogHeader>
+        <form
+          onSubmit={form.handleSubmit((values) =>
+            mutation.mutate({
+              title: values.title,
+              startAt: values.startAt ? fromDatetimeLocal(values.startAt) : undefined,
+              durationMinutes: values.durationMinutes,
+              venue: values.venue,
+            }),
+          )}
+          noValidate
+        >
+          <DialogBody>
+            <div className="space-y-3">
+              <Input
+                label="제목"
+                error={form.formState.errors.title?.message}
+                {...form.register('title')}
+              />
+              <Input
+                label="시작 시각"
+                type="datetime-local"
+                defaultValue={toDatetimeLocal(initial.startAt)}
+                error={form.formState.errors.startAt?.message}
+                {...form.register('startAt')}
+              />
+              <Input
+                label="소요 시간 (분)"
+                type="number"
+                min={30}
+                max={600}
+                step={30}
+                error={form.formState.errors.durationMinutes?.message}
+                {...form.register('durationMinutes', { valueAsNumber: true })}
+              />
+              <Input
+                label="장소"
+                error={form.formState.errors.venue?.message}
+                {...form.register('venue')}
+              />
+            </div>
+          </DialogBody>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              취소
+            </Button>
+            <Button type="submit" loading={mutation.isPending}>
+              저장
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AttachDialog({
+  open,
+  onOpenChange,
+  performanceId,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  performanceId: string;
+}) {
+  const toast = useToast();
+  const [mode, setMode] = useState<'batch' | 'new'>('batch');
+  const [practiceIdsRaw, setPracticeIdsRaw] = useState('');
+
+  const batchMutation = useBatchAddPerformancePractices(performanceId, {
+    onSuccess: () => {
+      toast.success('합주를 일괄 연결했습니다.');
+      setPracticeIdsRaw('');
+      onOpenChange(false);
+    },
+    onError: (err) => toast.error(err.message || '합주 연결에 실패했습니다.'),
+  });
+
+  const newForm = useForm<AddPerformancePracticeSchema>({
+    resolver: zodResolver(addPerformancePracticeSchema),
+    defaultValues: {
+      title: '',
+      songId: '',
+      startAt: '',
+      durationMinutes: 60,
+      venue: '',
+    },
+  });
+
+  const newMutation = useAddPerformancePractice(performanceId, {
+    onSuccess: () => {
+      toast.success('합주를 생성하고 연결했습니다.');
+      newForm.reset();
+      onOpenChange(false);
+    },
+    onError: (err) => toast.error(err.message || '합주 생성에 실패했습니다.'),
+  });
+
+  const attachExisting = () => {
+    const ids = practiceIdsRaw
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (ids.length === 0) {
+      toast.warn('최소 1개 이상의 practiceId 를 입력해 주세요.');
+      return;
+    }
+    batchMutation.mutate({ practiceIds: ids });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            <Link2 className="mr-1 inline h-4 w-4" />
+            합주 연결
+          </DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <Tabs value={mode} onValueChange={(v) => setMode(v as 'batch' | 'new')}>
+            <TabsList>
+              <TabsTrigger value="batch">기존 합주 연결</TabsTrigger>
+              <TabsTrigger value="new">신규 합주 생성</TabsTrigger>
+            </TabsList>
+            <TabsContent value="batch">
+              <div className="space-y-3">
+                <Textarea
+                  label="Practice ID 목록"
+                  placeholder="practiceId 를 쉼표 또는 줄바꿈으로 구분해 입력"
+                  hint="기존에 생성된 합주 UUID 를 붙여넣습니다. 백엔드 합주 검색 UI 도입 시 드롭다운으로 교체 예정."
+                  value={practiceIdsRaw}
+                  onChange={(e) => setPracticeIdsRaw(e.target.value)}
+                />
+                <Button onClick={attachExisting} loading={batchMutation.isPending}>
+                  일괄 연결
+                </Button>
+              </div>
+            </TabsContent>
+            <TabsContent value="new">
+              <form
+                className="space-y-3"
+                onSubmit={newForm.handleSubmit((values) =>
+                  newMutation.mutate({
+                    title: values.title,
+                    songId: values.songId,
+                    startAt: fromDatetimeLocal(values.startAt),
+                    durationMinutes: values.durationMinutes,
+                    venue: values.venue,
+                  }),
+                )}
+                noValidate
+              >
+                <Input
+                  label="제목 (선택)"
+                  error={newForm.formState.errors.title?.message}
+                  {...newForm.register('title')}
+                />
+                <Input
+                  label="합주곡 ID"
+                  placeholder="songId (UUID)"
+                  required
+                  error={newForm.formState.errors.songId?.message}
+                  {...newForm.register('songId')}
+                />
+                <Input
+                  label="시작 시각"
+                  type="datetime-local"
+                  required
+                  error={newForm.formState.errors.startAt?.message}
+                  {...newForm.register('startAt')}
+                />
+                <Input
+                  label="소요 시간 (분)"
+                  type="number"
+                  min={15}
+                  max={480}
+                  step={15}
+                  required
+                  error={newForm.formState.errors.durationMinutes?.message}
+                  {...newForm.register('durationMinutes', { valueAsNumber: true })}
+                />
+                <Input
+                  label="장소 (선택)"
+                  error={newForm.formState.errors.venue?.message}
+                  {...newForm.register('venue')}
+                />
+                <Button type="submit" loading={newMutation.isPending}>
+                  생성 + 연결
+                </Button>
+              </form>
+            </TabsContent>
+          </Tabs>
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            닫기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(main)/performances/[performanceId]/page.tsx
+++ b/src/app/(main)/performances/[performanceId]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+import { PerformanceDetailContent } from './PerformanceDetailContent.client';
+
+export const metadata: Metadata = {
+  title: '공연 상세 | Bandage',
+};
+
+type PageProps = {
+  params: Promise<{ performanceId: string }>;
+};
+
+export default async function PerformanceDetailPage({ params }: PageProps) {
+  const { performanceId } = await params;
+  return <PerformanceDetailContent performanceId={performanceId} />;
+}

--- a/src/app/(main)/performances/new/PerformanceCreateForm.client.tsx
+++ b/src/app/(main)/performances/new/PerformanceCreateForm.client.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useCreatePerformance } from '@/domain/performance/hooks/useCreatePerformance';
+import { createPerformanceSchema, type CreatePerformanceSchema } from '@/domain/performance/types';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+function toKstDatetime(v: string) {
+  if (!v) return v;
+  return v.replace('T', ' ').slice(0, 16);
+}
+
+type FormValues = CreatePerformanceSchema & { bandIdsRaw?: string };
+
+export function PerformanceCreateForm() {
+  const router = useRouter();
+  const toast = useToast();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(createPerformanceSchema),
+    defaultValues: {
+      title: '',
+      bandIds: [],
+      startAt: '',
+      durationMinutes: 120,
+      venue: '',
+    },
+  });
+
+  const mutation = useCreatePerformance({
+    onSuccess: (data) => {
+      toast.success('공연이 생성되었습니다.');
+      router.replace(ROUTES.PERFORMANCE_DETAIL(data.performanceId));
+    },
+    onError: (err) => toast.error(err.message || '공연 생성에 실패했습니다.'),
+  });
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={form.handleSubmit((values) => {
+        const raw = (values.bandIdsRaw ?? '').trim();
+        const bandIds = raw
+          ? raw
+              .split(/[\s,]+/)
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : undefined;
+        mutation.mutate({
+          title: values.title,
+          bandIds,
+          startAt: values.startAt,
+          durationMinutes: values.durationMinutes,
+          venue: values.venue,
+        });
+      })}
+      noValidate
+    >
+      <Input
+        label="공연 제목"
+        placeholder="예: TuNA 정기공연"
+        required
+        error={form.formState.errors.title?.message}
+        {...form.register('title')}
+      />
+      <Input
+        label="시작 시각"
+        type="datetime-local"
+        required
+        hint="Asia/Seoul 기준 yyyy-MM-dd HH:mm 으로 저장됩니다."
+        error={form.formState.errors.startAt?.message}
+        {...form.register('startAt', {
+          setValueAs: (v) => toKstDatetime(String(v ?? '')),
+        })}
+      />
+      <Input
+        label="소요 시간 (분)"
+        type="number"
+        min={30}
+        max={600}
+        step={30}
+        required
+        error={form.formState.errors.durationMinutes?.message}
+        {...form.register('durationMinutes', { valueAsNumber: true })}
+      />
+      <Input
+        label="장소 (선택)"
+        placeholder="예: Club FF"
+        error={form.formState.errors.venue?.message}
+        {...form.register('venue')}
+      />
+      <Textarea
+        label="참여 밴드 ID (선택)"
+        placeholder="bandId 를 쉼표 또는 줄바꿈으로 구분해 입력"
+        hint="백엔드 밴드 선택 UX 도입 전까지 bandId(UUID) 를 직접 입력합니다. 비워 두면 빈 배열로 전송됩니다."
+        {...form.register('bandIdsRaw')}
+      />
+      <Button type="submit" className="w-full" loading={mutation.isPending}>
+        공연 만들기
+      </Button>
+    </form>
+  );
+}

--- a/src/app/(main)/performances/new/page.tsx
+++ b/src/app/(main)/performances/new/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+
+import { PageTitle } from '@/components/layout/page-title';
+
+import { PerformanceCreateForm } from './PerformanceCreateForm.client';
+
+export const metadata: Metadata = {
+  title: '공연 만들기 | Bandage',
+};
+
+export default function PerformanceNewPage() {
+  return (
+    <div className="space-y-6">
+      <PageTitle
+        title="공연 만들기"
+        description="공연 기본 정보를 입력하세요. 합주 연결은 생성 후 상세 페이지에서 추가할 수 있습니다."
+      />
+      <PerformanceCreateForm />
+    </div>
+  );
+}

--- a/src/app/(main)/performances/page.tsx
+++ b/src/app/(main)/performances/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 
 import { PageTitle } from '@/components/layout/page-title';
+import { Skeleton } from '@/components/ui/skeleton';
 
 import { PerformancesList } from './PerformancesList.client';
 
@@ -12,7 +14,16 @@ export default function PerformancesPage() {
   return (
     <div className="space-y-6">
       <PageTitle title="공연" description="예정된 공연 일정과 연결된 합주를 확인하세요." />
-      <PerformancesList />
+      <Suspense
+        fallback={
+          <div className="space-y-3">
+            <Skeleton className="h-20 w-full" rounded="md" />
+            <Skeleton className="h-20 w-full" rounded="md" />
+          </div>
+        }
+      >
+        <PerformancesList />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/(main)/performances/page.tsx
+++ b/src/app/(main)/performances/page.tsx
@@ -1,10 +1,18 @@
+import type { Metadata } from 'next';
+
 import { PageTitle } from '@/components/layout/page-title';
+
+import { PerformancesList } from './PerformancesList.client';
+
+export const metadata: Metadata = {
+  title: '공연 | Bandage',
+};
 
 export default function PerformancesPage() {
   return (
     <div className="space-y-6">
-      <PageTitle title="공연" description="공연 일정과 신청 현황" />
-      <p className="text-foreground-sub text-sm">공연 도메인은 Task 9에서 구현됩니다.</p>
+      <PageTitle title="공연" description="예정된 공연 일정과 연결된 합주를 확인하세요." />
+      <PerformancesList />
     </div>
   );
 }

--- a/src/domain/performance/api/addPerformancePractice.ts
+++ b/src/domain/performance/api/addPerformancePractice.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { AddPerformancePracticeRequest, PerformancePracticeResponse } from '../types';
+
+export async function addPerformancePractice(
+  performanceId: string,
+  req: AddPerformancePracticeRequest,
+): Promise<PerformancePracticeResponse> {
+  const data = await apiClient.post<PerformancePracticeResponse>(
+    `/api/v1/performances/${performanceId}/practices`,
+    req,
+  );
+  if (!data) throw new Error('공연 합주 추가 응답이 비어 있습니다.');
+  return data;
+}

--- a/src/domain/performance/api/batchAddPerformancePractices.ts
+++ b/src/domain/performance/api/batchAddPerformancePractices.ts
@@ -1,0 +1,18 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { BatchAddPerformancePracticeRequest, PerformancePracticeResponse } from '../types';
+
+/**
+ * 기존 합주들을 공연에 일괄 연결.
+ * API_SPEC 6-6: 응답은 배열(`List<PerformancePracticeResponse>`).
+ */
+export async function batchAddPerformancePractices(
+  performanceId: string,
+  req: BatchAddPerformancePracticeRequest,
+): Promise<PerformancePracticeResponse[]> {
+  const data = await apiClient.post<PerformancePracticeResponse[]>(
+    `/api/v1/performances/${performanceId}/practices/batch`,
+    req,
+  );
+  return data ?? [];
+}

--- a/src/domain/performance/api/createPerformance.ts
+++ b/src/domain/performance/api/createPerformance.ts
@@ -1,0 +1,11 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { CreatePerformanceRequest, CreatePerformanceResponse } from '../types';
+
+export async function createPerformance(
+  req: CreatePerformanceRequest,
+): Promise<CreatePerformanceResponse> {
+  const data = await apiClient.post<CreatePerformanceResponse>('/api/v1/performances', req);
+  if (!data) throw new Error('공연 생성 응답이 비어 있습니다.');
+  return data;
+}

--- a/src/domain/performance/api/deletePerformance.ts
+++ b/src/domain/performance/api/deletePerformance.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function deletePerformance(performanceId: string): Promise<void> {
+  await apiClient.delete<null>(`/api/v1/performances/${performanceId}`);
+}

--- a/src/domain/performance/api/getPerformanceDetail.ts
+++ b/src/domain/performance/api/getPerformanceDetail.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { PerformanceDetailResponse } from '../types';
+
+export async function getPerformanceDetail(
+  performanceId: string,
+): Promise<PerformanceDetailResponse | null> {
+  return apiClient.get<PerformanceDetailResponse | null>(`/api/v1/performances/${performanceId}`);
+}

--- a/src/domain/performance/api/getPerformances.ts
+++ b/src/domain/performance/api/getPerformances.ts
@@ -1,0 +1,26 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { PerformanceListItemResponse } from '../types';
+
+type GetPerformancesParams = {
+  bandId?: string;
+  lastId?: string;
+  pageSize: number;
+};
+
+export async function getPerformances(
+  params: GetPerformancesParams,
+): Promise<CursorResponse<PerformanceListItemResponse, string>> {
+  const data = await apiClient.get<CursorResponse<PerformanceListItemResponse, string> | null>(
+    '/api/v1/performances',
+    {
+      query: {
+        bandId: params.bandId,
+        lastId: params.lastId,
+        pageSize: params.pageSize,
+      },
+    },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/performance/api/removePerformancePractice.ts
+++ b/src/domain/performance/api/removePerformancePractice.ts
@@ -1,0 +1,8 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function removePerformancePractice(
+  performanceId: string,
+  practiceId: string,
+): Promise<void> {
+  await apiClient.delete<null>(`/api/v1/performances/${performanceId}/practices/${practiceId}`);
+}

--- a/src/domain/performance/api/updatePerformance.ts
+++ b/src/domain/performance/api/updatePerformance.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { UpdatePerformanceRequest } from '../types';
+
+export async function updatePerformance(
+  performanceId: string,
+  req: UpdatePerformanceRequest,
+): Promise<void> {
+  await apiClient.patch<null>(`/api/v1/performances/${performanceId}`, req);
+}

--- a/src/domain/performance/components/PerformanceBandChips.tsx
+++ b/src/domain/performance/components/PerformanceBandChips.tsx
@@ -1,0 +1,19 @@
+import { Chip } from '@/components/ui/chip';
+
+/**
+ * 공연 참여 밴드 칩 목록.
+ * 현재는 bandId 만 표시 — 밴드 상세 조회는 호출 비용 고려해 추후 ID→이름 캐시 또는
+ * 백엔드가 PerformanceDetailResponse 에 band 요약 필드를 추가하는 방향으로 확장.
+ */
+export function PerformanceBandChips({ bandIds }: { bandIds: string[] }) {
+  if (bandIds.length === 0) {
+    return <span className="text-foreground-muted text-xs">참여 밴드 없음</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {bandIds.map((id) => (
+        <Chip key={id}>밴드 {id.slice(0, 8)}</Chip>
+      ))}
+    </div>
+  );
+}

--- a/src/domain/performance/components/PerformanceCard.tsx
+++ b/src/domain/performance/components/PerformanceCard.tsx
@@ -1,0 +1,48 @@
+import { CalendarDays, MapPin } from 'lucide-react';
+import Link from 'next/link';
+
+import { Card } from '@/components/ui/card';
+import { ROUTES } from '@/global/config/routes';
+import { formatKst, parseKst } from '@/lib/date';
+
+import { PerformanceDday } from './PerformanceDday';
+import type { PerformanceListItemResponse } from '../types';
+
+export function PerformanceCard({ performance }: { performance: PerformanceListItemResponse }) {
+  let label = performance.startAt;
+  try {
+    label = formatKst(parseKst(performance.startAt), 'M월 d일 (EEE) HH:mm');
+  } catch {
+    // keep raw
+  }
+
+  return (
+    <Link
+      href={ROUTES.PERFORMANCE_DETAIL(performance.performanceId)}
+      className="focus-visible:ring-accent focus-visible:ring-offset-bg block rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+    >
+      <Card interactive padding="md">
+        <div className="space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <p className="text-foreground line-clamp-1 text-base font-semibold">
+              {performance.title}
+            </p>
+            <PerformanceDday startAt={performance.startAt} />
+          </div>
+          <div className="text-foreground-sub flex flex-wrap items-center gap-3 text-xs">
+            <span className="inline-flex items-center gap-1">
+              <CalendarDays className="h-3 w-3" aria-hidden="true" />
+              {label} ({performance.durationMinutes}분)
+            </span>
+            {performance.venue && (
+              <span className="inline-flex items-center gap-1">
+                <MapPin className="h-3 w-3" aria-hidden="true" />
+                {performance.venue}
+              </span>
+            )}
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}

--- a/src/domain/performance/components/PerformanceDday.tsx
+++ b/src/domain/performance/components/PerformanceDday.tsx
@@ -1,0 +1,19 @@
+import { Badge } from '@/components/ui/badge';
+import { parseKst } from '@/lib/date';
+
+export function PerformanceDday({ startAt }: { startAt: string }) {
+  let days: number;
+  try {
+    const now = new Date();
+    const target = parseKst(startAt);
+    days = Math.ceil((target.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
+  } catch {
+    return null;
+  }
+
+  if (days < 0) return <Badge variant="default">종료</Badge>;
+  if (days === 0) return <Badge variant="danger">D-DAY</Badge>;
+  if (days <= 7) return <Badge variant="danger">D-{days}</Badge>;
+  if (days <= 14) return <Badge variant="warn">D-{days}</Badge>;
+  return <Badge variant="default">D-{days}</Badge>;
+}

--- a/src/domain/performance/components/PerformancePracticeRow.tsx
+++ b/src/domain/performance/components/PerformancePracticeRow.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Music, Unlink } from 'lucide-react';
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/button';
+import { useRemovePerformancePractice } from '@/domain/performance/hooks/useRemovePerformancePractice';
+import { useIsPerformanceManager } from '@/global/auth/useIsPerformanceManager';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+type Props = {
+  performanceId: string;
+  practiceId: string;
+};
+
+export function PerformancePracticeRow({ performanceId, practiceId }: Props) {
+  const toast = useToast();
+  const { isManager } = useIsPerformanceManager(performanceId);
+  const mutation = useRemovePerformancePractice(performanceId, {
+    onSuccess: () => toast.success('합주 연결을 해제했습니다.'),
+    onError: (err) => toast.error(err.message || '연결 해제에 실패했습니다.'),
+  });
+
+  return (
+    <div className="border-border flex items-center justify-between gap-3 border-b py-3 last:border-b-0">
+      <Link
+        href={ROUTES.PRACTICE_DETAIL(practiceId)}
+        className="text-foreground inline-flex min-w-0 items-center gap-2 text-sm hover:underline"
+      >
+        <Music className="text-foreground-muted h-4 w-4" aria-hidden="true" />
+        <span className="truncate">{practiceId}</span>
+      </Link>
+      {isManager && (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-danger hover:opacity-80"
+          onClick={() => mutation.mutate(practiceId)}
+          loading={mutation.isPending}
+        >
+          <Unlink className="h-4 w-4" />
+          해제
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/domain/performance/hooks/useAddPerformancePractice.ts
+++ b/src/domain/performance/hooks/useAddPerformancePractice.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { addPerformancePractice } from '../api/addPerformancePractice';
+import type { AddPerformancePracticeRequest, PerformancePracticeResponse } from '../types';
+
+type Options = {
+  onSuccess?: (data: PerformancePracticeResponse) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useAddPerformancePractice(performanceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<PerformancePracticeResponse, Error, AddPerformancePracticeRequest>({
+    mutationFn: (req) => addPerformancePractice(performanceId, req),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: [...queryKeys.performance.detail(performanceId)],
+      });
+      options?.onSuccess?.(data);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/performance/hooks/useBatchAddPerformancePractices.ts
+++ b/src/domain/performance/hooks/useBatchAddPerformancePractices.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { batchAddPerformancePractices } from '../api/batchAddPerformancePractices';
+import type { BatchAddPerformancePracticeRequest, PerformancePracticeResponse } from '../types';
+
+type Options = {
+  onSuccess?: (data: PerformancePracticeResponse[]) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useBatchAddPerformancePractices(performanceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<PerformancePracticeResponse[], Error, BatchAddPerformancePracticeRequest>({
+    mutationFn: (req) => batchAddPerformancePractices(performanceId, req),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: [...queryKeys.performance.detail(performanceId)],
+      });
+      options?.onSuccess?.(data);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/performance/hooks/useCreatePerformance.ts
+++ b/src/domain/performance/hooks/useCreatePerformance.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { createPerformance } from '../api/createPerformance';
+import type { CreatePerformanceRequest, CreatePerformanceResponse } from '../types';
+
+type Options = {
+  onSuccess?: (data: CreatePerformanceResponse) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useCreatePerformance(options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<CreatePerformanceResponse, Error, CreatePerformanceRequest>({
+    mutationFn: createPerformance,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.performance.all] });
+      options?.onSuccess?.(data);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/performance/hooks/useDeletePerformance.ts
+++ b/src/domain/performance/hooks/useDeletePerformance.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deletePerformance } from '../api/deletePerformance';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDeletePerformance(performanceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => deletePerformance(performanceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.performance.all] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/performance/hooks/usePerformanceDetail.ts
+++ b/src/domain/performance/hooks/usePerformanceDetail.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getPerformanceDetail } from '../api/getPerformanceDetail';
+import type { PerformanceDetailResponse } from '../types';
+
+export function usePerformanceDetail(performanceId: string, options?: { enabled?: boolean }) {
+  return useQuery<PerformanceDetailResponse | null, Error>({
+    queryKey: [...queryKeys.performance.detail(performanceId)],
+    queryFn: () => getPerformanceDetail(performanceId),
+    enabled: (options?.enabled ?? true) && !!performanceId,
+  });
+}

--- a/src/domain/performance/hooks/usePerformanceList.ts
+++ b/src/domain/performance/hooks/usePerformanceList.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useInfiniteCursor } from '@/hooks/useInfiniteCursor';
+
+import { getPerformances } from '../api/getPerformances';
+import type { PerformanceListItemResponse } from '../types';
+
+export function usePerformanceList(bandId?: string, pageSize: number = 20) {
+  return useInfiniteCursor<PerformanceListItemResponse, string>(
+    [...queryKeys.performance.list(bandId), pageSize],
+    ({ lastId, pageSize: size }) => getPerformances({ bandId, lastId, pageSize: size }),
+    pageSize,
+  );
+}

--- a/src/domain/performance/hooks/useRemovePerformancePractice.ts
+++ b/src/domain/performance/hooks/useRemovePerformancePractice.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { removePerformancePractice } from '../api/removePerformancePractice';
+import type { PerformanceDetailResponse } from '../types';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+type Context = { previous?: PerformanceDetailResponse | null };
+
+export function useRemovePerformancePractice(performanceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  const queryKey = [...queryKeys.performance.detail(performanceId)];
+
+  return useMutation<void, Error, string, Context>({
+    mutationFn: (practiceId) => removePerformancePractice(performanceId, practiceId),
+    onMutate: async (practiceId) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<PerformanceDetailResponse | null>(queryKey);
+      if (previous) {
+        queryClient.setQueryData<PerformanceDetailResponse>(queryKey, {
+          ...previous,
+          practiceIds: previous.practiceIds.filter((id) => id !== practiceId),
+        });
+      }
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(queryKey, ctx.previous);
+      options?.onError?.(err);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onSuccess: () => options?.onSuccess?.(),
+  });
+}

--- a/src/domain/performance/hooks/useUpdatePerformance.ts
+++ b/src/domain/performance/hooks/useUpdatePerformance.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updatePerformance } from '../api/updatePerformance';
+import type { PerformanceDetailResponse, UpdatePerformanceRequest } from '../types';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+type Context = { previous?: PerformanceDetailResponse | null };
+
+export function useUpdatePerformance(performanceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  const queryKey = [...queryKeys.performance.detail(performanceId)];
+
+  return useMutation<void, Error, UpdatePerformanceRequest, Context>({
+    mutationFn: (req) => updatePerformance(performanceId, req),
+    onMutate: async (req) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<PerformanceDetailResponse | null>(queryKey);
+      if (previous) {
+        queryClient.setQueryData<PerformanceDetailResponse>(queryKey, {
+          ...previous,
+          ...(req.title !== undefined ? { title: req.title } : {}),
+          ...(req.startAt !== undefined ? { startAt: req.startAt } : {}),
+          ...(req.durationMinutes !== undefined ? { durationMinutes: req.durationMinutes } : {}),
+          ...(req.venue !== undefined ? { venue: req.venue } : {}),
+        });
+      }
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(queryKey, ctx.previous);
+      options?.onError?.(err);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onSuccess: () => options?.onSuccess?.(),
+  });
+}

--- a/src/domain/performance/types/index.ts
+++ b/src/domain/performance/types/index.ts
@@ -1,0 +1,24 @@
+export type {
+  CreatePerformanceRequest,
+  UpdatePerformanceRequest,
+  AddPerformancePracticeRequest,
+  BatchAddPerformancePracticeRequest,
+} from './req';
+export type {
+  CreatePerformanceResponse,
+  PerformanceListItemResponse,
+  PerformanceDetailResponse,
+  PerformancePracticeResponse,
+} from './res';
+export {
+  createPerformanceSchema,
+  updatePerformanceSchema,
+  addPerformancePracticeSchema,
+  batchAddPerformancePracticeSchema,
+} from './schema';
+export type {
+  CreatePerformanceSchema,
+  UpdatePerformanceSchema,
+  AddPerformancePracticeSchema,
+  BatchAddPerformancePracticeSchema,
+} from './schema';

--- a/src/domain/performance/types/req.ts
+++ b/src/domain/performance/types/req.ts
@@ -1,0 +1,26 @@
+export interface CreatePerformanceRequest {
+  title: string;
+  bandIds?: string[];
+  startAt: string;
+  durationMinutes: number;
+  venue?: string;
+}
+
+export interface UpdatePerformanceRequest {
+  title?: string;
+  startAt?: string;
+  durationMinutes?: number;
+  venue?: string;
+}
+
+export interface AddPerformancePracticeRequest {
+  title?: string;
+  songId: string;
+  startAt: string;
+  durationMinutes: number;
+  venue?: string;
+}
+
+export interface BatchAddPerformancePracticeRequest {
+  practiceIds: string[];
+}

--- a/src/domain/performance/types/res.ts
+++ b/src/domain/performance/types/res.ts
@@ -1,0 +1,28 @@
+export interface CreatePerformanceResponse {
+  performanceId: string;
+  title: string;
+}
+
+export interface PerformanceListItemResponse {
+  performanceId: string;
+  title: string;
+  startAt: string;
+  durationMinutes: number;
+  venue?: string | null;
+}
+
+export interface PerformanceDetailResponse {
+  performanceId: string;
+  title: string;
+  startAt: string;
+  durationMinutes: number;
+  venue?: string | null;
+  bandIds: string[];
+  managerIds: number[];
+  practiceIds: string[];
+}
+
+export interface PerformancePracticeResponse {
+  performancePracticeId: string;
+  practiceId: string;
+}

--- a/src/domain/performance/types/schema.ts
+++ b/src/domain/performance/types/schema.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+const KST_DATETIME = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
+
+export const createPerformanceSchema = z.object({
+  title: z
+    .string()
+    .min(1, '공연 제목을 입력해 주세요.')
+    .max(100, '공연 제목은 100자 이하로 입력해 주세요.'),
+  bandIds: z.array(z.string().min(1)).optional(),
+  startAt: z.string().regex(KST_DATETIME, '시작 시각은 yyyy-MM-dd HH:mm 형식이어야 합니다.'),
+  durationMinutes: z
+    .number({ message: '소요 시간을 숫자로 입력해 주세요.' })
+    .int()
+    .min(30, '최소 30분 이상이어야 합니다.')
+    .max(600, '최대 600분(10시간)까지 입력 가능합니다.'),
+  venue: z
+    .string()
+    .max(200, '장소는 200자 이하로 입력해 주세요.')
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+});
+export type CreatePerformanceSchema = z.infer<typeof createPerformanceSchema>;
+
+export const updatePerformanceSchema = z
+  .object({
+    title: z.string().min(1).max(100).optional(),
+    startAt: z.string().regex(KST_DATETIME).optional(),
+    durationMinutes: z.number().int().min(30).max(600).optional(),
+    venue: z.string().max(200).optional(),
+  })
+  .refine(
+    (data) =>
+      data.title !== undefined ||
+      data.startAt !== undefined ||
+      data.durationMinutes !== undefined ||
+      data.venue !== undefined,
+    { message: '수정할 항목을 하나 이상 입력해 주세요.' },
+  );
+export type UpdatePerformanceSchema = z.infer<typeof updatePerformanceSchema>;
+
+export const addPerformancePracticeSchema = z.object({
+  title: z
+    .string()
+    .max(100)
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+  songId: z.string().min(1, 'songId 를 입력해 주세요.'),
+  startAt: z.string().regex(KST_DATETIME, '시작 시각은 yyyy-MM-dd HH:mm 형식이어야 합니다.'),
+  durationMinutes: z.number().int().min(15).max(480),
+  venue: z
+    .string()
+    .max(200)
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+});
+export type AddPerformancePracticeSchema = z.infer<typeof addPerformancePracticeSchema>;
+
+export const batchAddPerformancePracticeSchema = z.object({
+  practiceIds: z.array(z.string().min(1)).min(1, '최소 1개 이상의 합주를 선택해 주세요.'),
+});
+export type BatchAddPerformancePracticeSchema = z.infer<typeof batchAddPerformancePracticeSchema>;

--- a/src/global/auth/useIsPerformanceManager.ts
+++ b/src/global/auth/useIsPerformanceManager.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { usePerformanceDetail } from '@/domain/performance/hooks/usePerformanceDetail';
+import { useMe } from '@/domain/member/hooks/useMe';
+import { useIsAuthenticated } from '@/global/store/authStore';
+
+/**
+ * 현재 로그인 유저가 해당 공연의 매니저인지 판정.
+ * 로딩/에러 중에는 isManager=false 로 안전하게 반환.
+ */
+export function useIsPerformanceManager(performanceId: string) {
+  const authenticated = useIsAuthenticated();
+  const { data: me, isLoading: meLoading } = useMe({ enabled: authenticated });
+  const { data: performance, isLoading: perfLoading } = usePerformanceDetail(performanceId, {
+    enabled: !!performanceId,
+  });
+
+  const isLoading = meLoading || perfLoading;
+  const isManager = !!me?.id && !!performance?.managerIds && performance.managerIds.includes(me.id);
+
+  return { isManager, isLoading };
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #11

📌 **작업 내용 및 특이사항**

Task 9 (서브태스크 9.1 ~ 9.5) 구현. 공연(Performance) 도메인 전체 — 타입·스키마·API 8개·Query/Mutation 훅 8개(낙관 업데이트 포함)·UI 컴포넌트 4개·3개 페이지(`/performances`, `/performances/new`, `/performances/[performanceId]`)·매니저 권한 가드 훅(`useIsPerformanceManager`).

### 구현 파일
- 도메인 레이어 — `domain/performance/{types,api,hooks,components}/*`
  - types: 요청 4개 + 응답 4개 + zod 스키마 4개 (`startAt` yyyy-MM-dd HH:mm 정규식, `durationMinutes` 공연 30~600 / 합주 15~480)
  - api: createPerformance · getPerformances(bandId 필터) · getPerformanceDetail · updatePerformance · deletePerformance · addPerformancePractice · batchAddPerformancePractices (응답 배열) · removePerformancePractice
  - hooks: usePerformanceList(useInfiniteCursor) · usePerformanceDetail(useQuery) + Mutation 6종. useUpdatePerformance 는 부분 업데이트 낙관 반영, useRemovePerformancePractice 는 practiceIds 배열에서 즉시 제거 낙관 업데이트
  - components: PerformanceDday(D-n 뱃지, 7/14일 임계), PerformanceCard(목록), PerformanceBandChips, PerformancePracticeRow(매니저만 해제 버튼)
- 권한 가드 — `global/auth/useIsPerformanceManager.ts`: useMe.id 와 performance.managerIds 교차 판정
- 페이지
  - `/performances`: Suspense + useSearchParams?bandId= 필터, 무한 스크롤 + FAB
  - `/performances/new`: rhf + zodResolver, bandIds 는 쉼표·줄바꿈 구분 텍스트를 배열로
  - `/performances/[performanceId]`: 헤더(D-day + 매니저용 수정/삭제) + 참여 밴드 + 연결된 합주(매니저용 연결 Dialog — Tabs 로 "기존 합주 연결(batch)" / "신규 합주 생성")

### 로컬 검증
- [x] `pnpm lint` / `typecheck` / `format:check` / `build` 통과
- [x] `pnpm test` 16/16 유지
- [x] 18개 라우트 정적/동적 생성 모두 정상

### 실서버 검증 (CLAUDE.md §6)
로컬 백엔드 `http://localhost:8080` 에서 8개 엔드포인트 curl 호출. 리포트:

> [.taskmaster/report/performance-api-verification-2026-04-24.md](./.taskmaster/report/performance-api-verification-2026-04-24.md)

확정 결과:
- 정상: create/list/detail/delete 완전 통과. `managerIds` 에 생성자 자동 등록 확인 — `useIsPerformanceManager` 작동 조건 충족
- **비매니저 PATCH 가 403 Forbidden 으로 정확히 분리됨** — Task 7 §3-B 권고가 이 엔드포인트에는 선반영 (그러나 Task 7 의 `delegateLeader` 는 여전히 401. 도메인 일괄 정리 권장)
- Practice 연결(6-5/6-6/6-7) 은 경로·메서드·요청 shape 검증 완료. 유효 songId/practiceId 전제로 실경로 완결 검증은 Task 8 §3-A(Song 생성 엔드포인트 부재) 해결 후 2차 검증 필요

백엔드 수정 권장:
1. **(최우선) `PATCH /performances/{id}` 부분 업데이트 지원** — `startAt` 생략 시 "non-null is null" 400 발생. API_SPEC 6-4 는 모든 필드 optional 이나 Kotlin DTO `PerformanceUpdateRequest` 는 non-nullable. 프론트 EditDialog 의 "일정만 변경/장소만 변경" UX 가 막혀 있음 (리포트에 워크어라운드 코드 스니펫 포함)
2. Task 7 §3-B 의 401→403 분리 정책을 전 도메인 일괄 적용 (delegateLeader 등 잔존분 확인)
3. `CursorResponse.hasNext=false` 일 때 `nextCursor` null 로 정리 (일관성)

📚 **참고사항**
- 이 PR 은 Task 8(#25, `def9ad9`) 머지 후 develop 에 rebase 된 상태에서 분기
- 밴드/합주 상세 정보를 칩/행에 풍부하게 표시하려면 백엔드 응답에 요약 필드 추가가 필요 — 현재는 UUID 의 앞 8자만 표시 (N+1 호출 방지 목적)