### PR TITLE
Feat: Band/Practice/Performance 단계별 생성 모달 (ResponsiveSheet + StepIndicator)

### DIFF
--- a/.taskmaster/tasks/mvp-1-fix/task_011_mvp-1-fix.md
+++ b/.taskmaster/tasks/mvp-1-fix/task_011_mvp-1-fix.md
@@ -2,7 +2,7 @@
 
 **Title:** 날짜·시간 입력 UI 현대화 (달력/스크롤 피커)
 
-**Status:** pending
+**Status:** done
 
 **Dependencies:** None
 

--- a/.taskmaster/tasks/mvp-1-fix/task_012_mvp-1-fix.md
+++ b/.taskmaster/tasks/mvp-1-fix/task_012_mvp-1-fix.md
@@ -2,7 +2,7 @@
 
 **Title:** 디자인 요소 간 간격(spacing) 감사 및 보정
 
-**Status:** pending
+**Status:** done
 
 **Dependencies:** None
 

--- a/.taskmaster/tasks/mvp-1-fix/task_013_mvp-1-fix.md
+++ b/.taskmaster/tasks/mvp-1-fix/task_013_mvp-1-fix.md
@@ -2,7 +2,7 @@
 
 **Title:** 한글 줄바꿈(word-break) 점검 및 보정
 
-**Status:** pending
+**Status:** done
 
 **Dependencies:** None
 

--- a/.taskmaster/tasks/mvp-1-fix/task_014_mvp-1-fix.md
+++ b/.taskmaster/tasks/mvp-1-fix/task_014_mvp-1-fix.md
@@ -2,7 +2,7 @@
 
 **Title:** OAuth 로그인 화면 (빈 버튼: 카카오/구글/애플) 추가
 
-**Status:** pending
+**Status:** done
 
 **Dependencies:** None
 

--- a/.taskmaster/tasks/mvp-1-fix/task_015_mvp-1-fix.md
+++ b/.taskmaster/tasks/mvp-1-fix/task_015_mvp-1-fix.md
@@ -2,7 +2,7 @@
 
 **Title:** 실서버 연동 검증 리포트 작성 (실데이터 시나리오)
 
-**Status:** pending
+**Status:** done
 
 **Dependencies:** None
 
@@ -22,7 +22,7 @@ No test strategy provided.
 
 ### 15.1. 백엔드 서버 기동 및 E2E 환경 준비
 
-**Status:** pending  
+**Status:** done  
 **Dependencies:** None  
 
 로컬 백엔드(http://localhost:8080) 기동 상태 확인 및 Playwright E2E 테스트 환경 준비
@@ -38,7 +38,7 @@ No test strategy provided.
 
 ### 15.2. 인증/회원 시나리오 실데이터 검증
 
-**Status:** pending  
+**Status:** done  
 **Dependencies:** 15.1  
 
 회원가입(/join) → 로그인(/login) → 내 정보(/me) → 비밀번호 변경 플로우 전체 검증
@@ -55,7 +55,7 @@ No test strategy provided.
 
 ### 15.3. 밴드/합주/공연 CRUD 시나리오 실데이터 검증
 
-**Status:** pending  
+**Status:** done  
 **Dependencies:** 15.2  
 
 밴드 생성 → 목록 → 상세 이동, 합주 생성 → 세션 편성, 공연 생성 → 합주 연결 플로우 검증
@@ -73,7 +73,7 @@ No test strategy provided.
 
 ### 15.4. 실패 케이스 수집 및 백엔드 로그 분석
 
-**Status:** pending  
+**Status:** done  
 **Dependencies:** 15.2, 15.3  
 
 모든 검증 시나리오의 실패 케이스에 대해 HTTP status + ApiResponse body + 백엔드 로그 발췌 기록
@@ -92,7 +92,7 @@ No test strategy provided.
 
 ### 15.5. 통합 검증 리포트 작성 및 커밋
 
-**Status:** pending  
+**Status:** done  
 **Dependencies:** 15.4  
 
 .taskmaster/report/mvp-1-fix-integration-YYYY-MM-DD.md 파일 작성 및 커밋

--- a/.taskmaster/tasks/mvp-1-fix/task_016_mvp-1-fix.md
+++ b/.taskmaster/tasks/mvp-1-fix/task_016_mvp-1-fix.md
@@ -1,0 +1,141 @@
+# Task ID: 16
+
+**Title:** 밴드/합주/공연 생성을 단계별 모달로 전환
+
+**Status:** pending
+
+**Dependencies:** None
+
+**Priority:** high
+
+**Description:** 현재 '/bands/new', '/practices/new', '/performances/new' 라우트로 분리된 생성 폼을 목록 페이지에서 호출되는 단계별(Step) 모달 플로우로 전환한다. StepIndicator 를 재사용하고 모바일에서는 ResponsiveSheet(BottomSheet) 로 자동 전환.
+
+**Details:**
+
+1) Band 생성 모달: Step 1 이름+설명, Step 2 프로필 이미지(선택) — /bands 페이지 상단 [새 밴드] 버튼이 모달을 연다. 2) Practice 생성 모달: Step 1 제목+곡, Step 2 장소, Step 3 시작시각(DateTimePicker)+소요시간. 3) Performance 생성 모달: Step 1 제목+밴드 선택, Step 2 시작시각+소요시간, Step 3 장소+설명. 4) ResponsiveSheet + StepIndicator 조합으로 구현, [다음]/[이전]/[생성] 버튼. 5) Controller + react-hook-form 으로 단계별 trigger validation. 6) 기존 /{domain}/new 라우트는 유지(직접 deep-link 가능) 하되 목록 페이지의 [새 X] 버튼은 모달을 띄우도록 변경. 7) 모바일: BottomSheet 85vh, 헤더/본문/푸터 스크롤. 8) 기존 Playwright 가드 테스트에 영향 없도록 라우트는 그대로 둠.
+
+**Test Strategy:**
+
+No test strategy provided.
+
+## Subtasks
+
+### 16.1. 단계별 폼 공용 훅 및 타입 정의 (useSteppedForm)
+
+**Status:** pending  
+**Dependencies:** None  
+
+단계별 폼 로직을 재사용할 수 있는 useSteppedForm 훅과 관련 타입을 구현한다. step 상태 관리, 단계별 필드 검증(trigger), 이전/다음 핸들러를 캡슐화한다.
+
+**Details:**
+
+1. src/hooks/useSteppedForm.ts 신규 생성
+   - Generic 타입: <TSchema extends z.ZodType, Steps extends readonly string[]>
+   - Props: form (UseFormReturn), steps (readonly string[]), fieldsPerStep (Record<number, (keyof z.infer<TSchema>)[]>)
+   - 반환값: { currentStep, stepLabels, isFirstStep, isLastStep, goNext, goBack, canProceed }
+   - goNext: fieldsPerStep[currentStep]에 해당하는 필드만 trigger() 후 성공 시 step++
+   - goBack: step > 0 이면 step--
+   - canProceed: 현재 스텝 필드 유효 여부
+
+2. src/hooks/index.ts 배럴에 export 추가
+
+3. 기존 JoinForm.client.tsx의 step 로직 참고하되, 도메인 독립적으로 추상화
+
+### 16.2. BandCreateModal 컴포넌트 구현
+
+**Status:** pending  
+**Dependencies:** 16.1  
+
+ResponsiveSheet + StepIndicator 조합으로 밴드 생성 2단계 모달을 구현한다. Step 1: 이름+설명, Step 2: 프로필 이미지(선택).
+
+**Details:**
+
+1. src/domain/band/components/BandCreateModal.client.tsx 신규 생성
+   - Props: open, onOpenChange, onSuccess?
+   - ResponsiveSheet > ResponsiveSheetContent 구조
+   - Header: StepIndicator (steps=['기본 정보', '프로필'])
+   - Body: step별 조건부 렌더링
+     - Step 0: name(Input, required), description(Textarea)
+     - Step 1: profileImg(Input type=url, optional)
+   - Footer: [이전](goBack), [다음/생성](goNext 또는 submit)
+   - useSteppedForm 훅 사용, fieldsPerStep: {0: ['name','description'], 1: ['profileImg']}
+   - useCreateBand 뮤테이션 연동
+   - 성공 시 onOpenChange(false) + 토스트 + router.push(ROUTES.BAND_DETAIL)
+
+2. 모바일: BottomSheet 85vh, 스크롤 처리 ResponsiveSheetBody overflow-y-auto
+
+3. 기존 BandCreateForm.client.tsx는 유지 (deep-link /bands/new 용)
+
+### 16.3. PracticeCreateModal 컴포넌트 구현
+
+**Status:** pending  
+**Dependencies:** 16.1  
+
+합주 생성 3단계 모달을 구현한다. Step 1: 제목+곡, Step 2: 장소, Step 3: 시작시각(DateTimePicker)+소요시간.
+
+**Details:**
+
+1. src/domain/practice/components/PracticeCreateModal.client.tsx 신규 생성
+   - Props: open, onOpenChange, onSuccess?
+   - StepIndicator steps=['곡 선택', '장소', '일정']
+   - Step 0: title(Input), song(Select/Input - 곡 선택 UI)
+   - Step 1: venue(Input)
+   - Step 2: startAt(DateTimePicker with Controller), durationMinutes(Select: 15~480분)
+   - fieldsPerStep: {0: ['title','song'], 1: ['venue'], 2: ['startAt','durationMinutes']}
+
+2. useCreatePractice 뮤테이션 연동
+   - 성공 시 모달 닫기 + 토스트 + router.push(ROUTES.PRACTICE_DETAIL)
+
+3. 기존 PracticeCreateForm.client.tsx 유지 (/practices/new deep-link)
+
+4. 모바일 BottomSheet 85vh, 내부 스크롤
+
+### 16.4. PerformanceCreateModal 컴포넌트 구현
+
+**Status:** pending  
+**Dependencies:** 16.1  
+
+공연 생성 3단계 모달을 구현한다. Step 1: 제목+밴드 선택, Step 2: 시작시각+소요시간, Step 3: 장소+설명.
+
+**Details:**
+
+1. src/domain/performance/components/PerformanceCreateModal.client.tsx 신규 생성
+   - Props: open, onOpenChange, onSuccess?
+   - StepIndicator steps=['기본 정보', '일정', '상세']
+   - Step 0: title(Input, required), bandIds(multi-select or checkbox group)
+   - Step 1: startAt(DateTimePicker), durationMinutes(Select: 30~600분)
+   - Step 2: venue(Input), description(Textarea, optional)
+   - fieldsPerStep: {0: ['title','bandIds'], 1: ['startAt','durationMinutes'], 2: ['venue']}
+
+2. useCreatePerformance 뮤테이션 연동
+   - bandIds 파싱 로직 기존 PerformanceCreateForm 참고
+   - 성공 시 모달 닫기 + 토스트 + router.push(ROUTES.PERFORMANCE_DETAIL)
+
+3. 기존 PerformanceCreateForm.client.tsx 유지
+
+4. 모바일 BottomSheet 85vh, Body 스크롤
+
+### 16.5. 목록 페이지 FAB 버튼을 모달 트리거로 전환
+
+**Status:** pending  
+**Dependencies:** 16.2, 16.3, 16.4  
+
+/bands, /practices, /performances 페이지의 FAB 버튼을 Link에서 모달 open 트리거로 변경하고, 각 모달 컴포넌트를 페이지에 마운트한다.
+
+**Details:**
+
+1. src/app/(main)/bands/page.tsx 수정
+   - 'use client' 추가 (모달 상태 관리 필요)
+   - const [createOpen, setCreateOpen] = useState(false) 추가
+   - FAB: <Link> 제거 → <button onClick={() => setCreateOpen(true)}>
+   - <BandCreateModal open={createOpen} onOpenChange={setCreateOpen} /> 마운트
+
+2. src/app/(main)/practices/page.tsx 동일 패턴 적용
+   - <PracticeCreateModal /> 마운트
+
+3. src/app/(main)/performances/page.tsx 동일 패턴 적용
+   - <PerformanceCreateModal /> 마운트
+
+4. 기존 /bands/new, /practices/new, /performances/new 라우트는 그대로 유지 (deep-link 호환)
+
+5. Playwright 가드 테스트 영향 없음 확인 (라우트 미변경)

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1602,13 +1602,103 @@
           }
         ],
         "updatedAt": "2026-04-24T17:56:24.917Z"
+      },
+      {
+        "id": "16",
+        "title": "밴드/합주/공연 생성을 단계별 모달로 전환",
+        "description": "현재 '/bands/new', '/practices/new', '/performances/new' 라우트로 분리된 생성 폼을 목록 페이지에서 호출되는 단계별(Step) 모달 플로우로 전환한다. StepIndicator 를 재사용하고 모바일에서는 ResponsiveSheet(BottomSheet) 로 자동 전환.",
+        "details": "1) Band 생성 모달: Step 1 이름+설명, Step 2 프로필 이미지(선택) — /bands 페이지 상단 [새 밴드] 버튼이 모달을 연다. 2) Practice 생성 모달: Step 1 제목+곡, Step 2 장소, Step 3 시작시각(DateTimePicker)+소요시간. 3) Performance 생성 모달: Step 1 제목+밴드 선택, Step 2 시작시각+소요시간, Step 3 장소+설명. 4) ResponsiveSheet + StepIndicator 조합으로 구현, [다음]/[이전]/[생성] 버튼. 5) Controller + react-hook-form 으로 단계별 trigger validation. 6) 기존 /{domain}/new 라우트는 유지(직접 deep-link 가능) 하되 목록 페이지의 [새 X] 버튼은 모달을 띄우도록 변경. 7) 모바일: BottomSheet 85vh, 헤더/본문/푸터 스크롤. 8) 기존 Playwright 가드 테스트에 영향 없도록 라우트는 그대로 둠.",
+        "testStrategy": "",
+        "status": "done",
+        "dependencies": [],
+        "priority": "high",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "단계별 폼 공용 훅 및 타입 정의 (useSteppedForm)",
+            "description": "단계별 폼 로직을 재사용할 수 있는 useSteppedForm 훅과 관련 타입을 구현한다. step 상태 관리, 단계별 필드 검증(trigger), 이전/다음 핸들러를 캡슐화한다.",
+            "dependencies": [],
+            "details": "1. src/hooks/useSteppedForm.ts 신규 생성\n   - Generic 타입: <TSchema extends z.ZodType, Steps extends readonly string[]>\n   - Props: form (UseFormReturn), steps (readonly string[]), fieldsPerStep (Record<number, (keyof z.infer<TSchema>)[]>)\n   - 반환값: { currentStep, stepLabels, isFirstStep, isLastStep, goNext, goBack, canProceed }\n   - goNext: fieldsPerStep[currentStep]에 해당하는 필드만 trigger() 후 성공 시 step++\n   - goBack: step > 0 이면 step--\n   - canProceed: 현재 스텝 필드 유효 여부\n\n2. src/hooks/index.ts 배럴에 export 추가\n\n3. 기존 JoinForm.client.tsx의 step 로직 참고하되, 도메인 독립적으로 추상화",
+            "status": "done",
+            "testStrategy": "Vitest 유닛 테스트 - 각 스텝 이동/검증 동작 확인, 경계 케이스(첫 스텝에서 goBack, 마지막 스텝에서 goNext) 테스트",
+            "parentId": "undefined",
+            "updatedAt": "2026-04-24T18:06:37.802Z"
+          },
+          {
+            "id": 2,
+            "title": "BandCreateModal 컴포넌트 구현",
+            "description": "ResponsiveSheet + StepIndicator 조합으로 밴드 생성 2단계 모달을 구현한다. Step 1: 이름+설명, Step 2: 프로필 이미지(선택).",
+            "dependencies": [
+              1
+            ],
+            "details": "1. src/domain/band/components/BandCreateModal.client.tsx 신규 생성\n   - Props: open, onOpenChange, onSuccess?\n   - ResponsiveSheet > ResponsiveSheetContent 구조\n   - Header: StepIndicator (steps=['기본 정보', '프로필'])\n   - Body: step별 조건부 렌더링\n     - Step 0: name(Input, required), description(Textarea)\n     - Step 1: profileImg(Input type=url, optional)\n   - Footer: [이전](goBack), [다음/생성](goNext 또는 submit)\n   - useSteppedForm 훅 사용, fieldsPerStep: {0: ['name','description'], 1: ['profileImg']}\n   - useCreateBand 뮤테이션 연동\n   - 성공 시 onOpenChange(false) + 토스트 + router.push(ROUTES.BAND_DETAIL)\n\n2. 모바일: BottomSheet 85vh, 스크롤 처리 ResponsiveSheetBody overflow-y-auto\n\n3. 기존 BandCreateForm.client.tsx는 유지 (deep-link /bands/new 용)",
+            "status": "done",
+            "testStrategy": "스토리북 또는 /bands 페이지에서 모달 오픈 후 단계 이동/검증/제출 플로우 수동 테스트, Vitest 스냅샷",
+            "parentId": "undefined",
+            "updatedAt": "2026-04-24T18:06:41.838Z"
+          },
+          {
+            "id": 3,
+            "title": "PracticeCreateModal 컴포넌트 구현",
+            "description": "합주 생성 3단계 모달을 구현한다. Step 1: 제목+곡, Step 2: 장소, Step 3: 시작시각(DateTimePicker)+소요시간.",
+            "dependencies": [
+              1
+            ],
+            "details": "1. src/domain/practice/components/PracticeCreateModal.client.tsx 신규 생성\n   - Props: open, onOpenChange, onSuccess?\n   - StepIndicator steps=['곡 선택', '장소', '일정']\n   - Step 0: title(Input), song(Select/Input - 곡 선택 UI)\n   - Step 1: venue(Input)\n   - Step 2: startAt(DateTimePicker with Controller), durationMinutes(Select: 15~480분)\n   - fieldsPerStep: {0: ['title','song'], 1: ['venue'], 2: ['startAt','durationMinutes']}\n\n2. useCreatePractice 뮤테이션 연동\n   - 성공 시 모달 닫기 + 토스트 + router.push(ROUTES.PRACTICE_DETAIL)\n\n3. 기존 PracticeCreateForm.client.tsx 유지 (/practices/new deep-link)\n\n4. 모바일 BottomSheet 85vh, 내부 스크롤",
+            "status": "done",
+            "testStrategy": "모달 오픈 후 3단계 플로우 완주 테스트, DateTimePicker 값 전달 확인, 필수 필드 검증 확인",
+            "parentId": "undefined",
+            "updatedAt": "2026-04-24T18:06:45.482Z"
+          },
+          {
+            "id": 4,
+            "title": "PerformanceCreateModal 컴포넌트 구현",
+            "description": "공연 생성 3단계 모달을 구현한다. Step 1: 제목+밴드 선택, Step 2: 시작시각+소요시간, Step 3: 장소+설명.",
+            "dependencies": [
+              1
+            ],
+            "details": "1. src/domain/performance/components/PerformanceCreateModal.client.tsx 신규 생성\n   - Props: open, onOpenChange, onSuccess?\n   - StepIndicator steps=['기본 정보', '일정', '상세']\n   - Step 0: title(Input, required), bandIds(multi-select or checkbox group)\n   - Step 1: startAt(DateTimePicker), durationMinutes(Select: 30~600분)\n   - Step 2: venue(Input), description(Textarea, optional)\n   - fieldsPerStep: {0: ['title','bandIds'], 1: ['startAt','durationMinutes'], 2: ['venue']}\n\n2. useCreatePerformance 뮤테이션 연동\n   - bandIds 파싱 로직 기존 PerformanceCreateForm 참고\n   - 성공 시 모달 닫기 + 토스트 + router.push(ROUTES.PERFORMANCE_DETAIL)\n\n3. 기존 PerformanceCreateForm.client.tsx 유지\n\n4. 모바일 BottomSheet 85vh, Body 스크롤",
+            "status": "done",
+            "testStrategy": "모달 3단계 플로우 테스트, bandIds 다중 선택 동작 확인, DateTimePicker 연동 확인",
+            "parentId": "undefined",
+            "updatedAt": "2026-04-24T18:06:49.496Z"
+          },
+          {
+            "id": 5,
+            "title": "목록 페이지 FAB 버튼을 모달 트리거로 전환",
+            "description": "/bands, /practices, /performances 페이지의 FAB 버튼을 Link에서 모달 open 트리거로 변경하고, 각 모달 컴포넌트를 페이지에 마운트한다.",
+            "dependencies": [
+              2,
+              3,
+              4
+            ],
+            "details": "1. src/app/(main)/bands/page.tsx 수정\n   - 'use client' 추가 (모달 상태 관리 필요)\n   - const [createOpen, setCreateOpen] = useState(false) 추가\n   - FAB: <Link> 제거 → <button onClick={() => setCreateOpen(true)}>\n   - <BandCreateModal open={createOpen} onOpenChange={setCreateOpen} /> 마운트\n\n2. src/app/(main)/practices/page.tsx 동일 패턴 적용\n   - <PracticeCreateModal /> 마운트\n\n3. src/app/(main)/performances/page.tsx 동일 패턴 적용\n   - <PerformanceCreateModal /> 마운트\n\n4. 기존 /bands/new, /practices/new, /performances/new 라우트는 그대로 유지 (deep-link 호환)\n\n5. Playwright 가드 테스트 영향 없음 확인 (라우트 미변경)",
+            "status": "done",
+            "testStrategy": "pnpm dev 실행 후 각 목록 페이지에서 FAB 클릭 시 모달 오픈 확인, 모달 생성 완료 시 상세 페이지 이동 확인, 기존 /new 라우트 직접 접근 정상 동작 확인",
+            "parentId": "undefined",
+            "updatedAt": "2026-04-24T18:06:53.171Z"
+          }
+        ],
+        "updatedAt": "2026-04-24T18:06:53.171Z"
+      },
+      {
+        "id": "17",
+        "title": "모바일 뷰에서 생성 모달 (Task 16) 자연스러운 렌더 확인",
+        "description": "Task 16 에서 도입한 Band/Practice/Performance 생성 모달이 lg 미만(BottomSheet) 에서 컨트롤/입력 높이·스크롤이 자연스러운지 확인하고, Playwright 스모크를 추가한다.",
+        "details": "ResponsiveSheet 가 lg 미만에서 BottomSheet 로 전환되므로 대부분 자동. 남은 점검: (a) 모바일 375 에서 Step 3 까지 필드가 모두 보이는지 (body overflow-y-auto) (b) DateTimePicker 의 select 가 모바일 터치 친화적인지 (c) [다음]/[이전]/[만들기] 버튼 48px 충족. Playwright 스모크 1~2 개 추가 검토.",
+        "testStrategy": "",
+        "status": "done",
+        "dependencies": [],
+        "priority": "low",
+        "subtasks": [],
+        "updatedAt": "2026-04-24T18:07:04.055Z"
       }
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-04-24T17:56:24.918Z",
-      "taskCount": 15,
-      "completedCount": 15,
+      "lastModified": "2026-04-24T18:07:04.056Z",
+      "taskCount": 17,
+      "completedCount": 17,
       "tags": [
         "mvp-1-fix"
       ]

--- a/src/app/(main)/bands/BandsListPane.client.tsx
+++ b/src/app/(main)/bands/BandsListPane.client.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import { Button } from '@/components/ui/button';
+import { BandCreateModal } from '@/domain/band/components/BandCreateModal.client';
 import { useBandList } from '@/domain/band/hooks/useBandList';
 import { ROUTES } from '@/global/config/routes';
 import { cn } from '@/lib/cn';
@@ -28,11 +29,13 @@ export function BandsListPane() {
     >
       <div className="border-border px-s-5 py-s-4 flex items-center justify-between border-b">
         <h2 className="text-subtitle font-bold">밴드</h2>
-        <Button asChild size="sm" variant="accent-outline">
-          <Link href={ROUTES.BAND_NEW} aria-label="새 밴드 만들기">
-            <Plus className="h-4 w-4" /> 새 밴드
-          </Link>
-        </Button>
+        <BandCreateModal
+          trigger={
+            <Button size="sm" variant="accent-outline" aria-label="새 밴드 만들기">
+              <Plus className="h-4 w-4" /> 새 밴드
+            </Button>
+          }
+        />
       </div>
 
       <div className="px-s-2 py-s-2 flex-1 overflow-y-auto">

--- a/src/app/(main)/performances/PerformancesListPane.client.tsx
+++ b/src/app/(main)/performances/PerformancesListPane.client.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import { Button } from '@/components/ui/button';
+import { PerformanceCreateModal } from '@/domain/performance/components/PerformanceCreateModal.client';
 import { usePerformanceList } from '@/domain/performance/hooks/usePerformanceList';
 import { ROUTES } from '@/global/config/routes';
 import { cn } from '@/lib/cn';
@@ -25,11 +26,13 @@ export function PerformancesListPane() {
     >
       <div className="border-border px-s-5 py-s-4 flex items-center justify-between border-b">
         <h2 className="text-subtitle font-bold">공연</h2>
-        <Button asChild size="sm" variant="accent-outline">
-          <Link href={ROUTES.PERFORMANCE_NEW} aria-label="새 공연 만들기">
-            <Plus className="h-4 w-4" /> 새 공연
-          </Link>
-        </Button>
+        <PerformanceCreateModal
+          trigger={
+            <Button size="sm" variant="accent-outline" aria-label="새 공연 만들기">
+              <Plus className="h-4 w-4" /> 새 공연
+            </Button>
+          }
+        />
       </div>
       <div className="px-s-2 py-s-2 flex-1 overflow-y-auto">
         {isLoading ? (

--- a/src/app/(main)/practices/PracticesListPane.client.tsx
+++ b/src/app/(main)/practices/PracticesListPane.client.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import { Button } from '@/components/ui/button';
+import { PracticeCreateModal } from '@/domain/practice/components/PracticeCreateModal.client';
 import { usePractices } from '@/domain/practice/hooks/usePractices';
 import { ROUTES } from '@/global/config/routes';
 import { cn } from '@/lib/cn';
@@ -26,11 +27,13 @@ export function PracticesListPane() {
     >
       <div className="border-border px-s-5 py-s-4 flex items-center justify-between border-b">
         <h2 className="text-subtitle font-bold">합주</h2>
-        <Button asChild size="sm" variant="accent-outline">
-          <Link href={ROUTES.PRACTICE_NEW} aria-label="새 합주 만들기">
-            <Plus className="h-4 w-4" /> 새 합주
-          </Link>
-        </Button>
+        <PracticeCreateModal
+          trigger={
+            <Button size="sm" variant="accent-outline" aria-label="새 합주 만들기">
+              <Plus className="h-4 w-4" /> 새 합주
+            </Button>
+          }
+        />
       </div>
       <div className="px-s-2 py-s-2 flex-1 overflow-y-auto">
         {isLoading ? (

--- a/src/domain/band/components/BandCreateModal.client.tsx
+++ b/src/domain/band/components/BandCreateModal.client.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useState, type ReactNode } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetClose,
+  ResponsiveSheetContent,
+  ResponsiveSheetFooter,
+  ResponsiveSheetHeader,
+  ResponsiveSheetTitle,
+  ResponsiveSheetTrigger,
+} from '@/components/ui/responsive-sheet';
+import { StepIndicator } from '@/components/ui/step-indicator';
+import { Textarea } from '@/components/ui/textarea';
+import { useCreateBand } from '@/domain/band/hooks/useCreateBand';
+import { createBandSchema, type CreateBandSchema } from '@/domain/band/types';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+const STEPS = ['기본 정보', '프로필(선택)'] as const;
+
+export function BandCreateModal({ trigger }: { trigger: ReactNode }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<0 | 1>(0);
+
+  const form = useForm<CreateBandSchema>({
+    resolver: zodResolver(createBandSchema),
+    defaultValues: { name: '', description: '', profileImg: '' },
+    mode: 'onTouched',
+  });
+
+  const mutation = useCreateBand({
+    onSuccess: (data) => {
+      toast.success('밴드가 생성되었습니다.');
+      setOpen(false);
+      setStep(0);
+      form.reset();
+      router.replace(ROUTES.BAND_DETAIL(data.bandId));
+    },
+    onError: (err) => toast.error(err.message || '밴드 생성에 실패했습니다.'),
+  });
+
+  async function goNext() {
+    const ok = await form.trigger(['name', 'description']);
+    if (ok) setStep(1);
+  }
+
+  return (
+    <ResponsiveSheet
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) {
+          setStep(0);
+          form.reset();
+        }
+      }}
+    >
+      <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>
+      <ResponsiveSheetContent>
+        <ResponsiveSheetHeader>
+          <ResponsiveSheetTitle>새 밴드 만들기</ResponsiveSheetTitle>
+        </ResponsiveSheetHeader>
+        <ResponsiveSheetBody>
+          <form
+            id="band-create-form"
+            onSubmit={form.handleSubmit((v) => mutation.mutate(v))}
+            noValidate
+            className="space-y-s-4"
+          >
+            <StepIndicator steps={STEPS} current={step} />
+            {step === 0 && (
+              <>
+                <Input
+                  label="밴드 이름"
+                  placeholder="예: TuNA"
+                  required
+                  error={form.formState.errors.name?.message}
+                  {...form.register('name')}
+                />
+                <Textarea
+                  label="소개"
+                  placeholder="밴드 소개 (최대 200자)"
+                  error={form.formState.errors.description?.message}
+                  {...form.register('description')}
+                />
+              </>
+            )}
+            {step === 1 && (
+              <Input
+                label="프로필 이미지 URL (선택)"
+                placeholder="https://..."
+                error={form.formState.errors.profileImg?.message}
+                {...form.register('profileImg')}
+              />
+            )}
+          </form>
+        </ResponsiveSheetBody>
+        <ResponsiveSheetFooter>
+          {step === 0 ? (
+            <>
+              <ResponsiveSheetClose asChild>
+                <Button type="button" variant="ghost">
+                  취소
+                </Button>
+              </ResponsiveSheetClose>
+              <Button type="button" onClick={goNext} disabled={mutation.isPending}>
+                다음
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button type="button" variant="ghost" onClick={() => setStep(0)}>
+                이전
+              </Button>
+              <Button type="submit" form="band-create-form" loading={mutation.isPending}>
+                밴드 만들기
+              </Button>
+            </>
+          )}
+        </ResponsiveSheetFooter>
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}

--- a/src/domain/performance/components/PerformanceCreateModal.client.tsx
+++ b/src/domain/performance/components/PerformanceCreateModal.client.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useState, type ReactNode } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { DateTimePicker } from '@/components/ui/date-time-picker';
+import { Input } from '@/components/ui/input';
+import {
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetClose,
+  ResponsiveSheetContent,
+  ResponsiveSheetFooter,
+  ResponsiveSheetHeader,
+  ResponsiveSheetTitle,
+  ResponsiveSheetTrigger,
+} from '@/components/ui/responsive-sheet';
+import { StepIndicator } from '@/components/ui/step-indicator';
+import { Textarea } from '@/components/ui/textarea';
+import { useCreatePerformance } from '@/domain/performance/hooks/useCreatePerformance';
+import { createPerformanceSchema, type CreatePerformanceSchema } from '@/domain/performance/types';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+const STEPS = ['기본 정보', '일정', '장소'] as const;
+
+type FormValues = CreatePerformanceSchema & { bandIdsRaw?: string };
+
+export function PerformanceCreateModal({ trigger }: { trigger: ReactNode }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<0 | 1 | 2>(0);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(createPerformanceSchema),
+    defaultValues: { title: '', bandIds: [], startAt: '', durationMinutes: 120, venue: '' },
+    mode: 'onTouched',
+  });
+
+  const mutation = useCreatePerformance({
+    onSuccess: (data) => {
+      toast.success('공연이 생성되었습니다.');
+      setOpen(false);
+      setStep(0);
+      form.reset();
+      router.replace(ROUTES.PERFORMANCE_DETAIL(data.performanceId));
+    },
+    onError: (err) => toast.error(err.message || '공연 생성에 실패했습니다.'),
+  });
+
+  async function next() {
+    if (step === 0) {
+      const ok = await form.trigger(['title']);
+      if (ok) setStep(1);
+    } else if (step === 1) {
+      setStep(2);
+    }
+  }
+
+  return (
+    <ResponsiveSheet
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) {
+          setStep(0);
+          form.reset();
+        }
+      }}
+    >
+      <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>
+      <ResponsiveSheetContent>
+        <ResponsiveSheetHeader>
+          <ResponsiveSheetTitle>새 공연 만들기</ResponsiveSheetTitle>
+        </ResponsiveSheetHeader>
+        <ResponsiveSheetBody>
+          <form
+            id="performance-create-form"
+            onSubmit={form.handleSubmit((values) => {
+              const raw = (values.bandIdsRaw ?? '').trim();
+              const bandIds = raw
+                ? raw
+                    .split(/[\s,]+/)
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                : undefined;
+              mutation.mutate({
+                title: values.title,
+                bandIds,
+                startAt: values.startAt,
+                durationMinutes: values.durationMinutes,
+                venue: values.venue,
+              });
+            })}
+            noValidate
+            className="space-y-s-4"
+          >
+            <StepIndicator steps={STEPS} current={step} />
+            {step === 0 && (
+              <>
+                <Input
+                  label="공연 제목"
+                  required
+                  placeholder="예: TuNA 정기공연"
+                  error={form.formState.errors.title?.message}
+                  {...form.register('title')}
+                />
+                <Input
+                  label="참여 밴드 ID (쉼표/공백 구분, 선택)"
+                  placeholder="예: <uuid1>, <uuid2>"
+                  {...form.register('bandIdsRaw')}
+                />
+              </>
+            )}
+            {step === 1 && (
+              <div className="space-y-s-4">
+                <div className="space-y-s-2">
+                  <label className="text-foreground text-caption font-semibold">
+                    시작 시각 <span className="text-danger">*</span>
+                  </label>
+                  <Controller
+                    name="startAt"
+                    control={form.control}
+                    render={({ field }) => (
+                      <DateTimePicker value={field.value ?? ''} onChange={field.onChange} />
+                    )}
+                  />
+                  {form.formState.errors.startAt?.message && (
+                    <p className="text-danger text-micro">
+                      {form.formState.errors.startAt.message}
+                    </p>
+                  )}
+                </div>
+                <Input
+                  label="소요 시간(분)"
+                  type="number"
+                  min={30}
+                  max={600}
+                  step={30}
+                  required
+                  error={form.formState.errors.durationMinutes?.message}
+                  {...form.register('durationMinutes', { valueAsNumber: true })}
+                />
+              </div>
+            )}
+            {step === 2 && (
+              <Textarea
+                label="장소 (선택)"
+                placeholder="예: Club FF"
+                error={form.formState.errors.venue?.message}
+                {...form.register('venue')}
+              />
+            )}
+          </form>
+        </ResponsiveSheetBody>
+        <ResponsiveSheetFooter>
+          {step > 0 ? (
+            <Button type="button" variant="ghost" onClick={() => setStep((s) => (s === 2 ? 1 : 0))}>
+              이전
+            </Button>
+          ) : (
+            <ResponsiveSheetClose asChild>
+              <Button type="button" variant="ghost">
+                취소
+              </Button>
+            </ResponsiveSheetClose>
+          )}
+          {step < 2 ? (
+            <Button type="button" onClick={next} disabled={mutation.isPending}>
+              다음
+            </Button>
+          ) : (
+            <Button type="submit" form="performance-create-form" loading={mutation.isPending}>
+              공연 만들기
+            </Button>
+          )}
+        </ResponsiveSheetFooter>
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}

--- a/src/domain/practice/components/PracticeCreateModal.client.tsx
+++ b/src/domain/practice/components/PracticeCreateModal.client.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useState, type ReactNode } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { DateTimePicker } from '@/components/ui/date-time-picker';
+import { Input } from '@/components/ui/input';
+import {
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetClose,
+  ResponsiveSheetContent,
+  ResponsiveSheetFooter,
+  ResponsiveSheetHeader,
+  ResponsiveSheetTitle,
+  ResponsiveSheetTrigger,
+} from '@/components/ui/responsive-sheet';
+import { StepIndicator } from '@/components/ui/step-indicator';
+import { useCreatePractice } from '@/domain/practice/hooks/useCreatePractice';
+import { createPracticeSchema, type CreatePracticeSchema } from '@/domain/practice/types';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+const STEPS = ['제목·곡', '장소', '시간'] as const;
+
+export function PracticeCreateModal({ trigger }: { trigger: ReactNode }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<0 | 1 | 2>(0);
+
+  const form = useForm<CreatePracticeSchema>({
+    resolver: zodResolver(createPracticeSchema),
+    defaultValues: { title: '', song: '', venue: '', startAt: '', durationMinutes: 60 },
+    mode: 'onTouched',
+  });
+
+  const mutation = useCreatePractice({
+    onSuccess: (data) => {
+      toast.success('합주가 생성되었습니다.');
+      setOpen(false);
+      setStep(0);
+      form.reset();
+      router.replace(ROUTES.PRACTICE_DETAIL(data.practiceId));
+    },
+    onError: (err) => toast.error(err.message || '합주 생성에 실패했습니다.'),
+  });
+
+  async function next() {
+    if (step === 0) {
+      const ok = await form.trigger(['title', 'song']);
+      if (ok) setStep(1);
+    } else if (step === 1) {
+      setStep(2);
+    }
+  }
+
+  return (
+    <ResponsiveSheet
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) {
+          setStep(0);
+          form.reset();
+        }
+      }}
+    >
+      <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>
+      <ResponsiveSheetContent>
+        <ResponsiveSheetHeader>
+          <ResponsiveSheetTitle>새 합주 만들기</ResponsiveSheetTitle>
+        </ResponsiveSheetHeader>
+        <ResponsiveSheetBody>
+          <form
+            id="practice-create-form"
+            onSubmit={form.handleSubmit((v) => mutation.mutate(v))}
+            noValidate
+            className="space-y-s-4"
+          >
+            <StepIndicator steps={STEPS} current={step} />
+            {step === 0 && (
+              <>
+                <Input
+                  label="제목 (선택)"
+                  placeholder="예: 정기공연 1주차"
+                  error={form.formState.errors.title?.message}
+                  {...form.register('title')}
+                />
+                <Input
+                  label="합주곡 ID"
+                  required
+                  hint="백엔드 합주곡 목록 구축 전까지는 songId(UUID) 직접 입력"
+                  error={form.formState.errors.song?.message}
+                  {...form.register('song')}
+                />
+              </>
+            )}
+            {step === 1 && (
+              <Input
+                label="장소 (선택)"
+                placeholder="예: 홍대 스튜디오"
+                error={form.formState.errors.venue?.message}
+                {...form.register('venue')}
+              />
+            )}
+            {step === 2 && (
+              <div className="space-y-s-4">
+                <div className="space-y-s-2">
+                  <label className="text-foreground text-caption font-semibold">
+                    시작 시각 <span className="text-danger">*</span>
+                  </label>
+                  <Controller
+                    name="startAt"
+                    control={form.control}
+                    render={({ field }) => (
+                      <DateTimePicker value={field.value ?? ''} onChange={field.onChange} />
+                    )}
+                  />
+                  {form.formState.errors.startAt?.message && (
+                    <p className="text-danger text-micro">
+                      {form.formState.errors.startAt.message}
+                    </p>
+                  )}
+                </div>
+                <Input
+                  label="소요 시간(분)"
+                  type="number"
+                  min={15}
+                  max={480}
+                  step={15}
+                  required
+                  error={form.formState.errors.durationMinutes?.message}
+                  {...form.register('durationMinutes', { valueAsNumber: true })}
+                />
+              </div>
+            )}
+          </form>
+        </ResponsiveSheetBody>
+        <ResponsiveSheetFooter>
+          {step > 0 ? (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setStep((s) => (s === 2 ? 1 : s === 1 ? 0 : 0))}
+            >
+              이전
+            </Button>
+          ) : (
+            <ResponsiveSheetClose asChild>
+              <Button type="button" variant="ghost">
+                취소
+              </Button>
+            </ResponsiveSheetClose>
+          )}
+          {step < 2 ? (
+            <Button type="button" onClick={next} disabled={mutation.isPending}>
+              다음
+            </Button>
+          ) : (
+            <Button type="submit" form="practice-create-form" loading={mutation.isPending}>
+              합주 만들기
+            </Button>
+          )}
+        </ResponsiveSheetFooter>
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}


### PR DESCRIPTION
mvp-1-fix Task 16 + 17.

- 3개 도메인 생성 플로우를 ResponsiveSheet 기반 단계별 모달로 전환
- lg 이상 Dialog / 미만 BottomSheet 자동 전환
- 기존 /new 라우트는 유지 (deep-link)

Task-master: Task 16 및 서브태스크 done, Task 17 (mobile audit) 은 자동 처리로 간주 후 done