### PR TITLE
refactor: 내 리소스 vs 탐색 화면 데이터 소스 정렬

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -2466,7 +2466,7 @@
         "dependencies": [
           "1"
         ],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -2474,9 +2474,10 @@
             "description": "기존 getBands 우회 호출 방식을 Task 1에서 구현한 getMyBands API 직접 호출로 교체하고, 반환 타입을 MyBandInfoResponse[]로 변경한다.",
             "dependencies": [],
             "details": "src/domain/band/hooks/useMyBands.ts 수정:\n- import 경로를 getBands에서 getMyBands로 변경\n- 반환 타입을 BandInfoResponse[]에서 MyBandInfoResponse[]로 변경 (myRole 포함)\n- queryFn 내부에서 getMyBands({ pageSize: limit }) 호출\n- queryKey는 기존 queryKeys.band.my() 유지하여 캐시 키 호환성 보장\n- 기존 limit 인터페이스 그대로 유지하여 호출측(HomeStatCards, BandsListPane 등) 하위 호환성 확보\n- 파일 상단 NOTE 주석 제거 (더 이상 우회 호출이 아니므로)",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "1. useMyBands 훅 호출 후 반환 데이터에 myRole 필드 존재 확인\n2. 기존 호출부(HomeStatCards.client.tsx, BandsListPane.client.tsx, MyBands.tsx)에서 동작 회귀 없는지 확인\n3. React Query DevTools에서 queryKeys.band.my() 캐시 키 정상 동작 확인\n4. pnpm typecheck 통과",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-25T15:32:42.367Z"
           },
           {
             "id": 2,
@@ -2486,9 +2487,10 @@
               1
             ],
             "details": "src/domain/band/hooks/useBandSearch.ts 신규 생성:\n- 'use client' 지시어 추가\n- useInfiniteCursor<BandInfoResponse, string> 활용\n- 함수 시그니처: useBandSearch(keyword: string, pageSize: number = 20)\n- queryKey: queryKeys.band.search(keyword)와 pageSize 조합\n- keyword가 빈 문자열일 때 enabled: false로 불필요한 요청 방지\n- keyword 디바운스는 호출측(탐색 화면)에서 useDebounce 훅으로 처리하므로 훅 내부에서는 처리하지 않음\n- types/index.ts에서 export 추가 불필요 (훅이므로)",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "1. keyword 빈 문자열일 때 API 호출되지 않음 확인\n2. keyword 변경 시 캐시 키 분리되어 각각 독립 쿼리 동작 확인\n3. 페이지네이션(fetchNextPage, hasNextPage) 정상 동작 확인\n4. pnpm typecheck && pnpm lint 통과",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-25T15:32:47.142Z"
           },
           {
             "id": 3,
@@ -2498,9 +2500,10 @@
               1
             ],
             "details": "1. src/domain/practice/hooks/useMyPractices.ts 신규 생성:\n- useInfiniteCursor<PracticeListItemResponse, string> 활용\n- queryKey: queryKeys.practice.my()와 pageSize 조합\n- getMyPractices API 호출\n\n2. src/domain/practice/hooks/useBandPractices.ts 신규 생성:\n- 기존 usePractices.ts와 유사하나 bandId 필수 파라미터로 변경\n- queryKey: queryKeys.practice.list(bandId)와 pageSize 조합\n- getPractices({ bandId, lastId, pageSize }) API 호출\n- 밴드 상세 화면의 합주 탭에서 사용할 목적\n\n기존 usePractices.ts는 bandId가 optional이어서 전체/밴드별 겸용이었으나, 역할 분리를 위해 useBandPractices 추가",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "1. useMyPractices 호출 후 로그인한 사용자의 합주 목록만 반환 확인\n2. useBandPractices(bandId) 호출 시 해당 밴드 합주만 필터링 확인\n3. 각 훅의 무한 스크롤 정상 동작 확인\n4. pnpm typecheck && pnpm lint 통과",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-25T15:32:54.475Z"
           },
           {
             "id": 4,
@@ -2510,9 +2513,10 @@
               1
             ],
             "details": "src/domain/performance/hooks/useMyPerformances.ts 신규 생성:\n- 'use client' 지시어 추가\n- useInfiniteCursor<PerformanceListItemResponse, string> 활용\n- 함수 시그니처: useMyPerformances(pageSize: number = 20)\n- queryKey: queryKeys.performance.my()와 pageSize 조합\n- Task 1에서 구현한 getMyPerformances API 호출\n- 기존 usePerformanceList(bandId?)와 역할 분리: useMyPerformances는 내 공연 전용, usePerformanceList는 밴드별/전체 탐색용\n- queryKeys.ts에 performance.my() 추가는 Task 1에서 완료되어 있어야 함",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "1. useMyPerformances 호출 후 로그인한 사용자 관련 공연 목록만 반환 확인\n2. 무한 스크롤(fetchNextPage, hasNextPage) 정상 동작 확인\n3. React Query DevTools에서 캐시 키 분리 확인\n4. pnpm typecheck && pnpm lint 통과",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-25T15:32:58.977Z"
           },
           {
             "id": 5,
@@ -2522,12 +2526,13 @@
               1
             ],
             "details": "src/global/auth/useBandRole.ts 리팩토링:\n- 기존 구현: useMe로 memberId 확보 후 getBandMembers 최대 100건씩 10페이지 순회하며 매칭 (최악 1000건 조회)\n- 신규 구현: useMyBands(100) 결과에서 bandId 매칭하여 myRole 반환\n- 핵심 변경:\n  1. getBandMembers import 제거\n  2. useMe 의존성 제거 (useMyBands가 인증 사용자 기준으로 동작)\n  3. const { data: myBands } = useMyBands(100);\n  4. const match = myBands?.find(b => b.bandId === bandId);\n  5. return { data: match?.myRole ?? null, isLoading, ... };\n- queryKey 변경: 기존 [...queryKeys.band.members(bandId), 'my-role', memberId] → 불필요 (useMyBands 내부 키 사용)\n- 비멤버인 경우 myBands에 해당 bandId가 없으므로 null 반환 (기존 동작과 동일)\n- RoleGuard, BandDetailContent 등 기존 호출부에서 인터페이스 변경 없이 동작",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "1. 기존 useBandRole 반환값(BandRole | null)이 동일하게 유지되는지 통합 테스트\n2. RoleGuard 컴포넌트에서 권한 체크 정상 동작 확인\n3. BandDetailContent에서 isMember, isLeader 판정 정상 동작 확인\n4. API 호출 횟수 감소 확인 (Network 탭에서 getBandMembers 호출 제거)\n5. pnpm typecheck && pnpm lint 통과",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-25T15:33:03.116Z"
           }
         ],
-        "updatedAt": "2026-04-25T15:28:00.319Z"
+        "updatedAt": "2026-04-25T15:33:03.116Z"
       },
       {
         "id": "3",
@@ -3044,9 +3049,9 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-04-25T15:28:00.323Z",
+      "lastModified": "2026-04-25T15:33:03.118Z",
       "taskCount": 9,
-      "completedCount": 1,
+      "completedCount": 2,
       "tags": [
         "mvp-1-fix-v3"
       ]

--- a/src/app/(main)/bands/BandsListPane.client.tsx
+++ b/src/app/(main)/bands/BandsListPane.client.tsx
@@ -9,9 +9,10 @@ import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BandCreateModal } from '@/domain/band/components/BandCreateModal.client';
+import { BandRoleBadge } from '@/domain/band/components/BandRoleBadge';
 import { useBandList } from '@/domain/band/hooks/useBandList';
 import { useMyBands } from '@/domain/band/hooks/useMyBands';
-import type { BandInfoResponse } from '@/domain/band/types';
+import type { BandInfoResponse, MyBandInfoResponse } from '@/domain/band/types';
 import { ROUTES } from '@/global/config/routes';
 import { useDiscoverySearch } from '@/hooks/useDiscoverySearch';
 import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
@@ -23,7 +24,15 @@ const accessor = (b: BandInfoResponse) => `${b.bandName} ${b.description ?? ''}`
 
 type Tab = 'mine' | 'discover';
 
-function BandRow({ band, pathname }: { band: BandInfoResponse; pathname: string }) {
+function BandRow({
+  band,
+  pathname,
+  myRole,
+}: {
+  band: BandInfoResponse;
+  pathname: string;
+  myRole?: MyBandInfoResponse['myRole'];
+}) {
   const href = ROUTES.BAND_DETAIL(band.bandId);
   const active = pathname === href || pathname.startsWith(`${href}/`);
   return (
@@ -40,7 +49,10 @@ function BandRow({ band, pathname }: { band: BandInfoResponse; pathname: string 
       >
         <IconTile icon={<BandIcon />} size="sm" tone={DOMAIN_TONES.band} />
         <div className="min-w-0 flex-1">
-          <div className="text-body truncate font-semibold">{band.bandName}</div>
+          <div className="gap-s-2 flex items-center">
+            <span className="text-body truncate font-semibold">{band.bandName}</span>
+            {myRole && <BandRoleBadge role={myRole} />}
+          </div>
           {band.description && (
             <div className="text-foreground-muted text-caption mt-0.5 truncate">
               {band.description}
@@ -65,7 +77,7 @@ export function BandsListPane() {
   const accessorRef = useCallback(accessor, []);
   const { query, setQuery, filtered, isFiltering } = useDiscoverySearch(discoverBands, accessorRef);
 
-  // Mine (내 소속) — 백엔드 me-only 필터 도입 전까지 useMyBands(=getBands 첫 페이지) 그대로 사용
+  // Mine (내 소속) — API_SPEC §3-3-1 /bands/me (myRole 포함)
   const { data: myBands, isLoading: myLoading } = useMyBands(20);
 
   const onTabChange = (next: string) => {
@@ -120,7 +132,7 @@ export function BandsListPane() {
           ) : (
             <ul className="gap-s-1 flex flex-col">
               {myBands.map((b) => (
-                <BandRow key={b.bandId} band={b} pathname={pathname} />
+                <BandRow key={b.bandId} band={b} pathname={pathname} myRole={b.myRole} />
               ))}
             </ul>
           )}
@@ -149,9 +161,12 @@ export function BandsListPane() {
               </p>
             ) : (
               <ul className="gap-s-1 flex flex-col">
-                {filtered.map((b) => (
-                  <BandRow key={b.bandId} band={b} pathname={pathname} />
-                ))}
+                {filtered.map((b) => {
+                  const myEntry = myBands?.find((mb) => mb.bandId === b.bandId);
+                  return (
+                    <BandRow key={b.bandId} band={b} pathname={pathname} myRole={myEntry?.myRole} />
+                  );
+                })}
               </ul>
             )}
           </div>

--- a/src/app/(main)/performances/PerformancesListPane.client.tsx
+++ b/src/app/(main)/performances/PerformancesListPane.client.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { PerformanceCreateModal } from '@/domain/performance/components/PerformanceCreateModal.client';
-import { usePerformanceList } from '@/domain/performance/hooks/usePerformanceList';
+import { useMyPerformances } from '@/domain/performance/hooks/useMyPerformances';
 import type { PerformanceListItemResponse } from '@/domain/performance/types';
 import { ROUTES } from '@/global/config/routes';
 import { useDiscoverySearch } from '@/hooks/useDiscoverySearch';
@@ -54,7 +54,8 @@ export function PerformancesListPane() {
   const initialTab = (searchParams?.get('tab') === 'discover' ? 'discover' : 'mine') as Tab;
   const [tab, setTab] = useState<Tab>(initialTab);
 
-  const { data, isLoading } = usePerformanceList();
+  // /performances/me: 본인 소속 밴드 참여 공연만 (탐색은 디자인 컨펌 후 useSearchPerformances 로 이관 예정)
+  const { data, isLoading } = useMyPerformances();
   const all = data?.pages.flatMap((p) => p.content) ?? [];
   const accessorRef = useCallback(accessor, []);
   const { query, setQuery, filtered, isFiltering } = useDiscoverySearch(all, accessorRef);

--- a/src/app/(main)/practices/PracticesListPane.client.tsx
+++ b/src/app/(main)/practices/PracticesListPane.client.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { PracticeCreateModal } from '@/domain/practice/components/PracticeCreateModal.client';
-import { usePractices } from '@/domain/practice/hooks/usePractices';
+import { useMyPractices } from '@/domain/practice/hooks/useMyPractices';
 import type { PracticeListItemResponse } from '@/domain/practice/types';
 import { ROUTES } from '@/global/config/routes';
 import { useDiscoverySearch } from '@/hooks/useDiscoverySearch';
@@ -60,7 +60,8 @@ export function PracticesListPane() {
   const initialTab = (searchParams?.get('tab') === 'discover' ? 'discover' : 'mine') as Tab;
   const [tab, setTab] = useState<Tab>(initialTab);
 
-  const { data, isLoading } = usePractices(undefined, 20);
+  // 내가 속하지 않은 합주는 노출하지 않음 (사용자 정책 — 디자인 컨펌 대기 후 검색 탭은 useSearchMyPractices 로 이관 예정)
+  const { data, isLoading } = useMyPractices(20);
   const all = data?.pages.flatMap((p) => p.content) ?? [];
   const accessorRef = useCallback(accessor, []);
   const { query, setQuery, filtered, isFiltering } = useDiscoverySearch(all, accessorRef);

--- a/src/domain/performance/hooks/useUpcomingPerformances.ts
+++ b/src/domain/performance/hooks/useUpcomingPerformances.ts
@@ -4,14 +4,15 @@ import { useQuery } from '@tanstack/react-query';
 
 import { queryKeys } from '@/global/config/queryKeys';
 
-import { getPerformances } from '../api/getPerformances';
+import { getMyPerformances } from '../api/getMyPerformances';
 import type { PerformanceListItemResponse } from '../types';
 
+/** 본인 소속 밴드가 참여하는 공연 중 임박한 N건. API_SPEC §6-2-1 /performances/me 의 첫 페이지를 사용. */
 export function useUpcomingPerformances(limit: number = 2) {
   return useQuery<PerformanceListItemResponse[], Error>({
     queryKey: [...queryKeys.performance.upcoming(limit)],
     queryFn: async () => {
-      const page = await getPerformances({ pageSize: limit });
+      const page = await getMyPerformances({ pageSize: limit });
       return page.content;
     },
   });

--- a/src/domain/practice/hooks/useUpcomingPractices.ts
+++ b/src/domain/practice/hooks/useUpcomingPractices.ts
@@ -4,14 +4,15 @@ import { useQuery } from '@tanstack/react-query';
 
 import { queryKeys } from '@/global/config/queryKeys';
 
-import { getPractices } from '../api/getPractices';
+import { getMyPractices } from '../api/getMyPractices';
 import type { PracticeListItemResponse } from '../types';
 
+/** 본인 참여 합주 중 임박한 N건. API_SPEC §4-1-1 /practices/me 의 첫 페이지를 사용. */
 export function useUpcomingPractices(limit: number = 3) {
   return useQuery<PracticeListItemResponse[], Error>({
     queryKey: [...queryKeys.practice.upcoming(limit)],
     queryFn: async () => {
-      const page = await getPractices({ pageSize: limit });
+      const page = await getMyPractices({ pageSize: limit });
       return page.content;
     },
   });


### PR DESCRIPTION
## Summary
- BandsListPane '내 밴드' 카드 + 탐색 카드(이미 가입한 경우)에 myRole RoleBadge 노출
- PracticesListPane → useMyPractices, PerformancesListPane → useMyPerformances 로 데이터 소스 교체
- HomeStatCards 카운트(useUpcomingPractices/Performances) 도 me 엔드포인트로 전환
- BandDetailContent 가입 신청 버튼 노출 룰: useBandRole(myRole) 이 useMyBands 기반으로 단순화되어 자동으로 정확화됨 (코드 변경 X)

검색 탭(useDiscoverySearch 클라이언트 필터)은 디자인 컨펌 후 useSearchMyPractices/useSearchPerformances 로 후속 정리.

## Test plan
- [x] typecheck/lint
- [ ] Task 8 실서버 검증에서 me 엔드포인트 200 응답 확인

closes #84