### PR TITLE
feat: 홈 화면 섹션 노출 개수 상한 (최대 3건)

### DIFF
--- a/API_REQUIRED.md
+++ b/API_REQUIRED.md
@@ -122,6 +122,15 @@ mvp-1-fix-v3 Task 5 의 BandPickerModal 결과를 적용할 백엔드 엔드포�
 
 - **프론트 사용처**: `PracticeCreateWizard.submit` (현재 임시로 `<title> — <artist>` 텍스트 식별자 전송)
 
+### 8-7. 홈 피드 우선순위 정렬 (FE-API-019)
+
+홈 화면 '내 밴드 / 다가오는 합주 / 다가오는 공연' 섹션은 현재 클라이언트 측 `lib/home-feed.ts` 의 `pickUpcoming` 으로 startAt 오름차순 + 미래 필터링 + 상위 3건. 향후 백엔드가 활동성/우선순위 알고리즘을 적용한 별도 엔드포인트를 제공하면 클라이언트 정렬 제거 가능.
+
+- **GET `/api/v1/members/me/home-feed?limit=3`** (제안)
+- **응답**: `{ bands: [...], upcomingPractices: [...], upcomingPerformances: [...] }` 또는 도메인별 분리 엔드포인트
+- **프론트 사용처**: `UpcomingPractices`, `UpcomingPerformances`, `MyBands` (홈 한정 limit=3)
+- **현재 우회**: `pickUpcoming` 클라이언트 정렬
+
 ### 8-3. 멤버 표시명 정상화 (FE-API-012 / 013 / 014)
 
 화면에 UUID·숫자 ID 가 노출되지 않도록 `getMemberDisplayName` 유틸이 `name` 우선 → 마지막 4자리 폴백을 적용 중. 백엔드가 아래 응답에 `name` 을 포함하면 자동으로 정상화된다.

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -39,7 +39,7 @@ export default function HomePage() {
             title="내 밴드"
             action={<ViewAllLink href={ROUTES.BANDS} label="전체 밴드 보기" />}
           />
-          <MyBands limit={6} />
+          <MyBands limit={3} />
         </section>
         <section aria-labelledby="home-upcoming-practices">
           <SectionTitle

--- a/src/domain/performance/components/UpcomingPerformances.tsx
+++ b/src/domain/performance/components/UpcomingPerformances.tsx
@@ -6,12 +6,14 @@ import { EmptyState } from '@/components/feedback/empty-state';
 import { ErrorState } from '@/components/feedback/error-state';
 import { Skeleton } from '@/components/ui/skeleton';
 
+import { pickUpcoming } from '@/lib/home-feed';
+
 import { useUpcomingPerformances } from '../hooks/useUpcomingPerformances';
 
 import { PerformanceCard } from './PerformanceCard';
 
-export function UpcomingPerformances({ limit = 2 }: { limit?: number }) {
-  const { data, isLoading, isError, refetch } = useUpcomingPerformances(limit);
+export function UpcomingPerformances({ limit = 3 }: { limit?: number }) {
+  const { data, isLoading, isError, refetch } = useUpcomingPerformances(limit + 1);
 
   if (isLoading) {
     return (
@@ -27,8 +29,8 @@ export function UpcomingPerformances({ limit = 2 }: { limit?: number }) {
     return <ErrorState description="예정 공연을 불러오지 못했습니다." onRetry={() => refetch()} />;
   }
 
-  const performances = data ?? [];
-  if (performances.length === 0) {
+  const { items } = pickUpcoming(data ?? [], limit);
+  if (items.length === 0) {
     return (
       <EmptyState
         icon={CalendarDays}
@@ -40,7 +42,7 @@ export function UpcomingPerformances({ limit = 2 }: { limit?: number }) {
 
   return (
     <div className="space-y-3">
-      {performances.map((p) => (
+      {items.map((p) => (
         <PerformanceCard key={p.performanceId} performance={p} />
       ))}
     </div>

--- a/src/domain/practice/components/UpcomingPractices.tsx
+++ b/src/domain/practice/components/UpcomingPractices.tsx
@@ -6,12 +6,15 @@ import { EmptyState } from '@/components/feedback/empty-state';
 import { ErrorState } from '@/components/feedback/error-state';
 import { Skeleton } from '@/components/ui/skeleton';
 
+import { pickUpcoming } from '@/lib/home-feed';
+
 import { useUpcomingPractices } from '../hooks/useUpcomingPractices';
 
 import { PracticeCard } from './PracticeCard';
 
 export function UpcomingPractices({ limit = 3 }: { limit?: number }) {
-  const { data, isLoading, isError, refetch } = useUpcomingPractices(limit);
+  // limit+1 fetch 로 hasMore 판정. 백엔드 정렬은 ID 기준이라 본인 파일에서 startAt asc 재정렬 + 과거 제외.
+  const { data, isLoading, isError, refetch } = useUpcomingPractices(limit + 1);
 
   if (isLoading) {
     return (
@@ -29,8 +32,8 @@ export function UpcomingPractices({ limit = 3 }: { limit?: number }) {
     );
   }
 
-  const practices = data ?? [];
-  if (practices.length === 0) {
+  const { items } = pickUpcoming(data ?? [], limit);
+  if (items.length === 0) {
     return (
       <EmptyState
         icon={Music}
@@ -42,7 +45,7 @@ export function UpcomingPractices({ limit = 3 }: { limit?: number }) {
 
   return (
     <div className="space-y-3">
-      {practices.map((p) => (
+      {items.map((p) => (
         <PracticeCard key={p.practiceId} practice={p} />
       ))}
     </div>

--- a/src/lib/home-feed.ts
+++ b/src/lib/home-feed.ts
@@ -1,0 +1,45 @@
+/**
+ * 홈 화면 섹션의 임시 정렬/필터 유틸.
+ * 백엔드의 정식 home/feed 엔드포인트가 도입되기 전까지 클라이언트에서 적용.
+ *
+ * 추후 API_REQUIRED FE-API-019 (홈 피드 우선순위 정렬) 가 추가되면 본 유틸 제거 예정.
+ */
+
+interface HasStartAt {
+  startAt: string;
+}
+
+/**
+ * `startAt >= now` 인 항목만 startAt 오름차순 정렬 후 상위 `limit` 건 반환.
+ * 결과 + 더 많은 항목 존재 여부(`hasMore`) 도 함께 노출.
+ *
+ * @param items 입력 항목 (startAt 은 ISO 또는 'yyyy-MM-dd HH:mm' Asia/Seoul 가정)
+ * @param limit 최대 노출 개수
+ * @param now Date 인스턴스 (테스트 가능성 — 기본 Date.now)
+ */
+export function pickUpcoming<T extends HasStartAt>(
+  items: T[],
+  limit: number,
+  now: Date = new Date(),
+): { items: T[]; hasMore: boolean } {
+  const ts = now.getTime();
+  const upcoming = items
+    .filter((it) => {
+      const t = Date.parse(it.startAt.replace(' ', 'T') + ':00+09:00');
+      // 파싱 실패(NaN) 인 경우 보수적으로 포함.
+      return Number.isNaN(t) ? true : t >= ts;
+    })
+    .sort((a, b) => a.startAt.localeCompare(b.startAt));
+  return {
+    items: upcoming.slice(0, limit),
+    hasMore: upcoming.length > limit,
+  };
+}
+
+/** 단순 슬라이스 + hasMore 노출. (밴드 목록처럼 startAt 이 없는 항목용) */
+export function takeTop<T>(items: T[], limit: number): { items: T[]; hasMore: boolean } {
+  return {
+    items: items.slice(0, limit),
+    hasMore: items.length > limit,
+  };
+}


### PR DESCRIPTION
## Summary
- 'lib/home-feed.ts' pickUpcoming/takeTop 유틸
- UpcomingPractices/Performances: limit+1 fetch + startAt asc 정렬 + 과거 제외 + 상위 3건
- MyBands 홈 한정 limit 3
- API_REQUIRED FE-API-019 (홈 피드 정렬) 등록

closes #96