### PR TITLE
fix: 405 가 401 로 오염된 응답에서 refresh 루프 탈출

### DIFF
--- a/src/global/api/apiClient.interceptor.test.ts
+++ b/src/global/api/apiClient.interceptor.test.ts
@@ -8,15 +8,17 @@ type MockResponseInit = {
   status?: number;
   body?: unknown;
   statusText?: string;
+  headers?: Record<string, string>;
 };
 
-function mockResponse({ status = 200, body, statusText = 'OK' }: MockResponseInit = {}) {
+function mockResponse({ status = 200, body, statusText = 'OK', headers }: MockResponseInit = {}) {
   const text = body === undefined ? '' : JSON.stringify(body);
   return {
     status,
     ok: status >= 200 && status < 300,
     statusText,
     text: async () => text,
+    headers: new Headers(headers ?? {}),
   } as Response;
 }
 
@@ -106,6 +108,31 @@ describe('apiClient 401 interceptor', () => {
     await apiClient.get('/api/v1/bands').catch(() => undefined);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('401 이지만 Allow 헤더가 있으면 405 로 간주하고 refresh 루프를 건너뛴다', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      mockResponse({
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: { Allow: 'POST' },
+        body: {
+          success: false,
+          message: '인증되지 않은 회원입니다.',
+          data: null,
+          timestamp: 't',
+        },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const err = await apiClient.get('/api/v1/practices').catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(405);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().accessToken).toBe('old_token');
+    expect(unauthorized).not.toHaveBeenCalled();
   });
 
   it('동시에 발생한 401 은 한 번만 refresh 를 호출한다', async () => {

--- a/src/global/api/apiClient.ts
+++ b/src/global/api/apiClient.ts
@@ -145,6 +145,14 @@ export async function request<T>(
   }
 
   if (response.status === 401 && !config._skipAuthRefresh) {
+    // Spring 의 에러 디스패치 경로에서 405 Method Not Allowed 가 401 로 오염되는 경우가 있다.
+    // 표준 405 응답에만 붙는 `Allow` 헤더가 있으면 토큰 만료가 아닌 메서드 불일치로 간주하고
+    // refresh 루프를 건너뛰어 사용자 세션을 보존한다.
+    if (response.headers.get('Allow')) {
+      const parsed = await parseBody(response);
+      throw toApiError(parsed, 405, 'Method not allowed');
+    }
+
     try {
       await refreshAccessToken();
     } catch {


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #30

📌 **작업 내용 및 특이사항**

### 증상
로그인이 성공한 직후, 홈 대시보드(`/home`) 의 `UpcomingPractices` 위젯이 `GET /api/v1/practices` 를 호출하는 순간 세션이 초기화되어 로그인 화면으로 튕기는 현상이 재현되었습니다.

### 근본 원인
- 백엔드(`bandage` 레포) 가 해당 경로에 GET 핸들러가 없을 때 Spring 의 에러 디스패치 경로를 거치면서, 원래 405 로 나가야 할 응답이 Authorization 헤더를 잃은 채 재인증 필터를 타면서 **401 + `Allow: POST`** 로 오염된 응답을 반환.
- 프론트 `apiClient` 의 401 인터셉터는 이를 토큰 만료로 해석하여 `/auth/refresh` 를 호출하고, 성공 후 재시도도 같은 401 을 받으므로 `handleAuthFailure()` 경로로 빠져 `authStore.clear()` + `/login` 리다이렉트가 발생.

### 변경 내용
- `src/global/api/apiClient.ts`: 401 응답에 표준 405 시그널인 `Allow` 헤더가 있으면 refresh 루프를 건너뛰고 `ApiError(status=405)` 로 즉시 throw. 정상 401(토큰 만료) 응답은 기존 플로우 유지.
- `src/global/api/apiClient.interceptor.test.ts`: `mockResponse` 에 `headers` 옵션 추가 + Allow 헤더가 있는 401 케이스의 refresh 미호출/토큰 보존을 검증하는 테스트 추가.

### 검증
- `pnpm test --run` : 4 files / 17 tests 모두 통과 (신규 케이스 포함)
- `pnpm lint`, `pnpm typecheck`, `pnpm format:check` 통과 (pre-commit 훅에서 검증)

📚 **참고사항**

- 근본 해결은 백엔드 쪽에서 `HttpRequestMethodNotSupportedException` 을 전용 `@ExceptionHandler` 로 처리하여 405 가 401 로 오염되지 않도록 수정하는 작업이 필요 (`bandage` 레포 `fix/#58-method-not-supported-401-leak` 로 로컬 브랜치 준비됨, 별도 PR 예정).
- 이 PR 은 백엔드 수정이 배포되기 전까지의 프론트 방어, 그리고 배포 이후에도 유사 시그널에 대한 안전장치로 유지됩니다.