### PR TITLE
refactor: UUID 비노출 / 멤버 표시명 정상화 (Task 7)

### DIFF
--- a/API_REQUIRED.md
+++ b/API_REQUIRED.md
@@ -90,6 +90,16 @@ GET /api/v1/bands?q=<keyword>&genre=<genre>&memberOnly=<bool>&pageSize=20&lastId
 - `PATCH /api/v1/bands/{bandId}/members/{bandMemberId}/role` — 리더의 멤버 역할 변경 (LEADER 위임은 기존 API 유지, ADMIN ↔ MEMBER 강등/승급 신규)
 - 프론트 사용처: 향후 "밴드 설정" 화면. 현재는 toast info 안내만 (P2).
 
+### 8-3. 멤버 표시명 정상화 (FE-API-012 / 013 / 014)
+
+화면에 UUID·숫자 ID 가 노출되지 않도록 `getMemberDisplayName` 유틸이 `name` 우선 → 마지막 4자리 폴백을 적용 중. 백엔드가 아래 응답에 `name` 을 포함하면 자동으로 정상화된다.
+
+- **FE-API-012** `BandMemberInfoResponse` — `name: string`, `profileImg?: string` 추가
+- **FE-API-013** `BandApplicationInfoResponse` — `applicantName: string`, `applicantProfileImg?: string` 추가 (8 항목과 일관)
+- **FE-API-014** `PracticeParticipantResponse` 및 `PracticeSessionResponse.participant` — `name: string` 추가
+- 프론트 사용처: `BandMemberRow`, `BandApplicationRow`, `SessionRow`, `PracticeDetailContent` 참여자 목록
+- 현재 우회: `name` 미존재 시 `"멤버 #{memberId 마지막 4자리}"` 표시
+
 ### 9. 프로필 이미지 업로드 엔드포인트
 
 - `POST /api/v1/members/me/profile-image` (멀티파트) 또는 사전 서명 URL 발급 후 S3 직접 업로드.

--- a/src/app/(main)/practices/[practiceId]/PracticeDetailContent.client.tsx
+++ b/src/app/(main)/practices/[practiceId]/PracticeDetailContent.client.tsx
@@ -31,6 +31,7 @@ import { useDeletePractice } from '@/domain/practice/hooks/useDeletePractice';
 import { usePractice } from '@/domain/practice/hooks/usePractice';
 import { useUpdateSchedule } from '@/domain/practice/hooks/useUpdateSchedule';
 import { addParticipantSchema, type AddParticipantSchema } from '@/domain/practice/types';
+import { getMemberDisplayName } from '@/domain/member/utils';
 import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
 
@@ -204,8 +205,7 @@ export function PracticeDetailContent({ practiceId }: { practiceId: string }) {
                 <ul className="space-y-2">
                   {practice.participants.map((p) => (
                     <li key={p.participantId} className="text-foreground-sub text-sm">
-                      Member #{p.memberId}
-                      <span className="text-foreground-muted ml-2 text-xs">{p.participantId}</span>
+                      {getMemberDisplayName({ memberId: p.memberId, name: p.name })}
                     </li>
                   ))}
                 </ul>

--- a/src/domain/band/components/BandApplicationRow.tsx
+++ b/src/domain/band/components/BandApplicationRow.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useDecideApplication } from '@/domain/band/hooks/useDecideApplication';
+import { getMemberDisplayName } from '@/domain/member/utils';
 import { useToast } from '@/hooks/useToast';
 
 import type { BandApplicationInfoResponse } from '../types';
@@ -30,8 +31,10 @@ export function BandApplicationRow({ bandId, application }: Props) {
   });
 
   const isPending = application.status === 'PENDING';
-  // 신청자 표시명: 백엔드가 name 을 아직 안 주므로 임시로 "Member #{memberId}" 사용 (Phase G 에서 정상화)
-  const displayName = `Member #${application.memberId}`;
+  const displayName = getMemberDisplayName({
+    memberId: application.memberId,
+    name: application.applicantName,
+  });
 
   return (
     <div

--- a/src/domain/band/components/BandMemberRow.tsx
+++ b/src/domain/band/components/BandMemberRow.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useDelegateLeader } from '@/domain/band/hooks/useDelegateLeader';
+import { getMemberDisplayName } from '@/domain/member/utils';
 import { RoleGuard } from '@/global/auth/RoleGuard';
 import { useToast } from '@/hooks/useToast';
 
@@ -36,8 +37,7 @@ export function BandMemberRow({ bandId, member }: Props) {
     onError: (err) => toast.error(err.message || '리더 위임에 실패했습니다.'),
   });
 
-  // 멤버 표시명: 백엔드가 name 을 아직 안 주므로 임시로 "Member #{memberId}" 사용 (Phase G 에서 정상화)
-  const displayName = `Member #${member.memberId}`;
+  const displayName = getMemberDisplayName({ memberId: member.memberId, name: member.name });
 
   return (
     <div

--- a/src/domain/band/types/res.ts
+++ b/src/domain/band/types/res.ts
@@ -16,10 +16,19 @@ export interface BandMemberInfoResponse {
   bandMemberId: string;
   memberId: number;
   role: BandRole;
+  /** 백엔드 미지원 시 undefined. API_REQUIRED.md FE-API-012 참조. */
+  name?: string;
+  /** 동일 사유 — API 추가 시 자동 반영. */
+  profileImg?: string;
 }
 
 export interface BandApplicationInfoResponse {
   bandApplicationId: string;
   memberId: number;
   status: ApplicationStatus;
+  /** 백엔드 미지원 시 undefined. API_REQUIRED.md FE-API-013 참조. */
+  applicantName?: string;
+  applicantProfileImg?: string;
+  /** 신청 일시. 동일 사유. */
+  appliedAt?: string;
 }

--- a/src/domain/member/utils/getMemberDisplayName.ts
+++ b/src/domain/member/utils/getMemberDisplayName.ts
@@ -1,0 +1,18 @@
+/**
+ * 멤버 표시명을 일관된 규칙으로 반환한다.
+ * - name 이 있으면 그대로 사용
+ * - 없으면 "멤버 #{memberId 마지막 4자리}" 폴백
+ *
+ * UUID 전체나 긴 숫자 ID 가 화면에 노출되지 않도록 하기 위한 단일 진입점.
+ * 백엔드가 `name` 을 응답에 포함하면 자동으로 정상화된다 (API_REQUIRED.md FE-API-012/013).
+ */
+export function getMemberDisplayName(member: {
+  memberId: string | number;
+  name?: string | null;
+}): string {
+  const trimmed = member.name?.trim();
+  if (trimmed) return trimmed;
+  const id = String(member.memberId);
+  const tail = id.slice(-4);
+  return `멤버 #${tail || id}`;
+}

--- a/src/domain/member/utils/index.ts
+++ b/src/domain/member/utils/index.ts
@@ -1,0 +1,1 @@
+export { getMemberDisplayName } from './getMemberDisplayName';

--- a/src/domain/practice/components/SessionRow.tsx
+++ b/src/domain/practice/components/SessionRow.tsx
@@ -16,6 +16,7 @@ import {
 import { useAssignSession } from '@/domain/practice/hooks/useAssignSession';
 import { useDeleteSession } from '@/domain/practice/hooks/useDeleteSession';
 import { useUnassignSession } from '@/domain/practice/hooks/useUnassignSession';
+import { getMemberDisplayName } from '@/domain/member/utils';
 import { useToast } from '@/hooks/useToast';
 
 import type { PracticeSessionResponse } from '../types';
@@ -52,7 +53,11 @@ export function SessionRow({ practiceId, session }: Props) {
         <span className="text-foreground truncate text-sm font-medium">{session.label}</span>
         {isAssigned ? (
           <span className="text-foreground-sub truncate text-xs">
-            담당: Member #{session.participant!.memberId}
+            담당:{' '}
+            {getMemberDisplayName({
+              memberId: session.participant!.memberId,
+              name: session.participant!.name,
+            })}
           </span>
         ) : (
           <span className="text-foreground-muted truncate text-xs">담당 없음</span>

--- a/src/domain/practice/types/res.ts
+++ b/src/domain/practice/types/res.ts
@@ -15,6 +15,8 @@ export interface PracticeSongResponse {
 export interface PracticeParticipantResponse {
   participantId: string;
   memberId: number;
+  /** 백엔드 미지원 시 undefined. API_REQUIRED.md FE-API-014 참조. */
+  name?: string;
 }
 
 export interface PracticeSessionResponse {


### PR DESCRIPTION
## Summary

UUID 와 숫자 ID 가 화면에 노출되지 않도록 단일 유틸 `getMemberDisplayName` 으로 일관 처리.

| 영역 | 변경 |
|---|---|
| `src/domain/member/utils/getMemberDisplayName.ts` (신설) | `name` 우선, 없으면 `"멤버 #{id 마지막 4자리}"` 폴백 |
| `BandMemberRow` / `BandApplicationRow` | `'Member #{full id}'` 텍스트 제거 → 유틸 사용 |
| `PracticeDetailContent` 참여자 목록 | `participantId` UUID 노출 제거 + 유틸 적용 |
| `SessionRow` | `'담당: Member #{id}'` → 유틸 사용 |
| 타입 | `BandMemberInfoResponse` / `BandApplicationInfoResponse` / `PracticeParticipantResponse` 에 `name?`, `profileImg?`, `applicantName?`, `appliedAt?` optional 필드 추가 (BE 미지원 시 undefined) |
| `API_REQUIRED.md` | 8-3 항목 신설: FE-API-012/013/014 (응답에 `name`/`profileImg` 포함 요청) |

## 검증

- `grep "Member #"` 잔여 0건
- `participantId` / `bandApplicationId` 가 텍스트로 노출되는 곳 없음 (key prop 으로만 사용)
- 백엔드가 `name` 필드를 응답에 추가하면 코드 변경 없이 자동 정상화

## Linked Issues

Closes #67.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 48 passed