### PR TITLE
design: 카드/리스트 좌측 IconTile + list-item hover/selected (Task 2)

### DIFF
--- a/src/app/(main)/bands/BandsListPane.client.tsx
+++ b/src/app/(main)/bands/BandsListPane.client.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { IconTile } from '@/components/ui/icon-tile';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BandCreateModal } from '@/domain/band/components/BandCreateModal.client';
 import { useBandList } from '@/domain/band/hooks/useBandList';
@@ -13,7 +14,10 @@ import { useMyBands } from '@/domain/band/hooks/useMyBands';
 import type { BandInfoResponse } from '@/domain/band/types';
 import { ROUTES } from '@/global/config/routes';
 import { useDiscoverySearch } from '@/hooks/useDiscoverySearch';
-import { cn } from '@/lib/cn';
+import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
+import { listItemClasses } from '@/lib/list-item-styles';
+
+const BandIcon = DOMAIN_ICONS.band;
 
 const accessor = (b: BandInfoResponse) => `${b.bandName} ${b.description ?? ''}`;
 
@@ -27,19 +31,22 @@ function BandRow({ band, pathname }: { band: BandInfoResponse; pathname: string 
       <Link
         href={href}
         aria-current={active ? 'page' : undefined}
-        className={cn(
-          'px-s-3 py-s-3 block rounded-md transition-colors',
-          active
-            ? 'bg-accent-dim text-accent'
-            : 'hover:bg-card text-foreground-sub hover:text-foreground',
+        data-slot="band-row"
+        className={listItemClasses(
+          active,
+          DOMAIN_LIST_SELECTED_TONES.band,
+          'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
         )}
       >
-        <div className="text-body truncate font-semibold">{band.bandName}</div>
-        {band.description && (
-          <div className="text-foreground-muted text-caption mt-0.5 truncate">
-            {band.description}
-          </div>
-        )}
+        <IconTile icon={<BandIcon />} size="sm" tone={DOMAIN_TONES.band} />
+        <div className="min-w-0 flex-1">
+          <div className="text-body truncate font-semibold">{band.bandName}</div>
+          {band.description && (
+            <div className="text-foreground-muted text-caption mt-0.5 truncate">
+              {band.description}
+            </div>
+          )}
+        </div>
       </Link>
     </li>
   );

--- a/src/app/(main)/performances/PerformancesListPane.client.tsx
+++ b/src/app/(main)/performances/PerformancesListPane.client.tsx
@@ -6,13 +6,17 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { IconTile } from '@/components/ui/icon-tile';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { PerformanceCreateModal } from '@/domain/performance/components/PerformanceCreateModal.client';
 import { usePerformanceList } from '@/domain/performance/hooks/usePerformanceList';
 import type { PerformanceListItemResponse } from '@/domain/performance/types';
 import { ROUTES } from '@/global/config/routes';
 import { useDiscoverySearch } from '@/hooks/useDiscoverySearch';
-import { cn } from '@/lib/cn';
+import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
+import { listItemClasses } from '@/lib/list-item-styles';
+
+const PerformanceIcon = DOMAIN_ICONS.performance;
 
 const accessor = (p: PerformanceListItemResponse) => `${p.title} ${p.venue ?? ''}`;
 
@@ -26,15 +30,18 @@ function PerformanceRow({ p, pathname }: { p: PerformanceListItemResponse; pathn
       <Link
         href={href}
         aria-current={active ? 'page' : undefined}
-        className={cn(
-          'px-s-3 py-s-3 block rounded-md transition-colors',
-          active
-            ? 'bg-accent-dim text-accent'
-            : 'hover:bg-card text-foreground-sub hover:text-foreground',
+        data-slot="performance-row"
+        className={listItemClasses(
+          active,
+          DOMAIN_LIST_SELECTED_TONES.performance,
+          'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
         )}
       >
-        <div className="text-body truncate font-semibold">{p.title}</div>
-        <div className="text-foreground-muted text-caption mt-0.5 truncate">{p.startAt}</div>
+        <IconTile icon={<PerformanceIcon />} size="sm" tone={DOMAIN_TONES.performance} />
+        <div className="min-w-0 flex-1">
+          <div className="text-body truncate font-semibold">{p.title}</div>
+          <div className="text-foreground-muted text-caption mt-0.5 truncate">{p.startAt}</div>
+        </div>
       </Link>
     </li>
   );

--- a/src/app/(main)/practices/PracticesListPane.client.tsx
+++ b/src/app/(main)/practices/PracticesListPane.client.tsx
@@ -7,13 +7,17 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { IconTile } from '@/components/ui/icon-tile';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { PracticeCreateModal } from '@/domain/practice/components/PracticeCreateModal.client';
 import { usePractices } from '@/domain/practice/hooks/usePractices';
 import type { PracticeListItemResponse } from '@/domain/practice/types';
 import { ROUTES } from '@/global/config/routes';
 import { useDiscoverySearch } from '@/hooks/useDiscoverySearch';
-import { cn } from '@/lib/cn';
+import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
+import { listItemClasses } from '@/lib/list-item-styles';
+
+const PracticeIcon = DOMAIN_ICONS.practice;
 
 const accessor = (p: PracticeListItemResponse) =>
   `${p.title} ${p.venue ?? ''} ${p.song?.title ?? ''}`;
@@ -29,17 +33,20 @@ function PracticeRow({ p, pathname }: { p: PracticeListItemResponse; pathname: s
       <Link
         href={href}
         aria-current={active ? 'page' : undefined}
-        className={cn(
-          'px-s-3 py-s-3 block rounded-md transition-colors',
-          active
-            ? 'bg-accent-dim text-accent'
-            : 'hover:bg-card text-foreground-sub hover:text-foreground',
+        data-slot="practice-row"
+        className={listItemClasses(
+          active,
+          DOMAIN_LIST_SELECTED_TONES.practice,
+          'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
         )}
       >
-        <div className="text-body truncate font-semibold">{p.title}</div>
-        <div className="text-foreground-muted text-caption gap-s-2 mt-0.5 flex items-center">
-          <span>{when}</span>
-          {p.venue && <span className="truncate">· {p.venue}</span>}
+        <IconTile icon={<PracticeIcon />} size="sm" tone={DOMAIN_TONES.practice} />
+        <div className="min-w-0 flex-1">
+          <div className="text-body truncate font-semibold">{p.title}</div>
+          <div className="text-foreground-muted text-caption gap-s-2 mt-0.5 flex items-center">
+            <span>{when}</span>
+            {p.venue && <span className="truncate">· {p.venue}</span>}
+          </div>
         </div>
       </Link>
     </li>

--- a/src/domain/band/components/BandCard.tsx
+++ b/src/domain/band/components/BandCard.tsx
@@ -1,33 +1,39 @@
 import Link from 'next/link';
 
-import { Avatar } from '@/components/ui/avatar';
-import { Card } from '@/components/ui/card';
+import { IconTile } from '@/components/ui/icon-tile';
 import { ROUTES } from '@/global/config/routes';
+import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
+import { listItemClasses } from '@/lib/list-item-styles';
 
 import type { BandInfoResponse } from '../types';
 
-export function BandCard({ band }: { band: BandInfoResponse }) {
+const BandIcon = DOMAIN_ICONS.band;
+
+export function BandCard({
+  band,
+  selected = false,
+}: {
+  band: BandInfoResponse;
+  selected?: boolean;
+}) {
   return (
     <Link
       href={ROUTES.BAND_DETAIL(band.bandId)}
-      className="focus-visible:ring-accent focus-visible:ring-offset-bg block rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      aria-current={selected ? 'page' : undefined}
+      data-slot="band-card"
+      className={listItemClasses(
+        selected,
+        DOMAIN_LIST_SELECTED_TONES.band,
+        'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+      )}
     >
-      <Card interactive padding="md">
-        <div className="flex items-start gap-3">
-          <Avatar
-            size="lg"
-            src={band.profileImg}
-            fallback={band.bandName}
-            alt={`${band.bandName} 프로필`}
-          />
-          <div className="min-w-0 flex-1">
-            <p className="text-foreground truncate text-base font-semibold">{band.bandName}</p>
-            {band.description && (
-              <p className="text-foreground-sub mt-1 line-clamp-2 text-sm">{band.description}</p>
-            )}
-          </div>
-        </div>
-      </Card>
+      <IconTile icon={<BandIcon />} size="md" tone={DOMAIN_TONES.band} />
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-base font-semibold">{band.bandName}</p>
+        {band.description && (
+          <p className="text-foreground-sub mt-1 line-clamp-2 text-sm">{band.description}</p>
+        )}
+      </div>
     </Link>
   );
 }

--- a/src/domain/performance/components/PerformanceCard.tsx
+++ b/src/domain/performance/components/PerformanceCard.tsx
@@ -1,14 +1,24 @@
 import { CalendarDays, MapPin } from 'lucide-react';
 import Link from 'next/link';
 
-import { Card } from '@/components/ui/card';
+import { IconTile } from '@/components/ui/icon-tile';
 import { ROUTES } from '@/global/config/routes';
 import { formatKst, parseKst } from '@/lib/date';
+import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
+import { listItemClasses } from '@/lib/list-item-styles';
 
 import { PerformanceDday } from './PerformanceDday';
 import type { PerformanceListItemResponse } from '../types';
 
-export function PerformanceCard({ performance }: { performance: PerformanceListItemResponse }) {
+const PerformanceIcon = DOMAIN_ICONS.performance;
+
+export function PerformanceCard({
+  performance,
+  selected = false,
+}: {
+  performance: PerformanceListItemResponse;
+  selected?: boolean;
+}) {
   let label = performance.startAt;
   try {
     label = formatKst(parseKst(performance.startAt), 'M월 d일 (EEE) HH:mm');
@@ -19,30 +29,35 @@ export function PerformanceCard({ performance }: { performance: PerformanceListI
   return (
     <Link
       href={ROUTES.PERFORMANCE_DETAIL(performance.performanceId)}
-      className="focus-visible:ring-accent focus-visible:ring-offset-bg block rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      aria-current={selected ? 'page' : undefined}
+      data-slot="performance-card"
+      className={listItemClasses(
+        selected,
+        DOMAIN_LIST_SELECTED_TONES.performance,
+        'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+      )}
     >
-      <Card interactive padding="md">
-        <div className="space-y-2">
-          <div className="flex items-start justify-between gap-2">
-            <p className="text-foreground line-clamp-1 text-base font-semibold">
-              {performance.title}
-            </p>
-            <PerformanceDday startAt={performance.startAt} />
-          </div>
-          <div className="text-foreground-sub flex flex-wrap items-center gap-3 text-xs">
-            <span className="inline-flex items-center gap-1">
-              <CalendarDays className="h-3 w-3" aria-hidden="true" />
-              {label} ({performance.durationMinutes}분)
-            </span>
-            {performance.venue && (
-              <span className="inline-flex items-center gap-1">
-                <MapPin className="h-3 w-3" aria-hidden="true" />
-                {performance.venue}
-              </span>
-            )}
-          </div>
+      <IconTile icon={<PerformanceIcon />} size="md" tone={DOMAIN_TONES.performance} />
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-foreground line-clamp-1 text-base font-semibold">
+            {performance.title}
+          </p>
+          <PerformanceDday startAt={performance.startAt} />
         </div>
-      </Card>
+        <div className="text-foreground-sub flex flex-wrap items-center gap-3 text-xs">
+          <span className="inline-flex items-center gap-1">
+            <CalendarDays className="h-3 w-3" aria-hidden="true" />
+            {label} ({performance.durationMinutes}분)
+          </span>
+          {performance.venue && (
+            <span className="inline-flex items-center gap-1">
+              <MapPin className="h-3 w-3" aria-hidden="true" />
+              {performance.venue}
+            </span>
+          )}
+        </div>
+      </div>
     </Link>
   );
 }

--- a/src/domain/practice/components/PracticeCard.tsx
+++ b/src/domain/practice/components/PracticeCard.tsx
@@ -1,41 +1,56 @@
 import { MapPin, Music } from 'lucide-react';
 import Link from 'next/link';
 
-import { Card } from '@/components/ui/card';
+import { IconTile } from '@/components/ui/icon-tile';
 import { ROUTES } from '@/global/config/routes';
+import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
+import { listItemClasses } from '@/lib/list-item-styles';
 
 import { PracticeScheduleBadge } from './PracticeScheduleBadge';
 import type { PracticeListItemResponse } from '../types';
 
-export function PracticeCard({ practice }: { practice: PracticeListItemResponse }) {
+const PracticeIcon = DOMAIN_ICONS.practice;
+
+export function PracticeCard({
+  practice,
+  selected = false,
+}: {
+  practice: PracticeListItemResponse;
+  selected?: boolean;
+}) {
   return (
     <Link
       href={ROUTES.PRACTICE_DETAIL(practice.practiceId)}
-      className="focus-visible:ring-accent focus-visible:ring-offset-bg block rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      aria-current={selected ? 'page' : undefined}
+      data-slot="practice-card"
+      className={listItemClasses(
+        selected,
+        DOMAIN_LIST_SELECTED_TONES.practice,
+        'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+      )}
     >
-      <Card interactive padding="md">
-        <div className="space-y-2">
-          <p className="text-foreground line-clamp-1 text-base font-semibold">{practice.title}</p>
-          <div className="flex flex-wrap items-center gap-2 text-xs">
-            <PracticeScheduleBadge
-              startAt={practice.startAt}
-              durationMinutes={practice.durationMinutes}
-            />
-            {practice.venue && (
-              <span className="text-foreground-sub inline-flex items-center gap-1">
-                <MapPin className="h-3 w-3" aria-hidden="true" />
-                {practice.venue}
-              </span>
-            )}
-            {practice.song && (
-              <span className="text-foreground-sub inline-flex items-center gap-1">
-                <Music className="h-3 w-3" aria-hidden="true" />
-                {practice.song.title} — {practice.song.artist}
-              </span>
-            )}
-          </div>
+      <IconTile icon={<PracticeIcon />} size="md" tone={DOMAIN_TONES.practice} />
+      <div className="min-w-0 flex-1 space-y-1">
+        <p className="text-foreground line-clamp-1 text-base font-semibold">{practice.title}</p>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <PracticeScheduleBadge
+            startAt={practice.startAt}
+            durationMinutes={practice.durationMinutes}
+          />
+          {practice.venue && (
+            <span className="text-foreground-sub inline-flex items-center gap-1">
+              <MapPin className="h-3 w-3" aria-hidden="true" />
+              {practice.venue}
+            </span>
+          )}
+          {practice.song && (
+            <span className="text-foreground-sub inline-flex items-center gap-1">
+              <Music className="h-3 w-3" aria-hidden="true" />
+              {practice.song.title} — {practice.song.artist}
+            </span>
+          )}
         </div>
-      </Card>
+      </div>
     </Link>
   );
 }

--- a/src/lib/domain-icons.tsx
+++ b/src/lib/domain-icons.tsx
@@ -1,6 +1,7 @@
 import { Clock3, Guitar, Music2, type LucideIcon } from 'lucide-react';
 
 import type { IconTileTone } from '@/components/ui/icon-tile';
+import type { ListItemSelectedTone } from '@/lib/list-item-styles';
 
 export type DomainType = 'band' | 'practice' | 'performance';
 
@@ -13,5 +14,12 @@ export const DOMAIN_ICONS: Record<DomainType, LucideIcon> = {
 export const DOMAIN_TONES: Record<DomainType, IconTileTone> = {
   band: 'accent',
   practice: 'success',
+  performance: 'amber',
+};
+
+/** 리스트 선택 상태 톤은 design/dist/css/screens.css 기준으로 accent / amber 두 가지만 사용. */
+export const DOMAIN_LIST_SELECTED_TONES: Record<DomainType, ListItemSelectedTone> = {
+  band: 'accent',
+  practice: 'accent',
   performance: 'amber',
 };

--- a/src/lib/list-item-styles.ts
+++ b/src/lib/list-item-styles.ts
@@ -1,0 +1,20 @@
+import { cn } from './cn';
+
+const BASE =
+  'flex gap-s-3 p-s-3 rounded-lg border border-transparent bg-transparent transition-colors duration-fast cursor-pointer';
+const HOVER = 'hover:bg-card hover:border-border-hi';
+
+const SELECTED = {
+  accent: 'bg-accent-dim border-accent/25 hover:bg-accent-dim',
+  amber: 'bg-amber-dim border-amber/25 hover:bg-amber-dim',
+} as const;
+
+export type ListItemSelectedTone = keyof typeof SELECTED;
+
+export function listItemClasses(
+  selected = false,
+  tone: ListItemSelectedTone = 'accent',
+  extra?: string,
+) {
+  return cn(BASE, selected ? SELECTED[tone] : HOVER, extra);
+}


### PR DESCRIPTION
## Summary

- design/dist screens.css `.list-item` 의 hover/selected 스타일을 `src/lib/list-item-styles.ts` 유틸로 이식
- BandCard / PracticeCard / PerformanceCard: 기존 Card 래퍼 제거, IconTile 좌측 배치 + `selected` prop
- 3 개 ListPane 의 Row 컴포넌트(BandRow / PracticeRow / PerformanceRow): 동일 패턴 + `aria-current` + `data-slot`
- `DOMAIN_LIST_SELECTED_TONES` 추가 (band/practice = accent, performance = amber)

## Linked Issues

Closes #62. 의존: #61.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 48 passed (변경 영향 컴포넌트 스냅샷 회귀 X)
- [x] page-level lists (BandsList / PracticesList / PerformancesList) 가 동일 카드를 사용하므로 자동 반영