### PR TITLE
test: Playwright E2E 도메인별 가드 테스트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,8 @@ dist
 pnpm-lock.yaml
 next-env.d.ts
 public
+playwright-report
+test-results
 
 # Project-external assets and docs
 design

--- a/tests/e2e/band.spec.ts
+++ b/tests/e2e/band.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Band 도메인 가드', () => {
+  test('비인증 사용자가 /bands 접근 시 /login 으로 리다이렉트된다', async ({ page }) => {
+    await page.goto('/bands');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fbands/);
+  });
+
+  test('비인증 사용자가 /bands/new 접근 시 /login 으로 리다이렉트된다', async ({ page }) => {
+    await page.goto('/bands/new');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fbands%2Fnew/);
+  });
+
+  test('비인증 사용자가 /bands/:bandId 접근 시 /login 으로 리다이렉트된다', async ({ page }) => {
+    await page.goto('/bands/test-band-id');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fbands%2Ftest-band-id/);
+  });
+
+  // TODO(backend): 아래 시나리오는 Bandage 백엔드가 로컬에서 기동된 이후 활성화
+  // - 밴드 생성 → 상세 조회 → 가입 신청 → 승인 플로우
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('홈 대시보드 가드', () => {
+  test('비인증 사용자가 /home 접근 시 /login 으로 리다이렉트된다', async ({ page }) => {
+    await page.goto('/home');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fhome/);
+  });
+
+  test('비인증 사용자가 / 접근 시 /home 을 거쳐 /login 으로 리다이렉트된다', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  // TODO(backend): 아래 시나리오는 Bandage 백엔드가 로컬에서 기동된 이후 활성화
+  // - 홈 대시보드 3개 섹션(가까운 합주, 내 밴드, 예정 공연) 렌더링 확인
+  // - 각 섹션의 Skeleton/EmptyState/ErrorState 확인
+});

--- a/tests/e2e/performance.spec.ts
+++ b/tests/e2e/performance.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Performance 도메인 가드', () => {
+  test('비인증 사용자가 /performances 접근 시 /login 으로 리다이렉트된다', async ({ page }) => {
+    await page.goto('/performances');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fperformances/);
+  });
+
+  test('비인증 사용자가 /performances/new 접근 시 /login 으로 리다이렉트된다', async ({ page }) => {
+    await page.goto('/performances/new');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fperformances%2Fnew/);
+  });
+
+  test('비인증 사용자가 /performances/:performanceId 접근 시 /login 으로 리다이렉트된다', async ({
+    page,
+  }) => {
+    await page.goto('/performances/test-performance-id');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fperformances%2Ftest-performance-id/);
+  });
+
+  // TODO(backend): 아래 시나리오는 Bandage 백엔드가 로컬에서 기동된 이후 활성화
+  // - 공연 생성 → 합주 연결 → 삭제 플로우
+});

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Practice 도메인 가드', () => {
+  test('비인증 사용자가 /practices 접근 시 /login 으로 리다이렉트된다', async ({ page }) => {
+    await page.goto('/practices');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fpractices/);
+  });
+
+  test('비인증 사용자가 /practices/new 접근 시 /login 으로 리다이렉트된다', async ({ page }) => {
+    await page.goto('/practices/new');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fpractices%2Fnew/);
+  });
+
+  test('비인증 사용자가 /practices/:practiceId 접근 시 /login 으로 리다이렉트된다', async ({
+    page,
+  }) => {
+    await page.goto('/practices/test-practice-id');
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(/from=%2Fpractices%2Ftest-practice-id/);
+  });
+
+  // TODO(backend): 아래 시나리오는 Bandage 백엔드가 로컬에서 기동된 이후 활성화
+  // - 합주 생성 → 세션 추가 → 배정 → 삭제 플로우
+});


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #28

📌 **작업 내용 및 특이사항**

- `tests/e2e/band.spec.ts`: `/bands`, `/bands/new`, `/bands/:bandId` 비인증 접근 시 `/login` 리다이렉트 및 `from` 쿼리 보존 검증
- `tests/e2e/practice.spec.ts`: `/practices`, `/practices/new`, `/practices/:practiceId` 동일 검증
- `tests/e2e/performance.spec.ts`: `/performances`, `/performances/new`, `/performances/:performanceId` 동일 검증
- `tests/e2e/home.spec.ts`: `/home` 과 루트(`/`) 에서 `/login` 으로 리다이렉트되는지 검증
- 각 spec 말미에 백엔드 기동 후 활성화할 풀 플로우(회원가입→로그인→로그아웃, 밴드 생성→가입 신청→승인, 합주 생성→세션 추가→삭제, 공연 생성→합주 연결→삭제, 홈 3섹션 렌더링) 를 `TODO(backend):` 주석으로 기록
- Playwright 산출물(`playwright-report`, `test-results`) 이 로컬 실행 시 `pnpm format:check` 를 실패시키지 않도록 `.gitignore` 및 `.prettierignore` 에 추가

📚 **참고사항**

- 실행 결과: `PORT=3100 pnpm test:e2e` → 14 passed (기존 auth.spec.ts 3개 + 신규 11개)
- `pnpm lint`, `pnpm typecheck`, `pnpm format:check` 모두 통과 (pre-commit 훅에서 검증됨)
- 백엔드 기동 없이도 실행 가능한 미들웨어 가드 범위만 커버. 풀 플로우 시나리오는 후속 PR 에서 백엔드 실서버 검증과 함께 활성화 예정