### PR TITLE
feat: 홈 대시보드 및 MVP 마무리 구현

### DIFF
--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,12 +1,39 @@
+import type { Metadata } from 'next';
+
 import { PageTitle } from '@/components/layout/page-title';
+import { MyBands } from '@/domain/band/components/MyBands';
+import { UpcomingPerformances } from '@/domain/performance/components/UpcomingPerformances';
+import { UpcomingPractices } from '@/domain/practice/components/UpcomingPractices';
+
+export const metadata: Metadata = {
+  title: '홈 | Bandage',
+};
 
 export default function HomePage() {
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <PageTitle title="홈" description="오늘의 합주와 공연을 한눈에 확인하세요." />
-      <p className="text-foreground-sub text-sm">
-        홈 대시보드는 Task 10에서 주요 위젯으로 채워집니다.
-      </p>
+
+      <section aria-labelledby="home-upcoming-practices" className="space-y-3">
+        <h2 id="home-upcoming-practices" className="text-foreground text-base font-semibold">
+          가까운 합주
+        </h2>
+        <UpcomingPractices limit={3} />
+      </section>
+
+      <section aria-labelledby="home-my-bands" className="space-y-3">
+        <h2 id="home-my-bands" className="text-foreground text-base font-semibold">
+          내 밴드
+        </h2>
+        <MyBands limit={6} />
+      </section>
+
+      <section aria-labelledby="home-upcoming-performances" className="space-y-3">
+        <h2 id="home-upcoming-performances" className="text-foreground text-base font-semibold">
+          예정 공연
+        </h2>
+        <UpcomingPerformances limit={2} />
+      </section>
     </div>
   );
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { ErrorState } from '@/components/feedback/error-state';
+
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(error);
+    }
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center px-4">
+      <ErrorState
+        title="화면을 불러올 수 없습니다"
+        description={error.message || '잠시 후 다시 시도해 주세요.'}
+        onRetry={reset}
+        className="w-full max-w-md"
+      />
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,20 @@
+import { Compass } from 'lucide-react';
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/button';
+import { ROUTES } from '@/global/config/routes';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[70vh] flex-col items-center justify-center gap-4 px-4 text-center">
+      <Compass className="text-foreground-muted h-12 w-12" aria-hidden="true" />
+      <div className="space-y-1">
+        <p className="text-foreground text-xl font-semibold">페이지를 찾을 수 없어요</p>
+        <p className="text-foreground-sub text-sm">주소가 바뀌었거나 더 이상 존재하지 않습니다.</p>
+      </div>
+      <Button asChild variant="secondary">
+        <Link href={ROUTES.HOME}>홈으로 돌아가기</Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,65 +1,7 @@
-import Image from 'next/image';
+import { redirect } from 'next/navigation';
 
-export default function Home() {
-  return (
-    <div className="flex flex-1 flex-col items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex w-full max-w-3xl flex-1 flex-col items-center justify-between bg-white px-16 py-32 sm:items-start dark:bg-black">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl leading-10 font-semibold tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{' '}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{' '}
-            or the{' '}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{' '}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="bg-foreground text-background flex h-12 w-full items-center justify-center gap-2 rounded-full px-5 transition-colors hover:bg-[#383838] md:w-[158px] dark:hover:bg-[#ccc]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] md:w-[158px] dark:border-white/[.145] dark:hover:bg-[#1a1a1a]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
-    </div>
-  );
+import { ROUTES } from '@/global/config/routes';
+
+export default function RootPage() {
+  redirect(ROUTES.HOME);
 }

--- a/src/domain/band/components/MyBands.tsx
+++ b/src/domain/band/components/MyBands.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Users } from 'lucide-react';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { ErrorState } from '@/components/feedback/error-state';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import { useMyBands } from '../hooks/useMyBands';
+
+import { BandCard } from './BandCard';
+
+export function MyBands({ limit = 6 }: { limit?: number }) {
+  const { data, isLoading, isError, refetch } = useMyBands(limit);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20 w-full" rounded="md" />
+        <Skeleton className="h-20 w-full" rounded="md" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState description="밴드 목록을 불러오지 못했습니다." onRetry={() => refetch()} />;
+  }
+
+  const bands = data ?? [];
+  if (bands.length === 0) {
+    return (
+      <EmptyState
+        icon={Users}
+        title="가입한 밴드가 없습니다"
+        description="밴드 탭에서 새 밴드를 만들거나 가입 신청을 해 보세요."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {bands.map((b) => (
+        <BandCard key={b.bandId} band={b} />
+      ))}
+    </div>
+  );
+}

--- a/src/domain/band/hooks/useMyBands.ts
+++ b/src/domain/band/hooks/useMyBands.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getBands } from '../api/getBands';
+import type { BandInfoResponse } from '../types';
+
+// NOTE: API_SPEC v1 에 "내 밴드" 전용 엔드포인트가 없어, 일단 GET /api/v1/bands 첫 페이지를 사용한다.
+// 백엔드에 /api/v1/members/me/bands 가 추가되면 이 훅의 fetcher 만 교체한다.
+export function useMyBands(limit: number = 10) {
+  return useQuery<BandInfoResponse[], Error>({
+    queryKey: [...queryKeys.band.my(), limit],
+    queryFn: async () => {
+      const page = await getBands({ pageSize: limit });
+      return page.content;
+    },
+  });
+}

--- a/src/domain/performance/components/UpcomingPerformances.tsx
+++ b/src/domain/performance/components/UpcomingPerformances.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { CalendarDays } from 'lucide-react';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { ErrorState } from '@/components/feedback/error-state';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import { useUpcomingPerformances } from '../hooks/useUpcomingPerformances';
+
+import { PerformanceCard } from './PerformanceCard';
+
+export function UpcomingPerformances({ limit = 2 }: { limit?: number }) {
+  const { data, isLoading, isError, refetch } = useUpcomingPerformances(limit);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: limit }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full" rounded="md" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState description="예정 공연을 불러오지 못했습니다." onRetry={() => refetch()} />;
+  }
+
+  const performances = data ?? [];
+  if (performances.length === 0) {
+    return (
+      <EmptyState
+        icon={CalendarDays}
+        title="예정된 공연이 없습니다"
+        description="공연 탭에서 새 공연을 추가해 보세요."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {performances.map((p) => (
+        <PerformanceCard key={p.performanceId} performance={p} />
+      ))}
+    </div>
+  );
+}

--- a/src/domain/performance/hooks/useUpcomingPerformances.ts
+++ b/src/domain/performance/hooks/useUpcomingPerformances.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getPerformances } from '../api/getPerformances';
+import type { PerformanceListItemResponse } from '../types';
+
+export function useUpcomingPerformances(limit: number = 2) {
+  return useQuery<PerformanceListItemResponse[], Error>({
+    queryKey: [...queryKeys.performance.upcoming(limit)],
+    queryFn: async () => {
+      const page = await getPerformances({ pageSize: limit });
+      return page.content;
+    },
+  });
+}

--- a/src/domain/practice/components/PracticeVenueInline.client.tsx
+++ b/src/domain/practice/components/PracticeVenueInline.client.tsx
@@ -56,14 +56,20 @@ export function PracticeVenueInline({ practiceId, venue }: Props) {
       />
       <Button
         size="sm"
+        aria-label="장소 저장"
         onClick={() => mutation.mutate({ venue: value.trim() })}
         loading={mutation.isPending}
         disabled={value.trim().length === 0}
       >
-        <Check className="h-3 w-3" />
+        <Check className="h-3 w-3" aria-hidden="true" />
       </Button>
-      <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>
-        <X className="h-3 w-3" />
+      <Button
+        size="sm"
+        variant="ghost"
+        aria-label="장소 수정 취소"
+        onClick={() => setEditing(false)}
+      >
+        <X className="h-3 w-3" aria-hidden="true" />
       </Button>
     </div>
   );

--- a/src/domain/practice/components/SessionRow.tsx
+++ b/src/domain/practice/components/SessionRow.tsx
@@ -83,10 +83,11 @@ export function SessionRow({ practiceId, session }: Props) {
         <Button
           size="sm"
           variant="ghost"
+          aria-label="세션 삭제"
           className="text-danger hover:opacity-80"
           onClick={() => setConfirmDelete(true)}
         >
-          <Trash2 className="h-4 w-4" />
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
         </Button>
       </div>
 

--- a/src/domain/practice/components/SongRefLinkEditor.client.tsx
+++ b/src/domain/practice/components/SongRefLinkEditor.client.tsx
@@ -46,14 +46,20 @@ export function SongRefLinkEditor({ practiceId, songId, refLink }: Props) {
         />
         <Button
           size="sm"
+          aria-label="참조 링크 저장"
           onClick={() => upsertMutation.mutate(value.trim())}
           loading={upsertMutation.isPending}
           disabled={value.trim().length === 0}
         >
-          <Check className="h-3 w-3" />
+          <Check className="h-3 w-3" aria-hidden="true" />
         </Button>
-        <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>
-          <X className="h-3 w-3" />
+        <Button
+          size="sm"
+          variant="ghost"
+          aria-label="참조 링크 수정 취소"
+          onClick={() => setEditing(false)}
+        >
+          <X className="h-3 w-3" aria-hidden="true" />
         </Button>
       </div>
     );
@@ -74,21 +80,23 @@ export function SongRefLinkEditor({ practiceId, songId, refLink }: Props) {
         <Button
           size="sm"
           variant="ghost"
+          aria-label="참조 링크 편집"
           onClick={() => {
             setValue(refLink);
             setEditing(true);
           }}
         >
-          <Pencil className="h-3 w-3" />
+          <Pencil className="h-3 w-3" aria-hidden="true" />
         </Button>
         <Button
           size="sm"
           variant="ghost"
+          aria-label="참조 링크 삭제"
           className="text-danger hover:opacity-80"
           onClick={() => deleteMutation.mutate()}
           loading={deleteMutation.isPending}
         >
-          <Trash2 className="h-3 w-3" />
+          <Trash2 className="h-3 w-3" aria-hidden="true" />
         </Button>
       </div>
     );

--- a/src/domain/practice/components/UpcomingPractices.tsx
+++ b/src/domain/practice/components/UpcomingPractices.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Music } from 'lucide-react';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { ErrorState } from '@/components/feedback/error-state';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import { useUpcomingPractices } from '../hooks/useUpcomingPractices';
+
+import { PracticeCard } from './PracticeCard';
+
+export function UpcomingPractices({ limit = 3 }: { limit?: number }) {
+  const { data, isLoading, isError, refetch } = useUpcomingPractices(limit);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: limit }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full" rounded="md" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorState description="가까운 합주를 불러오지 못했습니다." onRetry={() => refetch()} />
+    );
+  }
+
+  const practices = data ?? [];
+  if (practices.length === 0) {
+    return (
+      <EmptyState
+        icon={Music}
+        title="예정된 합주가 없습니다"
+        description="합주 탭에서 첫 합주를 만들어 보세요."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {practices.map((p) => (
+        <PracticeCard key={p.practiceId} practice={p} />
+      ))}
+    </div>
+  );
+}

--- a/src/domain/practice/hooks/useUpcomingPractices.ts
+++ b/src/domain/practice/hooks/useUpcomingPractices.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getPractices } from '../api/getPractices';
+import type { PracticeListItemResponse } from '../types';
+
+export function useUpcomingPractices(limit: number = 3) {
+  return useQuery<PracticeListItemResponse[], Error>({
+    queryKey: [...queryKeys.practice.upcoming(limit)],
+    queryFn: async () => {
+      const page = await getPractices({ pageSize: limit });
+      return page.content;
+    },
+  });
+}

--- a/src/global/config/queryKeys.ts
+++ b/src/global/config/queryKeys.ts
@@ -8,6 +8,7 @@ export const queryKeys = {
   band: {
     all: ['band'] as const,
     list: () => [...queryKeys.band.all, 'list'] as const,
+    my: () => [...queryKeys.band.all, 'my'] as const,
     detail: (id: string) => [...queryKeys.band.all, id] as const,
     members: (id: string) => [...queryKeys.band.all, id, 'members'] as const,
     applications: (id: string, status?: string) =>
@@ -16,12 +17,14 @@ export const queryKeys = {
   practice: {
     all: ['practice'] as const,
     list: (bandId?: string) => [...queryKeys.practice.all, 'list', bandId ?? null] as const,
+    upcoming: (limit: number) => [...queryKeys.practice.all, 'upcoming', limit] as const,
     detail: (id: string) => [...queryKeys.practice.all, id] as const,
     songs: (id: string) => [...queryKeys.practice.all, id, 'songs'] as const,
   },
   performance: {
     all: ['performance'] as const,
     list: (bandId?: string) => [...queryKeys.performance.all, 'list', bandId ?? null] as const,
+    upcoming: (limit: number) => [...queryKeys.performance.all, 'upcoming', limit] as const,
     detail: (id: string) => [...queryKeys.performance.all, id] as const,
   },
 } as const;


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #12

📌 **작업 내용 및 특이사항**

홈 대시보드(/home) 를 구현하고, MVP 1차 마감을 위한 전역 화면(루트 리다이렉트 / error.tsx / not-found.tsx) 및 접근성 감사를 수행했습니다. Playwright E2E 확장 단계는 사용자 요청에 따라 이번 PR 에서 제외했습니다.

**홈 대시보드**
- `UpcomingPractices(limit=3)` · `MyBands(limit=6)` · `UpcomingPerformances(limit=2)` 클라이언트 위젯 추가
- 각 위젯에 Skeleton / EmptyState / ErrorState 일관 적용 (기존 list 페이지 패턴 미러링)
- `home/page.tsx` 를 3개 section 으로 재구성, `aria-labelledby` 로 h2 헤딩 연결
- 홈 전용 훅 3종 추가 (`useUpcomingPractices`, `useMyBands`, `useUpcomingPerformances`) — 기존 `getPractices` / `getBands` / `getPerformances` 재사용
- `queryKeys` 에 `band.my` / `practice.upcoming` / `performance.upcoming` 키 확장
- `useMyBands` 는 API_SPEC v1 에 전용 엔드포인트가 없어 `/api/v1/bands` 첫 페이지를 임시 사용 (훅 내 NOTE)

**전역 화면**
- `src/app/error.tsx`: ErrorState + reset 으로 화면 수준 에러 바운더리 제공
- `src/app/not-found.tsx`: 404 페이지 (EmptyState 스타일 + 홈으로 돌아가기)
- `src/app/page.tsx`: 기본 Next.js 템플릿 제거, `/home` 으로 redirect

**접근성 감사**
- Dialog/BottomSheet: Radix Dialog 기반으로 포커스 트랩 / ESC 닫기 / 트리거 포커스 복귀가 이미 적용됨을 확인
- Input: `Field` 공용 컴포넌트가 `label htmlFor`, `aria-invalid`, `aria-describedby`, `aria-required` 를 일관 처리
- BottomNav: `aria-current='page'`, `aria-label='주 탐색'` 이미 존재
- 아이콘 전용 버튼 aria-label 보강
  - `SessionRow` Trash2: '세션 삭제'
  - `PracticeVenueInline` Check/X: '장소 저장' / '장소 수정 취소'
  - `SongRefLinkEditor` Check/X/Pencil/Trash2: '참조 링크 저장 / 취소 / 편집 / 삭제'
  - 해당 아이콘들에 `aria-hidden='true'` 명시로 중복 낭독 방지

**목록 페이지 상태 처리 감사 결과**
- `bands`, `practices`, `performances`, `me` 전 페이지가 Skeleton + EmptyState/ErrorState 를 이미 갖추고 있음을 확인 (수정 불필요)

**CI 게이트 (Playwright 제외)**
- lint / typecheck / format:check / vitest(16/16) / build(18 pages) 모두 green

📚 **참고사항**

- Task-master `#10` (홈 대시보드 및 최종 마무리)
- PRD Phase 6
- E2E 확장은 별도 작업으로 분리. 현 CI 워크플로우에서 Playwright 단계는 주석 처리 상태 유지