### PR TITLE
feat: DateTimePicker UX 보강 — 연/월 빠른 선택 + 시간 듀얼 모드

### DIFF
--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Chip } from '@/components/ui/chip';
 import { Dialog, DialogClose, DialogContent } from '@/components/ui/dialog';
+import { YearMonthPicker } from '@/components/ui/year-month-picker';
 import { cn } from '@/lib/cn';
 
 const DOW = ['일', '월', '화', '수', '목', '금', '토'];
@@ -222,10 +223,39 @@ export function DateTimePicker({
               minDate={minDate}
               onNav={navMonth}
               onPick={(p) => setDraft((prev) => ({ ...prev, y: p.y, mo: p.mo, d: p.d }))}
+              onSetYM={({ year, month }) => setView({ y: year, mo: month })}
             />
             <div className="border-border px-s-4 py-s-4 flex flex-col border-t sm:w-[240px] sm:border-t-0 sm:border-l">
-              <div className="text-foreground-muted text-micro mb-s-3 text-center font-semibold tracking-wider uppercase">
+              <div className="text-foreground-muted text-micro mb-s-2 text-center font-semibold tracking-wider uppercase">
                 시간 선택
+              </div>
+              {/* 듀얼 모드: 직접 타이핑 가능한 input + 보조 휠 */}
+              <div className="mb-s-3 gap-s-2 flex items-center justify-center">
+                <input
+                  type="number"
+                  min={0}
+                  max={23}
+                  value={pad(draft.h)}
+                  onChange={(e) => {
+                    const h = Math.max(0, Math.min(23, Number(e.target.value) || 0));
+                    setDraft((prev) => ({ ...prev, h }));
+                  }}
+                  className="bg-card border-border text-foreground text-title focus-visible:border-accent w-16 rounded-md border-2 px-2 py-1 text-center font-bold tabular-nums outline-none"
+                  aria-label="시 직접 입력"
+                />
+                <span className="text-foreground-sub text-title font-bold">:</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={59}
+                  value={pad(draft.mi)}
+                  onChange={(e) => {
+                    const mi = Math.max(0, Math.min(59, Number(e.target.value) || 0));
+                    setDraft((prev) => ({ ...prev, mi }));
+                  }}
+                  className="bg-card border-border text-foreground text-title focus-visible:border-accent w-16 rounded-md border-2 px-2 py-1 text-center font-bold tabular-nums outline-none"
+                  aria-label="분 직접 입력"
+                />
               </div>
               <div className="gap-s-2 flex items-end justify-center">
                 <Wheel
@@ -272,12 +302,23 @@ interface CalendarProps {
   minDate: ParsedDate | null;
   onNav: (dir: number) => void;
   onPick: (p: { y: number; mo: number; d: number }) => void;
+  /** YearMonthPicker 의 직접 변경. */
+  onSetYM?: (next: { year: number; month: number }) => void;
 }
 
-function Calendar({ viewYear, viewMonth, selected, minDate, onNav, onPick }: CalendarProps) {
+function Calendar({
+  viewYear,
+  viewMonth,
+  selected,
+  minDate,
+  onNav,
+  onPick,
+  onSetYM,
+}: CalendarProps) {
   const firstDow = new Date(viewYear, viewMonth - 1, 1).getDay();
   const daysInMonth = new Date(viewYear, viewMonth, 0).getDate();
   const today = useMemo(todayParts, []);
+  const [ymOpen, setYmOpen] = useState(false);
 
   const cells: Array<number | null> = [];
   for (let i = 0; i < firstDow; i += 1) cells.push(null);
@@ -295,8 +336,25 @@ function Calendar({ viewYear, viewMonth, selected, minDate, onNav, onPick }: Cal
         >
           ‹
         </button>
-        <div className="text-foreground text-body font-bold">
-          {viewYear}년 {viewMonth}월
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => onSetYM && setYmOpen((v) => !v)}
+            className="text-foreground text-body hover:text-accent inline-flex items-center gap-1 font-bold transition-colors"
+            aria-haspopup="dialog"
+            aria-expanded={ymOpen}
+            aria-label="연도와 월 빠른 선택 열기"
+          >
+            {viewYear}년 {viewMonth}월{onSetYM && <span aria-hidden="true">▾</span>}
+          </button>
+          {ymOpen && onSetYM && (
+            <YearMonthPicker
+              year={viewYear}
+              month={viewMonth}
+              onChange={onSetYM}
+              onClose={() => setYmOpen(false)}
+            />
+          )}
         </div>
         <button
           type="button"

--- a/src/components/ui/year-month-picker.tsx
+++ b/src/components/ui/year-month-picker.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export interface YearMonthPickerProps {
+  /** 현재 표시 연도. */
+  year: number;
+  /** 현재 표시 월 (1-12). */
+  month: number;
+  /** 변경 시 호출 — Confirm 단계 없이 즉시 반영. */
+  onChange: (next: { year: number; month: number }) => void;
+  /** 닫기 콜백 — 외부 클릭/Esc/선택 후 자동 닫기 등. */
+  onClose: () => void;
+}
+
+/**
+ * 캘린더 헤더의 '2026년 4월' 영역 클릭 시 노출되는 빠른 연/월 선택기.
+ * - 연도: 현재 ±5년 (12칸 — 4×3 그리드)
+ * - 월: 1~12 (4×3 그리드)
+ * - 연·월 동시 표시. 선택 시 즉시 onChange + onClose.
+ */
+export function YearMonthPicker({ year, month, onChange, onClose }: YearMonthPickerProps) {
+  const [draftYear, setDraftYear] = useState(year);
+  const baseYear = year - 5;
+  const years = Array.from({ length: 12 }, (_, i) => baseYear + i);
+  const months = Array.from({ length: 12 }, (_, i) => i + 1);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="연도와 월 선택"
+      className="bg-bg border-border absolute top-9 left-1/2 z-20 -translate-x-1/2 rounded-md border shadow-lg"
+      data-slot="year-month-picker"
+    >
+      <div className="px-s-4 py-s-3 border-border space-y-s-3 border-b">
+        <p className="text-foreground-muted text-micro font-semibold tracking-wider uppercase">
+          연도
+        </p>
+        <ul className="grid grid-cols-4 gap-1">
+          {years.map((y) => (
+            <li key={y}>
+              <button
+                type="button"
+                onClick={() => setDraftYear(y)}
+                aria-pressed={y === draftYear}
+                className={cn(
+                  'px-s-2 py-s-1 text-caption w-full rounded-md font-semibold transition-colors',
+                  y === draftYear
+                    ? 'bg-accent text-foreground'
+                    : 'text-foreground-sub hover:bg-card',
+                )}
+              >
+                {y}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="px-s-4 py-s-3 space-y-s-3">
+        <p className="text-foreground-muted text-micro font-semibold tracking-wider uppercase">
+          월
+        </p>
+        <ul className="grid grid-cols-4 gap-1">
+          {months.map((m) => (
+            <li key={m}>
+              <button
+                type="button"
+                onClick={() => {
+                  onChange({ year: draftYear, month: m });
+                  onClose();
+                }}
+                aria-pressed={m === month && draftYear === year}
+                className={cn(
+                  'px-s-2 py-s-1 text-caption w-full rounded-md font-semibold transition-colors',
+                  m === month && draftYear === year
+                    ? 'bg-accent text-foreground'
+                    : 'text-foreground-sub hover:bg-card',
+                )}
+              >
+                {m}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ui/year-month-picker.tsx — 연도 ±5 (12칸) + 월 (4×3) 그리드
- 캘린더 헤더 클릭 시 YearMonthPicker 팝오버
- 시간 입력 듀얼 모드 — 휠 위에 시·분 number input

## 신규 컴포넌트
- src/components/ui/year-month-picker.tsx

closes #111