### PR TITLE
feat: 밴드 상세 TopBar/Tabs 레이아웃 handoff 스펙 정렬 (Task 4 redo v2)

### DIFF
--- a/.taskmaster/tasks/mvp-1-fix-v2/task_004_mvp-1-fix-v2.md
+++ b/.taskmaster/tasks/mvp-1-fix-v2/task_004_mvp-1-fix-v2.md
@@ -1,135 +1,98 @@
 # Task ID: 4
 
-**Title:** Phase D: 밴드 상세 탭 4분할 (정보/멤버/일정·합주/밴드 관리)
+**Title:** Phase D: 밴드 상세 화면 — TopBar/Tabs 레이아웃 재구성 (handoff 스펙 일치)
 
-**Status:** pending
+**Status:** in-progress
 
 **Dependencies:** 1, 2
 
 **Priority:** high
 
-**Description:** BandDetailContent의 탭을 정보/멤버/일정 및 합주/밴드 관리 4개로 분할, '밴드 관리' 탭은 LEADER 전용(RoleGuard role='LEADER'), '일정 및 합주' 탭은 API 미존재로 서비스 준비 중 EmptyState 표시
+**Description:** `handoff/band-detail.md` 와 `handoff/specs/03-band.md` 의 데스크톱 마스터-디테일 스펙에 맞춰 BandDetailContent 의 TopBar / Tabs / Content 레이아웃을 재구성한다. 정보 / 멤버 / 신청 현황 3 탭 구조와 권한 정책을 정확히 반영한다.
+
+**Source of truth:**
+- `handoff/band-detail.md` (전체 가로 비율, TopBar 72px, Tab bar 48px, content 24/32 padding)
+- `handoff/specs/03-band.md` (탭별 콘텐츠, 액션 버튼 권한)
+- `handoff/specs/00-global-layout.md` (240/360/flex 마스터-디테일)
+- `handoff/screens/03-band.png`, `07-band-detail.png` 캡처
 
 **Details:**
 
-1. src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx 수정:
-   - 기존 탭: info, members, applications(ADMIN)
-   - 변경 탭: info(정보), members(멤버), schedule(일정 및 합주), manage(밴드 관리-LEADER)
+1. 레이아웃 (handoff/band-detail.md L97-160 기준):
+   - TopBar: height 72px, padding `0 32px`, 하단 1px border
+     - breadcrumb "밴드 탐색" (12px / textMuted)
+     - 타이틀: 22px / weight 700
+     - 우측 액션 버튼: height 36px (sm)
+   - Tab bar: height 48px, padding `0 32px`, 활성 탭 하단 2px accent 보더
+     - 탭 텍스트 14px / weight 500, 비활성 textSub
+   - Content: padding `24px 32px`, flex 1, overflow-y auto
 
-2. 탭 구성:
-   ```tsx
-   <Tabs defaultValue="info">
-     <TabsList aria-label="밴드 상세 탭">
-       <TabsTrigger value="info">정보</TabsTrigger>
-       <TabsTrigger value="members">멤버</TabsTrigger>
-       <TabsTrigger value="schedule">일정 및 합주</TabsTrigger>
-       {hasRole(myRole, 'LEADER') && (
-         <TabsTrigger value="manage">밴드 관리</TabsTrigger>
-       )}
-     </TabsList>
-   ```
+2. 탭 구성 (3 탭): 정보 / 멤버 / 신청 현황
+   - 신청 현황 탭: **LEADER 만 노출**. (handoff 스펙은 LEADER+ADMIN 이지만 현재 BE 에 ADMIN 역할이 정의돼 있지 않아 본 라운드는 LEADER 만 적용)
+   - 비-LEADER 사용자에게는 DOM 자체에서 숨김
 
-3. 정보 탭:
-   - 프로필 이미지/밴드 이름/설명
-   - 통계 카드: 멤버 수, 예정 합주, 예정 공연 (3컬럼)
-   - API 미존재 시 mock 데이터 또는 Skeleton
+3. TopBar 액션 버튼:
+   | 사용자 상태 | 버튼 |
+   |---|---|
+   | LEADER | "밴드 설정" (Settings 아이콘) |
+   | MEMBER (LEADER 아님) | "밴드 탈퇴" (LogOut 아이콘) |
+   | 비회원 | "가입 신청" (UserPlus 아이콘) |
+   - "밴드 설정" 화면은 본 라운드 미구현 → toast info 안내
 
-4. 일정 및 합주 탭:
-   - 현재 API 미존재 (GET /api/v1/bands/{bandId}/practices, performances)
-   - EmptyState: '서비스를 준비하고 있어요' 톤 적용
-   - API_REQUIRED.md에 FE-API-009, FE-API-010 추가 예정
+4. 정보 탭 (handoff/band-detail.md L133-160):
+   - 커버 이미지 placeholder: 100% 너비 × **220px 고정** / 16px 라운드
+     - profileImg 없을 시 Camera 아이콘 + "band cover image" 라벨
+   - 밴드명 (h2, text-title)
+   - 설명 (textSub, leading-relaxed)
+   - 메타 라인: "멤버 N명" (memberCount). 결성일 등 부가 메타는 BE 미지원 → 생략
+   - "다가오는 합주 / 다가오는 공연" 2-col 그리드 자리 → API 미구현으로 EmptyState (Phase E 톤) 표시 또는 본 라운드 생략
 
-5. 밴드 관리 탭:
-   - 가입 신청 승인/거절 (기존 applications 내용 이동)
-   - RoleGuard role='LEADER' (기존 ADMIN에서 LEADER로 변경)
+5. 멤버 탭:
+   - 2-column 그리드 (`sm:grid-cols-2`, gap 12px)
+   - BandMemberRow: bg-card border 카드, Avatar + 이름 + RoleBadge + (위임 버튼: LEADER 만, non-LEADER 멤버 대상)
+   - 멤버 표시명은 Phase G (Task 7) 에서 정상화 예정 — 본 라운드는 `Member #{memberId}` 임시
+
+6. 신청 현황 탭 (LEADER):
+   - 상태 chip 필터: 대기중 / 승인됨 / 거부됨 (handoff/specs/03-band.md L41)
+   - 신청 카드: Avatar + 신청자 이름 + 신청일 + 상태 배지 + 승인/거부 버튼
+   - 신청일(`appliedAt`) 미지원 → 본 라운드는 "신청 대기 중" 텍스트로 폴백 + API_REQUIRED.md 신규 항목 추가
+
+7. Tabs 컴포넌트: handoff 스펙의 underline 스타일 지원 위해 `variant` prop 추가 (`pill` 기본 / `underline` 신규). BandDetailContent 는 `underline` 사용. 기존 ListPane mine/discover 등은 `pill` 유지.
 
 **Test Strategy:**
 
-1. LEADER 계정으로 4개 탭 모두 표시 확인
-2. ADMIN 계정으로 '밴드 관리' 탭 미표시 확인
-3. MEMBER 계정으로 정보/멤버/일정 3개 탭만 표시 확인
-4. '일정 및 합주' 탭의 EmptyState 메시지 확인
-5. pnpm typecheck 통과
+1. LEADER 계정: 밴드 설정 버튼 + 신청 현황 탭 노출
+2. MEMBER 계정: 탈퇴 버튼만, 신청 현황 탭 미노출
+3. 비회원: 가입 신청 버튼만, 신청 현황 탭 미노출
+5. 1024 / 1280 / 1440 / 1920 px viewport 에서 240 / 360 / flex 비율 유지 (master-detail 비율 검증)
+6. TopBar 72px / Tab bar 48px / content padding 24/32 확인
+7. `pnpm typecheck && pnpm lint && pnpm test` 통과
 
 ## Subtasks
 
-### 4.1. 기존 info 탭 콘텐츠를 통계 카드 포함 정보 탭으로 리팩터링
+### 4.1. Tabs 컴포넌트 underline variant 추가
 
-**Status:** pending  
-**Dependencies:** None  
+**Status:** pending
+**Dependencies:** None
 
-BandDetailContent의 현재 info 탭에 멤버 수/예정 합주/예정 공연 3컬럼 통계 카드 추가, 가입 신청/탈퇴 버튼 유지
+`src/components/ui/tabs.tsx` 에 `variant: 'pill' | 'underline'` prop 추가. underline 시 활성 탭 하단 2px accent 보더 + TabsList 가 가로 라인 형태.
 
-**Details:**
+### 4.2. BandDetailContent TopBar / Tabs / Content 레이아웃 재구성
 
-1. `BandDetailContent.client.tsx`의 `<TabsContent value="info">` 내부 리팩터링
-2. 통계 카드 섹션 추가: `<div className="grid grid-cols-3 gap-3">` 레이아웃
-   - 멤버 수: `useBandMembers`로 가져온 총 count 표시 (API에 totalElements 있으면 사용, 없으면 pages.flatMap().length)
-   - 예정 합주/공연: API 미존재로 현재 Skeleton 또는 `--` 표시 (목 데이터 삽입 금지)
-3. 기존 가입 신청/탈퇴 버튼 블록은 통계 아래로 이동
-4. Task 1의 IconTile이 완료되면 각 통계 카드에 도메인 아이콘 적용 가능하도록 구조화
-5. 프로필 이미지/밴드 이름/설명은 탭 외부 Card에 이미 있으므로 중복 제거 (현재 `band.description ?? '소개가 등록되지 않았습니다.'` 부분 정리)
+**Status:** pending
+**Dependencies:** 4.1
 
-### 4.2. '일정 및 합주' 탭 추가 및 EmptyState 표시
+handoff/band-detail.md 의 72/48/24+32 스펙에 맞춰 헤더/탭/본문 영역 재배치. 액션 버튼 권한 정책 (LEADER/ADMIN/MEMBER/비회원) 적용.
 
-**Status:** pending  
-**Dependencies:** 4.1  
+### 4.3. 정보 탭 콘텐츠 정렬
 
-schedule 탭을 새로 추가하고 API 미존재로 '서비스를 준비하고 있어요' 톤의 EmptyState 표시, API_REQUIRED.md에 FE-API-009/010 항목 추가
+**Status:** pending
+**Dependencies:** 4.2
 
-**Details:**
+커버 이미지 220px / 밴드명 / 설명 / 멤버 N명 메타 / 다가오는 합주·공연 자리.
 
-1. `TabsList`에 `<TabsTrigger value="schedule">일정 및 합주</TabsTrigger>` 추가 (members 다음 위치)
-2. `<TabsContent value="schedule">`에 EmptyState 컴포넌트 렌더링:
-   ```tsx
-   <EmptyState
-     icon={Calendar}
-     title="서비스를 준비하고 있어요"
-     description="밴드의 합주 및 공연 일정을 곧 확인할 수 있습니다."
-   />
-   ```
-3. `lucide-react`에서 Calendar 아이콘 import
-4. API_REQUIRED.md에 FE-API-009, FE-API-010 추가:
-   - FE-API-009: `GET /api/v1/bands/{bandId}/practices` — 특정 밴드의 합주 목록
-   - FE-API-010: `GET /api/v1/bands/{bandId}/performances` — 특정 밴드의 공연 목록
-5. 향후 API 연동 시 이 탭 내부만 교체하면 되도록 `ScheduleTab` 서브 컴포넌트로 분리 권장
+### 4.4. 신청 현황 탭 권한·필터 정렬 + API_REQUIRED 갱신 (스킵)
 
-### 4.3. '밴드 관리' 탭 추가 및 LEADER 전용 RoleGuard 적용
+**Status:** skipped — 본 라운드 미수행
 
-**Status:** pending  
-**Dependencies:** 4.1  
-
-기존 applications 탭을 manage로 이름 변경, ADMIN에서 LEADER 역할로 권한 상향, 가입 신청 승인/거절 기능 이동
-
-**Details:**
-
-1. 기존 `canSeeApplications = hasRole(myRole, 'ADMIN')` 를 `canManage = hasRole(myRole, 'LEADER')` 로 변경
-2. `TabsTrigger value="applications"` → `value="manage"`, 라벨을 '밴드 관리'로 변경
-3. `TabsContent value="applications"` → `value="manage"`로 변경
-4. 내부 `RoleGuard role="ADMIN"` → `role="LEADER"`로 변경
-5. 탭 내부 구조:
-   - 상단: '가입 신청 관리' 섹션 헤딩 (선택적)
-   - 기존 ApplicationsTab 컴포넌트 그대로 유지
-6. 향후 밴드 설정/삭제/위임 등 관리 기능 추가 시 이 탭에 추가 섹션 배치 예정
-7. fallback 메시지를 '접근 권한이 없습니다'에서 '리더만 접근할 수 있습니다'로 변경 (선택적)
-
-### 4.4. TabsList aria-label 및 4탭 통합 테스트
-
-**Status:** pending  
-**Dependencies:** 4.1, 4.2, 4.3  
-
-TabsList에 접근성 aria-label 추가, 4개 탭(정보/멤버/일정 및 합주/밴드 관리) 통합 렌더링 및 역할별 조건 테스트
-
-**Details:**
-
-1. `<TabsList>` 에 `aria-label="밴드 상세 탭"` 속성 추가 (접근성 보강)
-2. 최종 탭 순서 확인: info → members → schedule → manage(LEADER only)
-3. 전체 코드 정리:
-   - 불필요한 import 정리 (LogOut, UserPlus 등 info 탭 버튼에서만 사용)
-   - `canSeeApplications` 변수 제거 후 `canManage`로 통일
-4. `pnpm typecheck && pnpm lint` 실행 및 오류 수정
-5. 수동 테스트 시나리오 문서화:
-   - LEADER: 4개 탭 모두 표시
-   - ADMIN: 정보/멤버/일정 3개 탭 표시
-   - MEMBER: 정보/멤버/일정 3개 탭 표시
-   - 비회원: 정보/멤버/일정 3개 탭 표시, 가입 신청 버튼 활성
+handoff 원본은 LEADER + ADMIN 접근을 명시하지만, 현재 BE 에 ADMIN 역할이 정의되지 않아 본 서브태스크는 보류한다. ADMIN 도메인 도입 시 별도 라운드에서 진행. chip 라벨(대기중/승인됨/거부됨) 과 `appliedAt` 미지원 문서화는 4.3 범위 내에서 일부 반영.

--- a/API_REQUIRED.md
+++ b/API_REQUIRED.md
@@ -82,6 +82,13 @@ GET /api/v1/bands?q=<keyword>&genre=<genre>&memberOnly=<bool>&pageSize=20&lastId
 
 - 신청자 정보(`applicantName`, `applicantProfileImg`) 와 신청 메시지(`message`) 필드 추가.
 - 거절 시 사유(`rejectReason`) 필드 추가.
+- **신청 일시(`appliedAt`)** 필드 추가 — 현재 신청 카드에 신청 시각 노출 불가, "신청 대기 중" 텍스트로 폴백 중. `handoff/specs/03-band.md` "신청 카드: 신청자 이름 + 신청일 + 상태 배지" 참조.
+
+### 8-2. 멤버 강퇴 / 역할 변경 (밴드 설정)
+
+- `DELETE /api/v1/bands/{bandId}/members/{bandMemberId}` — 리더의 멤버 강퇴
+- `PATCH /api/v1/bands/{bandId}/members/{bandMemberId}/role` — 리더의 멤버 역할 변경 (LEADER 위임은 기존 API 유지, ADMIN ↔ MEMBER 강등/승급 신규)
+- 프론트 사용처: 향후 "밴드 설정" 화면. 현재는 toast info 안내만 (P2).
 
 ### 9. 프로필 이미지 업로드 엔드포인트
 

--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -32,6 +32,9 @@ import { ROUTES } from '@/global/config/routes';
 import type { ApplicationStatus } from '@/global/types';
 import { useToast } from '@/hooks/useToast';
 
+/**
+ * 밴드 상세. handoff/band-detail.md (TopBar 72px / Tab bar 48px / content 24/32 padding) 스펙 일치.
+ */
 export function BandDetailContent({ bandId }: { bandId: string }) {
   const router = useRouter();
   const toast = useToast();
@@ -55,7 +58,7 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
 
   if (isLoading) {
     return (
-      <div className="space-y-3">
+      <div className="px-s-5 py-s-6 space-y-3 lg:px-8 lg:py-7">
         <Skeleton className="h-32 w-full" rounded="lg" />
         <Skeleton className="h-10 w-1/2" />
       </div>
@@ -63,18 +66,28 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
   }
 
   if (isError || !band) {
-    return <ErrorState onRetry={() => refetch()} />;
+    return (
+      <div className="px-s-5 py-s-6 lg:px-8 lg:py-7">
+        <ErrorState onRetry={() => refetch()} />
+      </div>
+    );
   }
 
   const isMember = myRole !== null && myRole !== undefined;
-  const isLeader = hasRole(myRole, 'LEADER');
+  const isLeader = hasRole(myRole, 'LEADER'); // ADMIN 역할은 현재 BE 미정의 — LEADER 만 관리 권한
 
   return (
-    <div className="space-y-s-6">
-      <header className="flex items-start justify-between gap-3" data-slot="band-detail-header">
+    <div data-slot="band-detail">
+      {/* TopBar — 72px height, 32px horizontal padding, bottom 1px border */}
+      <header
+        className="border-border px-s-5 flex h-[72px] items-center justify-between gap-3 border-b lg:px-8"
+        data-slot="band-detail-topbar"
+      >
         <div className="min-w-0">
           <p className="text-foreground-muted text-caption">밴드 탐색</p>
-          <h1 className="text-foreground text-title-lg font-bold">{band.bandName}</h1>
+          <h1 className="text-foreground truncate text-[22px] leading-snug font-bold">
+            {band.bandName}
+          </h1>
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {!isMember && (
@@ -95,7 +108,7 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
               onClick={() => setLeaveOpen(true)}
             >
               <LogOut className="h-4 w-4" />
-              탈퇴
+              밴드 탈퇴
             </Button>
           )}
           {isLeader && (
@@ -111,30 +124,37 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
         </div>
       </header>
 
-      <Tabs defaultValue="info">
-        <TabsList aria-label="밴드 상세 탭">
-          <TabsTrigger value="info">정보</TabsTrigger>
-          <TabsTrigger value="members">멤버</TabsTrigger>
-          {isLeader && <TabsTrigger value="applications">신청 현황</TabsTrigger>}
-        </TabsList>
+      <Tabs defaultValue="info" variant="underline">
+        {/* Tab bar — 48px height, 32px horizontal padding */}
+        <div className="px-s-5 lg:px-8">
+          <TabsList aria-label="밴드 상세 탭">
+            <TabsTrigger value="info">정보</TabsTrigger>
+            <TabsTrigger value="members">멤버</TabsTrigger>
+            {isLeader && <TabsTrigger value="applications">신청 현황</TabsTrigger>}
+          </TabsList>
+        </div>
 
-        <TabsContent value="info">
-          <InfoTab
-            description={band.description}
-            profileImg={band.profileImg}
-            bandName={band.bandName}
-          />
-        </TabsContent>
-
-        <TabsContent value="members">
-          <MembersTab bandId={bandId} />
-        </TabsContent>
-
-        {isLeader && (
-          <TabsContent value="applications">
-            <ApplicationsTab bandId={bandId} />
+        {/* Content — padding 24px / 32px */}
+        <div className="px-s-5 py-s-6 lg:px-8" data-slot="band-detail-content">
+          <TabsContent value="info" className="mt-0">
+            <InfoTab
+              bandId={bandId}
+              bandName={band.bandName}
+              description={band.description}
+              profileImg={band.profileImg}
+            />
           </TabsContent>
-        )}
+
+          <TabsContent value="members" className="mt-0">
+            <MembersTab bandId={bandId} />
+          </TabsContent>
+
+          {isLeader && (
+            <TabsContent value="applications" className="mt-0">
+              <ApplicationsTab bandId={bandId} />
+            </TabsContent>
+          )}
+        </div>
       </Tabs>
 
       <Dialog open={leaveOpen} onOpenChange={setLeaveOpen}>
@@ -169,18 +189,23 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
 }
 
 function InfoTab({
+  bandId,
   bandName,
   description,
   profileImg,
 }: {
+  bandId: string;
   bandName: string;
   description?: string;
   profileImg?: string;
 }) {
+  const members = useBandMembers(bandId, 20);
+  const memberCount = members.data?.pages.flatMap((p) => p.content).length ?? 0;
+
   return (
-    <div className="space-y-s-5">
+    <div className="space-y-s-6">
       <div
-        className="bg-card border-border flex aspect-[3/1] w-full items-center justify-center overflow-hidden rounded-lg border"
+        className="bg-card border-border flex h-[220px] w-full items-center justify-center overflow-hidden rounded-2xl border"
         data-slot="band-cover"
         aria-label={`${bandName} 커버 이미지`}
       >
@@ -189,15 +214,19 @@ function InfoTab({
           <img src={profileImg} alt={`${bandName} 커버`} className="h-full w-full object-cover" />
         ) : (
           <div className="text-foreground-muted gap-s-2 flex flex-col items-center text-xs">
-            <Camera className="h-6 w-6" aria-hidden="true" />
+            <Camera className="h-7 w-7" aria-hidden="true" />
             band cover image
           </div>
         )}
       </div>
-      <div className="space-y-s-2">
+
+      <div className="space-y-s-2 max-w-[720px]">
         <h2 className="text-foreground text-title font-extrabold">{bandName}</h2>
         <p className="text-foreground-sub text-body leading-relaxed">
           {description ?? '소개가 등록되지 않았습니다.'}
+        </p>
+        <p className="text-foreground-muted text-caption">
+          {members.isLoading ? '멤버 정보를 불러오는 중…' : `멤버 ${memberCount}명`}
         </p>
       </div>
     </div>
@@ -238,9 +267,9 @@ function MembersTab({ bandId }: { bandId: string }) {
 }
 
 const STATUS_FILTERS: { value: ApplicationStatus; label: string }[] = [
-  { value: 'PENDING', label: '대기' },
-  { value: 'APPROVED', label: '승인' },
-  { value: 'REJECTED', label: '거절' },
+  { value: 'PENDING', label: '대기중' },
+  { value: 'APPROVED', label: '승인됨' },
+  { value: 'REJECTED', label: '거부됨' },
 ];
 
 function ApplicationsTab({ bandId }: { bandId: string }) {
@@ -249,6 +278,7 @@ function ApplicationsTab({ bandId }: { bandId: string }) {
     useBandApplications(bandId, status, 20);
 
   const apps = data?.pages.flatMap((p) => p.content) ?? [];
+  const currentLabel = STATUS_FILTERS.find((f) => f.value === status)?.label ?? '';
 
   return (
     <div className="space-y-s-4">
@@ -269,9 +299,7 @@ function ApplicationsTab({ bandId }: { bandId: string }) {
       ) : isError ? (
         <ErrorState onRetry={() => refetch()} />
       ) : apps.length === 0 ? (
-        <EmptyState
-          title={`${STATUS_FILTERS.find((f) => f.value === status)?.label} 상태 신청이 없습니다`}
-        />
+        <EmptyState title={`${currentLabel} 상태 신청이 없습니다`} />
       ) : (
         <div className="space-y-s-2">
           {apps.map((a) => (

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,44 +1,68 @@
 'use client';
 
 import { Root, List, Trigger, Content } from '@radix-ui/react-tabs';
-import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+} from 'react';
 
 import { cn } from '@/lib/cn';
 
-export const Tabs = Root;
+export type TabsVariant = 'pill' | 'underline';
+
+const TabsVariantContext = createContext<TabsVariant>('pill');
+
+type TabsRootProps = ComponentPropsWithoutRef<typeof Root> & { variant?: TabsVariant };
+
+export const Tabs = forwardRef<ElementRef<typeof Root>, TabsRootProps>(function Tabs(
+  { variant = 'pill', children, ...props },
+  ref,
+) {
+  return (
+    <TabsVariantContext.Provider value={variant}>
+      <Root ref={ref} {...props}>
+        {children}
+      </Root>
+    </TabsVariantContext.Provider>
+  );
+});
+
+const listVariantClasses: Record<TabsVariant, string> = {
+  pill: 'border-border bg-surface text-foreground-sub inline-flex gap-1 rounded-md border p-1',
+  underline: 'border-border text-foreground-sub flex w-full gap-s-6 border-b',
+};
 
 export const TabsList = forwardRef<ElementRef<typeof List>, ComponentPropsWithoutRef<typeof List>>(
   function TabsList({ className, ...props }, ref) {
-    return (
-      <List
-        ref={ref}
-        className={cn(
-          'border-border bg-surface text-foreground-sub inline-flex gap-1 rounded-md border p-1',
-          className,
-        )}
-        {...props}
-      />
-    );
+    const variant = useContext(TabsVariantContext);
+    return <List ref={ref} className={cn(listVariantClasses[variant], className)} {...props} />;
   },
 );
+
+const triggerVariantClasses: Record<TabsVariant, string> = {
+  pill: cn(
+    'inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium transition-colors',
+    'hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+    'data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+    'disabled:pointer-events-none disabled:opacity-50',
+  ),
+  underline: cn(
+    'inline-flex h-12 items-center justify-center -mb-px border-b-2 border-transparent px-1 text-sm font-medium transition-colors',
+    'hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+    'data-[state=active]:border-accent data-[state=active]:text-accent',
+    'disabled:pointer-events-none disabled:opacity-50',
+  ),
+};
 
 export const TabsTrigger = forwardRef<
   ElementRef<typeof Trigger>,
   ComponentPropsWithoutRef<typeof Trigger>
 >(function TabsTrigger({ className, ...props }, ref) {
-  return (
-    <Trigger
-      ref={ref}
-      className={cn(
-        'inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium transition-colors',
-        'hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-        'data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=active]:shadow-sm',
-        'disabled:pointer-events-none disabled:opacity-50',
-        className,
-      )}
-      {...props}
-    />
-  );
+  const variant = useContext(TabsVariantContext);
+  return <Trigger ref={ref} className={cn(triggerVariantClasses[variant], className)} {...props} />;
 });
 
 export const TabsContent = forwardRef<


### PR DESCRIPTION
## Summary

`handoff/band-detail.md` (TopBar 72px / Tab bar 48px / content 24·32 padding) 와 `handoff/specs/03-band.md` 스펙에 맞춰 BandDetailContent 레이아웃을 다시 정렬.

| 영역 | 변경 |
|---|---|
| TopBar | height **72px**, padding `0 32px`, 하단 1px border. "밴드 탐색" breadcrumb + 밴드명(22px/700) + 우측 액션 버튼 |
| Tabs | **underline** variant 신설 — 활성 탭 하단 2px accent 보더. BandDetailContent 만 `variant="underline"` 사용, ListPane mine/discover 등 기존 호출은 `pill` 기본값 유지 |
| Content | padding `24px 32px` |
| TopBar 액션 버튼 | LEADER → 밴드 설정 / MEMBER → 탈퇴 / 비회원 → 가입 신청. (handoff 원본은 LEADER+ADMIN 이지만 BE 에 ADMIN 역할 미정의 → 본 라운드 LEADER 전용) |
| 신청 현황 탭 | LEADER 전용 유지, 상태 chip 라벨을 `대기중/승인됨/거부됨` 으로 정렬 |
| 정보 탭 | 커버 이미지 placeholder **220px / 16px round** + 밴드명 + 설명 + "멤버 N명" 메타 |

## API_REQUIRED.md 갱신

- 항목 8 (`BandApplicationInfoResponse` 풍부화) 에 **`appliedAt`** 필드 누락 명시 — 현재 신청 카드에 신청 시각 노출 불가
- 항목 8-2 (멤버 강퇴/역할 변경) 신설 — 향후 "밴드 설정" 화면용

## task_004 md

handoff 스펙으로 재기술. 서브태스크 4.4 (LEADER+ADMIN 권한 확장) 은 BE 에 ADMIN 역할이 정의되지 않아 본 라운드 스킵으로 표시.

## Linked Issues

Closes #64. 의존: #61, #62.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 48 passed
- [ ] 1024 / 1280 / 1440 / 1920 px viewport 비율 검증 (Phase H)

## Note

지난 PR #74 / #76 도 같은 #64 의 작업이며, 이번 PR 이 최종 상태.