### PR TITLE
feat: 밴드 상세 4탭 분할 (Task 4)

### DIFF
--- a/API_REQUIRED.md
+++ b/API_REQUIRED.md
@@ -97,7 +97,29 @@ GET /api/v1/bands?q=<keyword>&genre=<genre>&memberOnly=<bool>&pageSize=20&lastId
 
 - `PerformanceDetailResponse` 에 `posterImg`, `ticketUrl`, `mapPlaceId` 등.
 
-### 12. 홈 사용자 통계 (FE-API-014)
+### 12. 밴드별 합주 목록 (FE-API-009)
+
+- **엔드포인트**: `GET /api/v1/bands/{bandId}/practices`
+- **요청 헤더**: `Authorization: Bearer <accessToken>`
+- **Path**: `bandId: UUID`
+- **Query**: `?lastId=<uuid>&pageSize=20&filter=upcoming|past|all` (기본 `upcoming`)
+- **기대 응답**: `ApiResponse<CursorResponse<PracticeListItemResponse, string>>`
+- **프론트 사용처**: 밴드 상세 → "일정 및 합주" 탭 (`BandDetailContent.client.tsx` `ScheduleTab`)
+- **현재 우회**: 탭에서 "서비스를 준비하고 있어요" EmptyState 표시. 호출 자체 미구현.
+- **백엔드 체크리스트**: `BandPracticeController`, `PracticeService.findByBandId`, 권한 체크(밴드 멤버 + 비멤버는 공개 일정만), 인덱스 (band_id, start_at).
+
+### 13. 밴드별 공연 목록 (FE-API-010)
+
+- **엔드포인트**: `GET /api/v1/bands/{bandId}/performances`
+- **요청 헤더**: `Authorization: Bearer <accessToken>`
+- **Path**: `bandId: UUID`
+- **Query**: `?lastId=<uuid>&pageSize=20&filter=upcoming|past|all`
+- **기대 응답**: `ApiResponse<CursorResponse<PerformanceListItemResponse, string>>`
+- **프론트 사용처**: 밴드 상세 → "일정 및 합주" 탭
+- **현재 우회**: 동일 EmptyState.
+- **백엔드 체크리스트**: `BandPerformanceController`, `PerformanceService.findByBandId`, 권한 체크.
+
+### 14. 홈 사용자 통계 (FE-API-014)
 
 - **엔드포인트**: `GET /api/v1/members/me/stats`
 - **요청 헤더**: `Authorization: Bearer <accessToken>`

--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { LogOut, UserPlus } from 'lucide-react';
+import { CalendarRange, LogOut, Settings2, UserPlus } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -67,7 +67,7 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
   }
 
   const isMember = myRole !== null && myRole !== undefined;
-  const canSeeApplications = hasRole(myRole, 'ADMIN');
+  const canManage = hasRole(myRole, 'LEADER');
 
   return (
     <div className="space-y-6">
@@ -89,52 +89,40 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
       </Card>
 
       <Tabs defaultValue="info">
-        <TabsList>
+        <TabsList aria-label="밴드 상세 탭">
           <TabsTrigger value="info">정보</TabsTrigger>
           <TabsTrigger value="members">멤버</TabsTrigger>
-          {canSeeApplications && <TabsTrigger value="applications">신청 현황</TabsTrigger>}
+          <TabsTrigger value="schedule">일정 및 합주</TabsTrigger>
+          {canManage && <TabsTrigger value="manage">밴드 관리</TabsTrigger>}
         </TabsList>
 
         <TabsContent value="info">
-          <Card padding="lg">
-            <div className="space-y-3">
-              <p className="text-foreground-sub text-sm">
-                {band.description ?? '소개가 등록되지 않았습니다.'}
-              </p>
-              <div className="flex gap-2">
-                {!isMember && (
-                  <Button onClick={() => applyMutation.mutate()} loading={applyMutation.isPending}>
-                    <UserPlus className="h-4 w-4" />
-                    가입 신청
-                  </Button>
-                )}
-                {isMember && (
-                  <Button
-                    variant="ghost"
-                    className="text-danger hover:opacity-80"
-                    onClick={() => setLeaveOpen(true)}
-                  >
-                    <LogOut className="h-4 w-4" />
-                    밴드 탈퇴
-                  </Button>
-                )}
-              </div>
-            </div>
-          </Card>
+          <InfoTab
+            bandId={bandId}
+            description={band.description}
+            isMember={isMember}
+            applyPending={applyMutation.isPending}
+            onApply={() => applyMutation.mutate()}
+            onLeave={() => setLeaveOpen(true)}
+          />
         </TabsContent>
 
         <TabsContent value="members">
           <MembersTab bandId={bandId} />
         </TabsContent>
 
-        {canSeeApplications && (
-          <TabsContent value="applications">
+        <TabsContent value="schedule">
+          <ScheduleTab />
+        </TabsContent>
+
+        {canManage && (
+          <TabsContent value="manage">
             <RoleGuard
               bandId={bandId}
-              role="ADMIN"
-              fallback={<EmptyState title="접근 권한이 없습니다" />}
+              role="LEADER"
+              fallback={<EmptyState title="리더만 접근할 수 있습니다" />}
             >
-              <ApplicationsTab bandId={bandId} />
+              <ManageTab bandId={bandId} />
             </RoleGuard>
           </TabsContent>
         )}
@@ -171,6 +159,101 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
   );
 }
 
+function InfoTab({
+  bandId,
+  description,
+  isMember,
+  applyPending,
+  onApply,
+  onLeave,
+}: {
+  bandId: string;
+  description: string | undefined;
+  isMember: boolean;
+  applyPending: boolean;
+  onApply: () => void;
+  onLeave: () => void;
+}) {
+  const members = useBandMembers(bandId, 20);
+  const memberCount = members.data?.pages.flatMap((p) => p.content).length ?? 0;
+
+  return (
+    <div className="space-y-s-4">
+      <Card padding="lg">
+        <div className="space-y-3">
+          <h2 className="text-foreground-sub text-caption font-semibold tracking-wide uppercase">
+            소개
+          </h2>
+          <p className="text-foreground-sub text-sm leading-relaxed">
+            {description ?? '소개가 등록되지 않았습니다.'}
+          </p>
+        </div>
+      </Card>
+
+      <div className="gap-s-3 grid grid-cols-3" data-slot="band-info-stats">
+        <StatTile label="멤버" value={members.isLoading ? '—' : memberCount} />
+        <StatTile label="예정 합주" value="—" />
+        <StatTile label="예정 공연" value="—" />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {!isMember && (
+          <Button onClick={onApply} loading={applyPending}>
+            <UserPlus className="h-4 w-4" />
+            가입 신청
+          </Button>
+        )}
+        {isMember && (
+          <Button variant="ghost" className="text-danger hover:opacity-80" onClick={onLeave}>
+            <LogOut className="h-4 w-4" />
+            밴드 탈퇴
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatTile({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div
+      className="bg-card border-border p-s-4 rounded-lg border text-center"
+      data-slot="band-info-stat"
+    >
+      <div className="text-foreground text-title-lg leading-tight font-extrabold">{value}</div>
+      <div className="text-foreground-sub text-micro mt-1">{label}</div>
+    </div>
+  );
+}
+
+function ScheduleTab() {
+  return (
+    <Card padding="lg">
+      <EmptyState
+        icon={CalendarRange}
+        title="서비스를 준비하고 있어요"
+        description="밴드의 합주·공연 일정을 곧 한 화면에서 확인할 수 있습니다."
+      />
+    </Card>
+  );
+}
+
+function ManageTab({ bandId }: { bandId: string }) {
+  return (
+    <Card padding="lg">
+      <div className="space-y-s-4">
+        <div className="flex items-center gap-2">
+          <Settings2 className="text-foreground-sub h-4 w-4" aria-hidden="true" />
+          <h2 className="text-foreground-sub text-caption font-semibold tracking-wide uppercase">
+            가입 신청 관리
+          </h2>
+        </div>
+        <ApplicationsList bandId={bandId} />
+      </div>
+    </Card>
+  );
+}
+
 function MembersTab({ bandId }: { bandId: string }) {
   const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useBandMembers(bandId, 20);
@@ -202,7 +285,7 @@ function MembersTab({ bandId }: { bandId: string }) {
   );
 }
 
-function ApplicationsTab({ bandId }: { bandId: string }) {
+function ApplicationsList({ bandId }: { bandId: string }) {
   const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useBandApplications(bandId, 'PENDING', 20);
 


### PR DESCRIPTION
## Summary

밴드 상세 화면을 design/dist/js/screens/band.js 와 일치하는 4탭 구조로 재편.

| 탭 | 노출 조건 | 내용 |
|---|---|---|
| 정보 | 모두 | 소개 + 3컬럼 통계 카드 (멤버 / 예정 합주 — / 예정 공연 —) + 가입신청·탈퇴 |
| 멤버 | 모두 | 기존 BandMemberRow 무한스크롤 |
| 일정 및 합주 | 모두 | EmptyState "서비스를 준비하고 있어요" (CalendarRange 아이콘) |
| 밴드 관리 | LEADER 전용 | 가입 신청 승인/거절 |

- 권한 정책: 가입 신청 관리는 ADMIN → **LEADER 전용**으로 좁힘
- `<TabsList aria-label="밴드 상세 탭">` 접근성 보강
- 권한 미일치 탭은 DOM 자체에서 제거 (`canManage && <TabsTrigger />`)
- `RoleGuard` fallback: "리더만 접근할 수 있습니다"

## Stub 데이터

"예정 합주" / "예정 공연" 통계는 백엔드 미구현 → `'—'` 표시 (`API_REQUIRED.md` FE-API-009 / FE-API-010 추가)

## Linked Issues

Closes #64. 의존: #61 (IconTile), #62 (list-item).

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 48 passed
- [ ] LEADER / ADMIN / MEMBER / 비회원 4 케이스 수동 검증 (Phase H 종합 회귀에서 다룸)