### PR TITLE
refactor: 오류/빈상태 톤 완화 (Task 5)

### DIFF
--- a/src/app/(main)/bands/BandsList.client.tsx
+++ b/src/app/(main)/bands/BandsList.client.tsx
@@ -37,7 +37,7 @@ export function BandsList() {
   }
 
   if (isError) {
-    return <ErrorState description="밴드 목록을 불러오지 못했습니다." onRetry={() => refetch()} />;
+    return <ErrorState onRetry={() => refetch()} />;
   }
 
   const bands = data?.pages.flatMap((p) => p.content) ?? [];

--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -69,7 +69,7 @@ export function MeContent() {
   }
 
   if (isError || !me) {
-    return <ErrorState description="회원 정보를 불러오지 못했습니다." onRetry={() => refetch()} />;
+    return <ErrorState onRetry={() => refetch()} />;
   }
 
   return (

--- a/src/app/(main)/performances/PerformancesList.client.tsx
+++ b/src/app/(main)/performances/PerformancesList.client.tsx
@@ -40,7 +40,7 @@ export function PerformancesList() {
   }
 
   if (isError) {
-    return <ErrorState description="공연 목록을 불러오지 못했습니다." onRetry={() => refetch()} />;
+    return <ErrorState onRetry={() => refetch()} />;
   }
 
   const performances = data?.pages.flatMap((p) => p.content) ?? [];

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -14,8 +14,8 @@ export default function GlobalError({ error, reset }: { error: Error; reset: () 
   return (
     <div className="flex min-h-[60vh] items-center justify-center px-4">
       <ErrorState
-        title="화면을 불러올 수 없습니다"
-        description={error.message || '잠시 후 다시 시도해 주세요.'}
+        title="화면을 준비하지 못했어요"
+        description="잠시 후 다시 시도하거나 다른 메뉴를 이용해 주세요."
         onRetry={reset}
         className="w-full max-w-md"
       />

--- a/src/components/feedback/error-boundary.tsx
+++ b/src/components/feedback/error-boundary.tsx
@@ -39,6 +39,9 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     const { fallback } = this.props;
     if (typeof fallback === 'function') return fallback(error, this.reset);
     if (fallback !== undefined) return fallback;
-    return <ErrorState description={error.message} onRetry={this.reset} />;
+    // 기본 fallback 은 사용자에게 기술적 메시지(error.message) 를 노출하지 않고
+    // ErrorState 의 부드러운 기본 카피("서비스를 준비하고 있어요") 를 그대로 사용한다.
+    void error;
+    return <ErrorState onRetry={this.reset} />;
   }
 }

--- a/src/components/feedback/error-state.tsx
+++ b/src/components/feedback/error-state.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from 'lucide-react';
+import { Wrench } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/cn';
@@ -11,20 +11,21 @@ type ErrorStateProps = {
 };
 
 export function ErrorState({
-  title = '오류가 발생했습니다',
-  description = '잠시 후 다시 시도해 주세요.',
+  title = '서비스를 준비하고 있어요',
+  description = '잠시 후 다시 시도하거나 다른 메뉴를 이용해 주세요.',
   onRetry,
   className,
 }: ErrorStateProps) {
   return (
     <div
       role="alert"
+      data-slot="error-state"
       className={cn(
         'flex flex-col items-center justify-center gap-3 rounded-md py-12 text-center',
         className,
       )}
     >
-      <AlertTriangle className="text-danger h-10 w-10" aria-hidden="true" />
+      <Wrench className="text-foreground-muted h-10 w-10" aria-hidden="true" />
       <div className="space-y-1">
         <p className="text-foreground text-lg font-medium">{title}</p>
         <p className="text-foreground-sub text-sm">{description}</p>


### PR DESCRIPTION
## Summary

오류 컴포넌트의 빨간 ⚠️ 톤 → 부드러운 "서비스 준비 중" 톤으로 일관 완화.

| 파일 | 변경 |
|---|---|
| `error-state.tsx` | `AlertTriangle / text-danger` → `Wrench / text-foreground-muted`, 기본 카피 "서비스를 준비하고 있어요" |
| `error-boundary.tsx` | 기본 fallback 에서 `error.message` 노출 제거 — 사용자에 기술 텍스트 미노출 |
| `app/error.tsx` | 글로벌 에러 카피 "화면을 준비하지 못했어요" 로 정렬 |
| `BandsList / PerformancesList / MeContent` | "~ 불러오지 못했습니다" 강한 표현 제거 → 기본 부드러운 카피 |

`role="alert"` 는 그대로 유지 (스크린리더 우선순위 회귀 X). `data-slot="error-state"` 부여.

## Linked Issues

Closes #65.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 48 passed (스냅샷 회귀 X)