### PR TITLE
feat: 마법사 이탈 가드 (Navigation Guard)

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,10 +1,12 @@
 import { Suspense, type ReactNode } from 'react';
 
+import { LeaveConfirmDialog } from '@/components/feedback/leave-confirm-dialog';
 import { BottomNav } from '@/components/layout/bottom-nav';
 import { Container } from '@/components/layout/container';
 import { Shell } from '@/components/layout/shell';
 import { Sidebar } from '@/components/layout/sidebar';
 import { AuthBootstrapper } from '@/global/auth/AuthBootstrapper.client';
+import { DirtyFormProvider } from '@/global/navigation/dirty-form-context';
 
 /**
  * (main) 레이아웃.
@@ -24,21 +26,24 @@ export default function MainLayout({ children }: { children: ReactNode }) {
   return (
     <Suspense fallback={null}>
       <AuthBootstrapper>
-        {/* Desktop */}
-        <div className="hidden lg:block">
-          <Shell>
-            <Sidebar />
-            <main className="flex flex-1 flex-col overflow-hidden">{children}</main>
-          </Shell>
-        </div>
+        <DirtyFormProvider>
+          {/* Desktop */}
+          <div className="hidden lg:block">
+            <Shell>
+              <Sidebar />
+              <main className="flex flex-1 flex-col overflow-hidden">{children}</main>
+            </Shell>
+          </div>
 
-        {/* Mobile */}
-        <div className="min-h-screen pb-16 lg:hidden">
-          <Container maxWidth="xl" padding className="py-s-6">
-            {children}
-          </Container>
-          <BottomNav />
-        </div>
+          {/* Mobile */}
+          <div className="min-h-screen pb-16 lg:hidden">
+            <Container maxWidth="xl" padding className="py-s-6">
+              {children}
+            </Container>
+            <BottomNav />
+          </div>
+          <LeaveConfirmDialog />
+        </DirtyFormProvider>
       </AuthBootstrapper>
     </Suspense>
   );

--- a/src/app/(main)/practices/new/PracticeCreateWizard.client.tsx
+++ b/src/app/(main)/practices/new/PracticeCreateWizard.client.tsx
@@ -13,6 +13,7 @@ import { useCreatePractice } from '@/domain/practice/hooks/useCreatePractice';
 import { useSearchSongs } from '@/domain/practice-song/hooks/useSearchSongs';
 import type { SongSearchItem } from '@/domain/practice-song/types';
 import { ROUTES } from '@/global/config/routes';
+import { useRegisterDirtyForm } from '@/global/navigation/dirty-form-context';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useToast } from '@/hooks/useToast';
 
@@ -50,6 +51,18 @@ export function PracticeCreateWizard() {
   const [venue, setVenue] = useState('');
   const [startAt, setStartAt] = useState('');
   const [durationMinutes, setDurationMinutes] = useState<number>(60);
+
+  // Navigation Guard 등록 — 어느 단계든 입력값이 있으면 dirty.
+  const dirty =
+    step > 0 ||
+    !!bandId ||
+    !!picked ||
+    customTitle.length > 0 ||
+    customArtist.length > 0 ||
+    title.length > 0 ||
+    venue.length > 0 ||
+    !!startAt;
+  useRegisterDirtyForm('practice-create-wizard', dirty);
 
   const mutation = useCreatePractice({
     onSuccess: (data) => {

--- a/src/components/feedback/leave-confirm-dialog.tsx
+++ b/src/components/feedback/leave-confirm-dialog.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useDirtyFormController } from '@/global/navigation/dirty-form-context';
+
+/**
+ * 진행 중인 마법사/폼이 있을 때 라우트 이동 직전에 띄워지는 확인 모달.
+ * DirtyFormProvider 의 pendingConfirm/resolveConfirm 와 연결.
+ */
+export function LeaveConfirmDialog() {
+  const ctx = useDirtyFormController();
+  if (!ctx) return null;
+
+  return (
+    <Dialog
+      open={ctx.pendingConfirm}
+      onOpenChange={(open) => {
+        if (!open) ctx.resolveConfirm(false);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>진행 중인 작업이 있어요</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <p className="text-foreground-sub text-sm">
+            이 페이지를 떠나면 입력한 내용이 모두 사라집니다. 그래도 이동하시겠습니까?
+          </p>
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => ctx.resolveConfirm(false)}>
+            머무르기
+          </Button>
+          <Button variant="danger" onClick={() => ctx.resolveConfirm(true)}>
+            이동하기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { CalendarDays, Home, Music, User, Users, type LucideIcon } from 'lucide-react';
-import Link from 'next/link';
+import { GuardedLink as Link } from '@/global/navigation/guarded-link';
 import { usePathname } from 'next/navigation';
 
 import { ROUTES } from '@/global/config/routes';

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -10,7 +10,7 @@ import {
   Users,
   type LucideIcon,
 } from 'lucide-react';
-import Link from 'next/link';
+import { GuardedLink as Link } from '@/global/navigation/guarded-link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 

--- a/src/global/navigation/dirty-form-context.tsx
+++ b/src/global/navigation/dirty-form-context.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/**
+ * 진행 중인 마법사/폼이 있는지 추적하는 전역 컨텍스트.
+ * 마운트된 마법사가 dirty=true 신호를 보내면, 사이드바/Link 인터셉터가
+ * 라우트 이탈 직전에 LeaveConfirmDialog 를 띄울 수 있다.
+ *
+ * Provider 가 노출하는 핵심 API
+ * - registerDirty(scope, dirty): 마법사가 자기 scope 의 dirty 상태를 갱신
+ * - hasDirty: 어딘가에 dirty 가 있는지 여부 (탐색 인터셉터가 사용)
+ * - confirmLeave(): 모달을 통해 사용자 확인 후 boolean 반환 (Promise)
+ */
+
+type DirtyScope = string;
+
+interface DirtyFormContextValue {
+  hasDirty: boolean;
+  registerDirty: (scope: DirtyScope, dirty: boolean) => void;
+  /** 라우트 이동 직전에 호출. dirty 가 있으면 모달을 띄우고 사용자 응답을 반환. */
+  confirmLeave: () => Promise<boolean>;
+  /** 내부용 — LeaveConfirmDialog 가 열려있는지. */
+  pendingConfirm: boolean;
+  /** 내부용 — 모달 응답. */
+  resolveConfirm: (confirmed: boolean) => void;
+}
+
+const DirtyFormContext = createContext<DirtyFormContextValue | null>(null);
+
+export function DirtyFormProvider({ children }: { children: ReactNode }) {
+  const [scopes, setScopes] = useState<Record<DirtyScope, boolean>>({});
+  const [pendingConfirm, setPendingConfirm] = useState(false);
+  const resolverRef = useRef<((confirmed: boolean) => void) | null>(null);
+
+  const hasDirty = useMemo(() => Object.values(scopes).some(Boolean), [scopes]);
+
+  const registerDirty = useCallback((scope: DirtyScope, dirty: boolean) => {
+    setScopes((prev) => {
+      if (Boolean(prev[scope]) === dirty) return prev;
+      return { ...prev, [scope]: dirty };
+    });
+  }, []);
+
+  const confirmLeave = useCallback((): Promise<boolean> => {
+    if (!hasDirty) return Promise.resolve(true);
+    setPendingConfirm(true);
+    return new Promise<boolean>((resolve) => {
+      resolverRef.current = resolve;
+    });
+  }, [hasDirty]);
+
+  const resolveConfirm = useCallback((confirmed: boolean) => {
+    if (resolverRef.current) {
+      resolverRef.current(confirmed);
+      resolverRef.current = null;
+    }
+    setPendingConfirm(false);
+    if (confirmed) {
+      // 사용자가 이동 확정 — dirty 해제 (이동 후 마법사가 unmount 되며 자동 unregister 되지만,
+      // 즉시 모달이 다시 뜨지 않도록 선제 해제).
+      setScopes({});
+    }
+  }, []);
+
+  // 브라우저 새로고침/탭 닫기 가드 (dirty 일 때만).
+  useEffect(() => {
+    function onBeforeUnload(e: BeforeUnloadEvent) {
+      if (!hasDirty) return;
+      e.preventDefault();
+      // 일부 브라우저는 returnValue 필요.
+      e.returnValue = '';
+    }
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [hasDirty]);
+
+  const value = useMemo<DirtyFormContextValue>(
+    () => ({ hasDirty, registerDirty, confirmLeave, pendingConfirm, resolveConfirm }),
+    [hasDirty, registerDirty, confirmLeave, pendingConfirm, resolveConfirm],
+  );
+
+  return <DirtyFormContext.Provider value={value}>{children}</DirtyFormContext.Provider>;
+}
+
+/**
+ * 마법사/폼 컴포넌트가 호출. dirty 변경 시 자동 register, unmount 시 false 등록.
+ *
+ * @param scope 다중 마법사 충돌 방지용 식별자 (`practice-create`, `performance-create` 등)
+ * @param dirty 입력값이 비어있지 않거나 step > 0 인 경우 true
+ */
+export function useRegisterDirtyForm(scope: DirtyScope, dirty: boolean) {
+  const ctx = useContext(DirtyFormContext);
+  useEffect(() => {
+    if (!ctx) return;
+    ctx.registerDirty(scope, dirty);
+    return () => {
+      ctx.registerDirty(scope, false);
+    };
+  }, [ctx, scope, dirty]);
+}
+
+/** 사이드바/Link 인터셉터가 사용. */
+export function useDirtyFormGuard() {
+  const ctx = useContext(DirtyFormContext);
+  if (!ctx) {
+    return {
+      hasDirty: false,
+      confirmLeave: async () => true,
+    };
+  }
+  return { hasDirty: ctx.hasDirty, confirmLeave: ctx.confirmLeave };
+}
+
+/** LeaveConfirmDialog 가 사용. Provider 외부에서는 null 반환. */
+export function useDirtyFormController() {
+  return useContext(DirtyFormContext);
+}

--- a/src/global/navigation/guarded-link.tsx
+++ b/src/global/navigation/guarded-link.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { forwardRef, type ComponentPropsWithoutRef, type MouseEvent } from 'react';
+
+import { useDirtyFormGuard } from './dirty-form-context';
+
+type Props = ComponentPropsWithoutRef<typeof Link>;
+
+/**
+ * Next.js Link 의 drop-in 대체. 진행 중인 dirty form 이 있으면 이동 직전에 LeaveConfirmDialog
+ * 를 띄워 사용자 확인을 받음.
+ *
+ * 단, 외부 링크/새 탭/modifier-click(Cmd/Ctrl/Shift) 은 인터셉트하지 않고 기본 동작 유지.
+ */
+export const GuardedLink = forwardRef<HTMLAnchorElement, Props>(function GuardedLink(
+  { href, onClick, target, ...rest },
+  ref,
+) {
+  const router = useRouter();
+  const { hasDirty, confirmLeave } = useDirtyFormGuard();
+
+  async function handleClick(e: MouseEvent<HTMLAnchorElement>) {
+    onClick?.(e);
+    if (e.defaultPrevented) return;
+    if (target && target !== '_self') return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    if (typeof href !== 'string') return;
+    if (!hasDirty) return;
+
+    e.preventDefault();
+    const confirmed = await confirmLeave();
+    if (confirmed) router.push(href);
+  }
+
+  return <Link ref={ref} href={href} target={target} onClick={handleClick} {...rest} />;
+});


### PR DESCRIPTION
## Summary
- DirtyFormProvider + useRegisterDirtyForm: 마법사 dirty 상태 전역 추적
- LeaveConfirmDialog: 이동 직전 사용자 확인 모달
- GuardedLink: Next.js Link drop-in 대체. dirty 시 confirmLeave 후 router.push
- Sidebar/BottomNav 의 Link 를 GuardedLink 로 교체
- PracticeCreateWizard 가 dirty 등록
- beforeunload 도 함께 가드 (새로고침/탭 닫기)

## 신규 컴포넌트
- src/global/navigation/dirty-form-context.tsx — Provider + useRegisterDirtyForm + useDirtyFormGuard
- src/global/navigation/guarded-link.tsx — Link 인터셉터
- src/components/feedback/leave-confirm-dialog.tsx — 모달

## Test plan
- [x] typecheck/lint
- [ ] 마법사 step>0 또는 입력값 있을 때 사이드바 클릭 → 모달
- [ ] 모달 머무르기 → 머무름, 이동하기 → 이동
- [ ] 새로고침 시 beforeunload 경고

closes #100