### PR TITLE
feat: 밴드 설정 모달 (정보/사진/삭제 3탭)

### DIFF
--- a/API_REQUIRED.md
+++ b/API_REQUIRED.md
@@ -135,6 +135,15 @@ mvp-1-fix-v3 Task 5 의 BandPickerModal 결과를 적용할 백엔드 엔드포�
 
 - **프론트 사용처**: `PracticeCreateWizard.submit` (현재 임시로 `<title> — <artist>` 텍스트 식별자 전송)
 
+### 8-8. 밴드 정보 수정 / 삭제 (FE-API-022, FE-API-023)
+
+밴드 설정 모달이 도입됐지만 백엔드에 엔드포인트가 없음. 본 라운드는 UI 만 완성, 동작 시 toast 안내.
+
+- **PATCH `/api/v1/bands/{bandId}`** (FE-API-022) — 리더만, body: `{ name?, description? }`. Partial update.
+- **DELETE `/api/v1/bands/{bandId}`** (FE-API-023) — 리더만. 응답 204. 멤버·합주·공연 연결 cascade 정리 정책 결정 필요.
+- **POST `/api/v1/bands/{bandId}/profile-image`** (FE-API-009 — P2 항목 활성화) — 멀티파트 업로드 또는 사전서명 URL.
+- 프론트 사용처: `BandSettingsModal` (정보/사진/삭제 탭)
+
 ### 8-7. 홈 피드 우선순위 정렬 (FE-API-019)
 
 홈 화면 '내 밴드 / 다가오는 합주 / 다가오는 공연' 섹션은 현재 클라이언트 측 `lib/home-feed.ts` 의 `pickUpcoming` 으로 startAt 오름차순 + 미래 필터링 + 상위 3건. 향후 백엔드가 활동성/우선순위 알고리즘을 적용한 별도 엔드포인트를 제공하면 클라이언트 정렬 제거 가능.

--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BandApplicationRow } from '@/domain/band/components/BandApplicationRow';
 import { BandMemberRow } from '@/domain/band/components/BandMemberRow';
+import { BandSettingsModal } from '@/domain/band/components/BandSettingsModal.client';
 import { useApplyBand } from '@/domain/band/hooks/useApplyBand';
 import { useBandApplications } from '@/domain/band/hooks/useBandApplications';
 import { useBandDetail } from '@/domain/band/hooks/useBandDetail';
@@ -39,6 +40,7 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
   const router = useRouter();
   const toast = useToast();
   const [leaveOpen, setLeaveOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const { data: band, isLoading, isError, refetch } = useBandDetail(bandId);
   const { data: myRole } = useBandRole(bandId);
@@ -112,11 +114,7 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
             </Button>
           )}
           {isLeader && (
-            <Button
-              size="sm"
-              variant="secondary"
-              onClick={() => toast.info('밴드 설정 화면은 곧 제공될 예정입니다.')}
-            >
+            <Button size="sm" variant="secondary" onClick={() => setSettingsOpen(true)}>
               <Settings className="h-4 w-4" />
               밴드 설정
             </Button>
@@ -156,6 +154,17 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
           )}
         </div>
       </Tabs>
+
+      <BandSettingsModal
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        band={{
+          bandId: band.bandId,
+          bandName: band.bandName,
+          description: band.description,
+          profileImg: band.profileImg,
+        }}
+      />
 
       <Dialog open={leaveOpen} onOpenChange={setLeaveOpen}>
         <DialogContent>

--- a/src/domain/band/components/BandSettingsModal.client.tsx
+++ b/src/domain/band/components/BandSettingsModal.client.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetContent,
+  ResponsiveSheetFooter,
+  ResponsiveSheetHeader,
+  ResponsiveSheetTitle,
+} from '@/components/ui/responsive-sheet';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/useToast';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  band: { bandId: string; bandName: string; description?: string; profileImg?: string };
+}
+
+/**
+ * 밴드 설정 모달 — 정보 수정 / 사진 변경 / 삭제 3탭.
+ * 백엔드 PATCH/DELETE/profile-image 엔드포인트 미지원 (API_REQUIRED FE-API-022, 023, 009).
+ * 본 라운드는 UI 완성 + toast 안내, 백엔드 도입 시 mutation 만 교체.
+ */
+export function BandSettingsModal({ open, onOpenChange, band }: Props) {
+  const toast = useToast();
+  const [tab, setTab] = useState<'info' | 'image' | 'delete'>('info');
+
+  // 정보
+  const [name, setName] = useState(band.bandName);
+  const [description, setDescription] = useState(band.description ?? '');
+
+  // 사진
+  const [profileImg, setProfileImg] = useState(band.profileImg ?? '');
+
+  // 삭제
+  const [confirmText, setConfirmText] = useState('');
+
+  function handleSaveInfo() {
+    toast.info('정보 수정 API 가 백엔드에 추가되면 자동 반영됩니다 (FE-API-022).');
+    onOpenChange(false);
+  }
+
+  function handleSaveImage() {
+    toast.info('프로필 이미지 업로드 API 가 백엔드에 추가되면 자동 반영됩니다 (FE-API-009).');
+    onOpenChange(false);
+  }
+
+  function handleDelete() {
+    if (confirmText !== band.bandName) {
+      toast.error('밴드 이름을 정확히 입력해 주세요.');
+      return;
+    }
+    toast.info('밴드 삭제 API 가 백엔드에 추가되면 자동 반영됩니다 (FE-API-023).');
+    onOpenChange(false);
+  }
+
+  return (
+    <ResponsiveSheet open={open} onOpenChange={onOpenChange}>
+      <ResponsiveSheetContent>
+        <ResponsiveSheetHeader>
+          <ResponsiveSheetTitle>밴드 설정</ResponsiveSheetTitle>
+        </ResponsiveSheetHeader>
+        <ResponsiveSheetBody>
+          <Tabs value={tab} onValueChange={(v) => setTab(v as 'info' | 'image' | 'delete')}>
+            <TabsList className="mb-s-4 w-full">
+              <TabsTrigger value="info" className="flex-1">
+                정보
+              </TabsTrigger>
+              <TabsTrigger value="image" className="flex-1">
+                사진
+              </TabsTrigger>
+              <TabsTrigger value="delete" className="flex-1">
+                삭제
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="info" className="space-y-s-3">
+              <Input
+                label="밴드 이름"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+              <Textarea
+                label="소개 (선택)"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+              <p className="text-foreground-muted text-micro">
+                백엔드에 PATCH /bands/&#123;id&#125; 가 추가되면 즉시 반영됩니다 (FE-API-022).
+              </p>
+            </TabsContent>
+
+            <TabsContent value="image" className="space-y-s-3">
+              <Input
+                label="프로필 이미지 URL"
+                placeholder="https://..."
+                value={profileImg}
+                onChange={(e) => setProfileImg(e.target.value)}
+                hint="업로드 엔드포인트 도입 전까지는 URL 입력으로 대체합니다."
+              />
+            </TabsContent>
+
+            <TabsContent value="delete" className="space-y-s-3">
+              <p className="text-foreground-sub text-sm">
+                밴드를 삭제하면 모든 멤버·합주·공연 연결이 함께 제거되며 복구할 수 없습니다.
+              </p>
+              <Input
+                label={`밴드 이름(${band.bandName}) 을 그대로 입력해 주세요`}
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder={band.bandName}
+              />
+            </TabsContent>
+          </Tabs>
+        </ResponsiveSheetBody>
+        <ResponsiveSheetFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          {tab === 'info' && <Button onClick={handleSaveInfo}>저장</Button>}
+          {tab === 'image' && <Button onClick={handleSaveImage}>저장</Button>}
+          {tab === 'delete' && (
+            <Button
+              variant="danger"
+              onClick={handleDelete}
+              disabled={confirmText !== band.bandName}
+            >
+              삭제
+            </Button>
+          )}
+        </ResponsiveSheetFooter>
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}


### PR DESCRIPTION
## Summary
- BandSettingsModal — Tabs(정보,사진,삭제)
- 백엔드 PATCH/DELETE/profile-image 미지원 (FE-API-022/023/009 — toast 안내)
- BandDetailContent 의 Settings 버튼이 모달 트리거로 교체

## 신규 컴포넌트
- src/domain/band/components/BandSettingsModal.client.tsx

closes #107