### PR TITLE
design: 홈 인사 헤더 + 4컬럼 통계 카드 (Task 3)

### DIFF
--- a/API_REQUIRED.md
+++ b/API_REQUIRED.md
@@ -97,6 +97,28 @@ GET /api/v1/bands?q=<keyword>&genre=<genre>&memberOnly=<bool>&pageSize=20&lastId
 
 - `PerformanceDetailResponse` 에 `posterImg`, `ticketUrl`, `mapPlaceId` 등.
 
+### 12. 홈 사용자 통계 (FE-API-014)
+
+- **엔드포인트**: `GET /api/v1/members/me/stats`
+- **요청 헤더**: `Authorization: Bearer <accessToken>`
+- **기대 응답 (`ApiResponse<MemberStatsResponse>`)**:
+
+```json
+{
+  "success": true,
+  "data": {
+    "bandCount": 3,
+    "upcomingPracticeCount": 2,
+    "upcomingPerformanceCount": 1,
+    "sessionCount": 5
+  }
+}
+```
+
+- **프론트 사용처**: `src/app/(main)/home/HomeStatCards.client.tsx` 4번째 카드 ("참여 세션")
+- **현재 우회**: `bandCount` / `upcomingPractice/Performance` 는 각 list API 의 `length` 로 대체, `sessionCount` 는 `'—'` mock 표시.
+- **백엔드 체크리스트**: `MemberStatsResponse` DTO, `MemberService.getStats(memberId)`, 컨트롤러 + 권한 체크(자신만), JPA 통계 쿼리 또는 도메인 별 카운트 합산.
+
 ---
 
 ## ℹ️ 참고 — 프론트 mock / 우회 현황 (2026-04-25 기준)

--- a/src/app/(main)/home/HomeGreeting.client.tsx
+++ b/src/app/(main)/home/HomeGreeting.client.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { useMe } from '@/domain/member/hooks/useMe';
+
+export function HomeGreeting() {
+  const { data: me, isLoading } = useMe();
+
+  return (
+    <header className="space-y-s-1" data-slot="home-greeting">
+      {isLoading ? (
+        <Skeleton className="h-8 w-64" rounded="md" />
+      ) : (
+        <h1 className="text-foreground text-title-lg font-extrabold">
+          {me?.name ? `안녕하세요, ${me.name} 님 👋` : '안녕하세요 👋'}
+        </h1>
+      )}
+      <p className="text-foreground-sub text-body">오늘도 좋은 합주 되세요.</p>
+    </header>
+  );
+}

--- a/src/app/(main)/home/HomeStatCards.client.tsx
+++ b/src/app/(main)/home/HomeStatCards.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarDays, Music, Users } from 'lucide-react';
+import { CalendarDays, Music, Music2, Users } from 'lucide-react';
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { StatCard } from '@/components/ui/stat-card';
@@ -13,8 +13,8 @@ function Stub() {
 }
 
 /**
- * 홈 상단 3-stat 요약.
- * 참여 세션 수는 list API 에 포함되지 않아 현재 누락 (추후 별도 summary API 도입 예정).
+ * 홈 상단 4-stat 요약. 참여 세션은 백엔드 통계 API 도입 전까지 mock '—' 표시.
+ * (API_REQUIRED.md FE-API-014 GET /api/v1/members/me/stats 참고)
  */
 export function HomeStatCards() {
   const bands = useMyBands();
@@ -22,7 +22,7 @@ export function HomeStatCards() {
   const performances = useUpcomingPerformances();
 
   return (
-    <div className="gap-s-3 grid grid-cols-1 sm:grid-cols-3" data-slot="home-stat-cards">
+    <div className="gap-s-3 grid grid-cols-2 lg:grid-cols-4" data-slot="home-stat-cards">
       {bands.isLoading ? (
         <Stub />
       ) : (
@@ -48,6 +48,7 @@ export function HomeStatCards() {
           accent="amber"
         />
       )}
+      <StatCard icon={Music2} label="참여 세션" value="—" accent="warn" />
     </div>
   );
 }

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import { PageTitle } from '@/components/layout/page-title';
 import { SectionTitle } from '@/components/ui/section-title';
 import { MyBands } from '@/domain/band/components/MyBands';
 import { UpcomingPerformances } from '@/domain/performance/components/UpcomingPerformances';
 import { UpcomingPractices } from '@/domain/practice/components/UpcomingPractices';
 import { ROUTES } from '@/global/config/routes';
 
+import { HomeGreeting } from './HomeGreeting.client';
 import { HomeStatCards } from './HomeStatCards.client';
 
 export const metadata: Metadata = {
@@ -29,7 +29,7 @@ function ViewAllLink({ href, label }: { href: string; label: string }) {
 export default function HomePage() {
   return (
     <div className="space-y-s-8 lg:p-s-10 lg:mx-auto lg:h-[calc(100vh-0px)] lg:w-full lg:max-w-5xl lg:overflow-y-auto">
-      <PageTitle title="홈" description="오늘의 합주와 공연을 한눈에 확인하세요." />
+      <HomeGreeting />
 
       <HomeStatCards />
 


### PR DESCRIPTION
## Summary

- 홈 화면 헤더를 design/dist/js/screens/home.js 의 `home-header` 패턴으로 교체
- `HomeGreeting.client.tsx` — `useMe()` 로 "안녕하세요, {name} 님 👋" + "오늘도 좋은 합주 되세요." (로딩/비로그인 폴백)
- 통계 카드 그리드 → `grid-cols-2 lg:grid-cols-4`, 4번째 "참여 세션" 카드 mock '—' 추가
- `API_REQUIRED.md` FE-API-014 (`GET /api/v1/members/me/stats`) 명세 추가

## Linked Issues

Closes #63. 의존: #61.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 48 passed
- [x] 비로그인 폴백 / 로딩 Skeleton / 데스크탑 4컬럼 동작 검증