### PR TITLE
design: IconTile 컴포넌트 및 도메인 아이콘 매핑 추가 (Task 1)

### DIFF
--- a/src/components/ui/__snapshots__/icon-tile.test.tsx.snap
+++ b/src/components/ui/__snapshots__/icon-tile.test.tsx.snap
@@ -1,0 +1,77 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`IconTile > size lg + tone amber 조합 클래스를 반영한다 1`] = `
+<DocumentFragment>
+  <span
+    aria-hidden="true"
+    class="inline-flex shrink-0 items-center justify-center transition-colors h-14 w-14 rounded-[14px] [&>svg]:h-[22px] [&>svg]:w-[22px] bg-amber-dim text-amber"
+    data-slot="icon-tile"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-music"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 18V5l12-2v13"
+      />
+      <circle
+        cx="6"
+        cy="18"
+        r="3"
+      />
+      <circle
+        cx="18"
+        cy="16"
+        r="3"
+      />
+    </svg>
+  </span>
+</DocumentFragment>
+`;
+
+exports[`IconTile > 기본 렌더는 md/accent 변형을 반영한다 1`] = `
+<DocumentFragment>
+  <span
+    aria-hidden="true"
+    class="inline-flex shrink-0 items-center justify-center transition-colors h-10 w-10 rounded-md [&>svg]:h-[18px] [&>svg]:w-[18px] bg-accent-dim text-accent"
+    data-slot="icon-tile"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-music"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 18V5l12-2v13"
+      />
+      <circle
+        cx="6"
+        cy="18"
+        r="3"
+      />
+      <circle
+        cx="18"
+        cy="16"
+        r="3"
+      />
+    </svg>
+  </span>
+</DocumentFragment>
+`;

--- a/src/components/ui/icon-tile.test.tsx
+++ b/src/components/ui/icon-tile.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import { Music } from 'lucide-react';
+import { describe, expect, it } from 'vitest';
+
+import { IconTile } from './icon-tile';
+
+describe('IconTile', () => {
+  it('기본 렌더는 md/accent 변형을 반영한다', () => {
+    const { asFragment } = render(<IconTile icon={<Music />} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('size lg + tone amber 조합 클래스를 반영한다', () => {
+    const { asFragment } = render(<IconTile icon={<Music />} size="lg" tone="amber" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('aria-hidden 속성과 data-slot 가 부여된다', () => {
+    const { container } = render(<IconTile icon={<Music />} />);
+    const tile = container.querySelector('[data-slot="icon-tile"]');
+    expect(tile).not.toBeNull();
+    expect(tile).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('className prop 이 병합된다', () => {
+    const { container } = render(<IconTile icon={<Music />} className="custom-cls" />);
+    const tile = container.querySelector('[data-slot="icon-tile"]');
+    expect(tile?.className).toContain('custom-cls');
+  });
+});

--- a/src/components/ui/icon-tile.tsx
+++ b/src/components/ui/icon-tile.tsx
@@ -1,0 +1,50 @@
+import { type HTMLAttributes, type ReactNode } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export type IconTileSize = 'sm' | 'md' | 'lg';
+export type IconTileTone = 'accent' | 'success' | 'amber' | 'warn' | 'card';
+
+export interface IconTileProps extends HTMLAttributes<HTMLSpanElement> {
+  icon: ReactNode;
+  size?: IconTileSize;
+  tone?: IconTileTone;
+}
+
+const sizeClasses: Record<IconTileSize, string> = {
+  sm: 'h-8 w-8 rounded-sm [&>svg]:h-3.5 [&>svg]:w-3.5',
+  md: 'h-10 w-10 rounded-md [&>svg]:h-[18px] [&>svg]:w-[18px]',
+  lg: 'h-14 w-14 rounded-[14px] [&>svg]:h-[22px] [&>svg]:w-[22px]',
+};
+
+const toneClasses: Record<IconTileTone, string> = {
+  accent: 'bg-accent-dim text-accent',
+  success: 'bg-success-dim text-success',
+  amber: 'bg-amber-dim text-amber',
+  warn: 'bg-warn-dim text-warn',
+  card: 'bg-card text-foreground-sub',
+};
+
+export function IconTile({
+  icon,
+  size = 'md',
+  tone = 'accent',
+  className,
+  ...props
+}: IconTileProps) {
+  return (
+    <span
+      data-slot="icon-tile"
+      aria-hidden="true"
+      className={cn(
+        'inline-flex shrink-0 items-center justify-center transition-colors',
+        sizeClasses[size],
+        toneClasses[tone],
+        className,
+      )}
+      {...props}
+    >
+      {icon}
+    </span>
+  );
+}

--- a/src/lib/domain-icons.tsx
+++ b/src/lib/domain-icons.tsx
@@ -1,0 +1,17 @@
+import { Clock3, Guitar, Music2, type LucideIcon } from 'lucide-react';
+
+import type { IconTileTone } from '@/components/ui/icon-tile';
+
+export type DomainType = 'band' | 'practice' | 'performance';
+
+export const DOMAIN_ICONS: Record<DomainType, LucideIcon> = {
+  band: Guitar,
+  practice: Clock3,
+  performance: Music2,
+};
+
+export const DOMAIN_TONES: Record<DomainType, IconTileTone> = {
+  band: 'accent',
+  practice: 'success',
+  performance: 'amber',
+};


### PR DESCRIPTION
## Summary

- design/dist/css/components.css 의 `.icon-tile` 토큰을 Tailwind 컴포넌트로 이식
- `src/lib/domain-icons.tsx` — band/practice/performance 아이콘+톤 매핑 단일 소스
- `src/components/ui/icon-tile.tsx` — size(sm/md/lg) × tone(accent/success/amber/warn/card)
- `data-slot="icon-tile"` + `aria-hidden="true"` 부여

## Background

mvp-1-fix-v2 Phase A: 모든 후속 phase(B 카드 우측 아이콘, C 홈 카드, D 밴드 상세 통계 카드, F DateTimePicker chip 등)가 IconTile 위에 올라갑니다.

## Linked Issues

Closes #61

## Test plan

- [x] `pnpm test` 48 passed
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] icon-tile.test.tsx 스냅샷(default + lg/amber) + aria-hidden + className 병합 검증