### PR TITLE
refactor: 신규 me 엔드포인트 API/타입 통합

### DIFF
--- a/src/domain/band/api/getMyBands.ts
+++ b/src/domain/band/api/getMyBands.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { MyBandInfoResponse } from '../types';
+
+type GetMyBandsParams = {
+  lastId?: string;
+  pageSize: number;
+};
+
+/** API_SPEC §3-3-1 — 현재 로그인 회원이 소속된 밴드 목록 (myRole 포함). */
+export async function getMyBands(
+  params: GetMyBandsParams,
+): Promise<CursorResponse<MyBandInfoResponse, string>> {
+  const data = await apiClient.get<CursorResponse<MyBandInfoResponse, string> | null>(
+    '/api/v1/bands/me',
+    { query: { lastId: params.lastId, pageSize: params.pageSize } },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/band/api/searchBands.ts
+++ b/src/domain/band/api/searchBands.ts
@@ -1,0 +1,27 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { BandInfoResponse } from '../types';
+
+type SearchBandsParams = {
+  keyword: string;
+  lastId?: string;
+  pageSize: number;
+};
+
+/** API_SPEC §3-3-2 — 밴드명에 keyword 가 포함된 밴드 검색 (대소문자 구분 없음). */
+export async function searchBands(
+  params: SearchBandsParams,
+): Promise<CursorResponse<BandInfoResponse, string>> {
+  const data = await apiClient.get<CursorResponse<BandInfoResponse, string> | null>(
+    '/api/v1/bands/search',
+    {
+      query: {
+        keyword: params.keyword,
+        lastId: params.lastId,
+        pageSize: params.pageSize,
+      },
+    },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/band/types/index.ts
+++ b/src/domain/band/types/index.ts
@@ -2,6 +2,7 @@ export type { CreateBandRequest, BandApplicationDecision } from './req';
 export type {
   CreateBandResponse,
   BandInfoResponse,
+  MyBandInfoResponse,
   BandMemberInfoResponse,
   BandApplicationInfoResponse,
 } from './res';

--- a/src/domain/band/types/res.ts
+++ b/src/domain/band/types/res.ts
@@ -12,6 +12,11 @@ export interface BandInfoResponse {
   profileImg?: string;
 }
 
+/** API_SPEC §3-3-1 — `/bands/me` 응답 항목. 본인의 밴드 내 역할(myRole) 포함. */
+export interface MyBandInfoResponse extends BandInfoResponse {
+  myRole: BandRole;
+}
+
 export interface BandMemberInfoResponse {
   bandMemberId: string;
   memberId: number;

--- a/src/domain/performance/api/getMyPerformances.ts
+++ b/src/domain/performance/api/getMyPerformances.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { PerformanceListItemResponse } from '../types';
+
+type GetMyPerformancesParams = {
+  lastId?: string;
+  pageSize: number;
+};
+
+/** API_SPEC §6-2-1 — 현재 로그인 회원의 소속 밴드가 참여하는 모든 공연. */
+export async function getMyPerformances(
+  params: GetMyPerformancesParams,
+): Promise<CursorResponse<PerformanceListItemResponse, string>> {
+  const data = await apiClient.get<CursorResponse<PerformanceListItemResponse, string> | null>(
+    '/api/v1/performances/me',
+    { query: { lastId: params.lastId, pageSize: params.pageSize } },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/performance/api/searchPerformances.ts
+++ b/src/domain/performance/api/searchPerformances.ts
@@ -1,0 +1,27 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { PerformanceListItemResponse } from '../types';
+
+type SearchPerformancesParams = {
+  keyword: string;
+  lastId?: string;
+  pageSize: number;
+};
+
+/** API_SPEC §6-2-2 — 공연 제목에 keyword 포함 (대소문자 구분 없음). */
+export async function searchPerformances(
+  params: SearchPerformancesParams,
+): Promise<CursorResponse<PerformanceListItemResponse, string>> {
+  const data = await apiClient.get<CursorResponse<PerformanceListItemResponse, string> | null>(
+    '/api/v1/performances/search',
+    {
+      query: {
+        keyword: params.keyword,
+        lastId: params.lastId,
+        pageSize: params.pageSize,
+      },
+    },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/practice/api/getMyPractices.ts
+++ b/src/domain/practice/api/getMyPractices.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { PracticeListItemResponse } from '../types';
+
+type GetMyPracticesParams = {
+  lastId?: string;
+  pageSize: number;
+};
+
+/** API_SPEC §4-1-1 — 현재 로그인 회원이 참여 중인 합주 목록. */
+export async function getMyPractices(
+  params: GetMyPracticesParams,
+): Promise<CursorResponse<PracticeListItemResponse, string>> {
+  const data = await apiClient.get<CursorResponse<PracticeListItemResponse, string> | null>(
+    '/api/v1/practices/me',
+    { query: { lastId: params.lastId, pageSize: params.pageSize } },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/practice/api/searchMyPractices.ts
+++ b/src/domain/practice/api/searchMyPractices.ts
@@ -1,0 +1,27 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { PracticeListItemResponse } from '../types';
+
+type SearchMyPracticesParams = {
+  keyword: string;
+  lastId?: string;
+  pageSize: number;
+};
+
+/** API_SPEC §4-1-3 — 본인 참여 합주 중 합주 타이틀/곡 제목에 keyword 포함. */
+export async function searchMyPractices(
+  params: SearchMyPracticesParams,
+): Promise<CursorResponse<PracticeListItemResponse, string>> {
+  const data = await apiClient.get<CursorResponse<PracticeListItemResponse, string> | null>(
+    '/api/v1/practices/me/search',
+    {
+      query: {
+        keyword: params.keyword,
+        lastId: params.lastId,
+        pageSize: params.pageSize,
+      },
+    },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/global/config/queryKeys.ts
+++ b/src/global/config/queryKeys.ts
@@ -9,6 +9,7 @@ export const queryKeys = {
     all: ['band'] as const,
     list: () => [...queryKeys.band.all, 'list'] as const,
     my: () => [...queryKeys.band.all, 'my'] as const,
+    search: (keyword: string) => [...queryKeys.band.all, 'search', keyword] as const,
     detail: (id: string) => [...queryKeys.band.all, id] as const,
     members: (id: string) => [...queryKeys.band.all, id, 'members'] as const,
     applications: (id: string, status?: string) =>
@@ -17,6 +18,8 @@ export const queryKeys = {
   practice: {
     all: ['practice'] as const,
     list: (bandId?: string) => [...queryKeys.practice.all, 'list', bandId ?? null] as const,
+    my: () => [...queryKeys.practice.all, 'my'] as const,
+    mySearch: (keyword: string) => [...queryKeys.practice.all, 'my', 'search', keyword] as const,
     upcoming: (limit: number) => [...queryKeys.practice.all, 'upcoming', limit] as const,
     detail: (id: string) => [...queryKeys.practice.all, id] as const,
     songs: (id: string) => [...queryKeys.practice.all, id, 'songs'] as const,
@@ -24,6 +27,8 @@ export const queryKeys = {
   performance: {
     all: ['performance'] as const,
     list: (bandId?: string) => [...queryKeys.performance.all, 'list', bandId ?? null] as const,
+    my: () => [...queryKeys.performance.all, 'my'] as const,
+    search: (keyword: string) => [...queryKeys.performance.all, 'search', keyword] as const,
     upcoming: (limit: number) => [...queryKeys.performance.all, 'upcoming', limit] as const,
     detail: (id: string) => [...queryKeys.performance.all, id] as const,
   },


### PR DESCRIPTION
## Summary
- API_SPEC.md (2026-04-25) 가 새로 추가한 me/search 엔드포인트들을 도메인 API 함수 + 타입으로 통합
- `MyBandInfoResponse` (myRole 포함) 추가, `getMyBands`/`searchBands`/`getMyPractices`/`searchMyPractices`/`getMyPerformances`/`searchPerformances` 6개 API 함수 신설
- `queryKeys` 에 me/search 네임스페이스 추가

호출부는 Task 2 (TanStack Query 훅) / Task 3 (페이지 적용) 에서 교체.

## Test plan
- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과
- [ ] Task 2 에서 훅 결합 후 실서버 검증 (mvp-1-fix-v3 Task 8)

closes #80