### PR TITLE
refactor: API_SPEC v3 변경사항 반영 — Practice 닭-달걀 해소 + 마법사 정식 시퀀스

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -3490,7 +3490,7 @@
         "dependencies": [
           "2"
         ],
-        "status": "in-progress",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -3498,9 +3498,10 @@
             "description": "현재 useMyBands 훅은 content 배열만 반환하지만, '전체 보기' 버튼 표시 여부 결정을 위해 hasNext 플래그도 함께 반환하도록 확장합니다.",
             "dependencies": [],
             "details": "## 수정 파일\n- `src/domain/band/hooks/useMyBands.ts`\n\n## 변경 내용\n1. 반환 타입을 `{ data: MyBandInfoResponse[], hasNext: boolean }` 구조로 확장\n2. getMyBands API가 반환하는 CursorResponse의 hasNext 필드를 함께 반환\n3. 기존 호출부(PracticeCreateWizard)와의 하위 호환성 유지 — data.data 또는 data 자체로 접근 가능\n\n## 의사 코드\n```ts\nexport function useMyBands(limit = 10) {\n  return useQuery({\n    queryKey: [...queryKeys.band.my(), limit],\n    queryFn: async () => {\n      const page = await getMyBands({ pageSize: limit });\n      return { data: page.content, hasNext: page.hasNext };\n    },\n  });\n}\n```\n\n## 참조\n- `src/domain/band/api/getMyBands.ts` — CursorResponse<T, string> 반환\n- `src/global/types/index.ts` — CursorResponse 타입 정의",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "1. useMyBands(6) 호출 시 data.data (배열)와 data.hasNext (boolean) 모두 접근 가능 확인\n2. 6개 미만 밴드 → hasNext: false\n3. 6개 초과 밴드 → hasNext: true\n4. TypeScript 타입 체크 통과",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-26T01:31:29.806Z"
           },
           {
             "id": 2,
@@ -3510,9 +3511,10 @@
               1
             ],
             "details": "## 수정 파일\n- `src/app/(main)/practices/new/PracticeCreateWizard.client.tsx`\n\n## 변경 내용\n1. **useMyBands 호출 변경**: `useMyBands(50)` → `useMyBands(6)`\n2. **그리드 레이아웃**: `grid-cols-1 sm:grid-cols-2` → `grid-cols-2 sm:grid-cols-3`\n3. **hasNext 조건부 버튼**: hasNext=true일 때 '전체 보기/검색' 버튼 표시\n4. **BandPickerModal 상태 추가**: `pickerOpen` state + BandPickerModal import\n5. **모달 onConfirm 핸들러**: 선택한 밴드의 bandId를 setBandId에 설정\n6. **선택된 밴드가 그리드에 없을 때 상단 표시**: 모달에서 선택한 밴드가 6개 그리드에 없으면 별도 '선택됨' 카드로 상단에 표시\n\n## 추가 import\n```ts\nimport { BandPickerModal } from '@/domain/band/components/BandPickerModal.client';\nimport type { BandInfoResponse } from '@/domain/band/types';\n```\n\n## 참조\n- `src/domain/band/components/BandPickerModal.client.tsx` — multiple=false (단일 선택)\n- 기존 PracticeCreateWizard.client.tsx:134-166 (현재 Step 1 구현)",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "1. 6개 미만 밴드 소속 → 그리드에 모든 밴드 표시, '전체 보기' 버튼 미표시\n2. 7개 이상 밴드 소속 → 6개 그리드 + '전체 보기' 버튼 표시\n3. '전체 보기' 클릭 → BandPickerModal 오픈\n4. 모달에서 밴드 선택 → setBandId 호출, 모달 닫힘\n5. 모달에서 선택한 밴드가 그리드에 없으면 상단에 '선택됨' 카드 표시\n6. 반응형 확인: 모바일 2열, sm+ 3열",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-26T01:31:33.598Z"
           },
           {
             "id": 3,
@@ -3522,9 +3524,10 @@
               1
             ],
             "details": "## 수정 파일\n- `src/domain/performance/components/PerformanceCreateModal.client.tsx`\n- `src/app/(main)/performances/new/PerformanceCreateForm.client.tsx` (동일 패턴 적용)\n\n## 변경 내용 (PerformanceCreateModal Step 0)\n1. **useMyBands 훅 추가**: `useMyBands(6)` import 및 호출\n2. **그리드 레이아웃 추가**: Step 0에 2x3 밴드 그리드 (grid-cols-2 sm:grid-cols-3)\n3. **기존 칩 UI 유지**: selectedBands를 칩으로 표시 (현재 구현 유지)\n4. **그리드 카드 클릭 → 토글**: 그리드 카드 클릭 시 selectedBands에 추가/제거\n5. **'더 추가' 버튼 조건**: hasNext=true 또는 selectedBands에 그리드에 없는 밴드가 있을 때\n6. **BandPickerModal multiple=true**: 다중 선택 모드로 모달 연결\n\n## 의사 코드\n```tsx\n// Step 0 수정\n{step === 0 && (\n  <>\n    <Input ... />\n    <div className=\"space-y-s-2\">\n      <label>참여 밴드</label>\n      {/* 선택된 밴드 칩 */}\n      {selectedBands.length > 0 && (\n        <ul className=\"flex flex-wrap gap-s-2\">...</ul>\n      )}\n      {/* 6개 그리드 */}\n      <ul className=\"grid grid-cols-2 sm:grid-cols-3 gap-s-2\">\n        {myBands.data?.data.map(b => (\n          <BandSelectCard band={b} selected={isSelected} onToggle={toggle} />\n        ))}\n      </ul>\n      {hasNext && (\n        <Button onClick={() => setPickerOpen(true)}>더 추가</Button>\n      )}\n    </div>\n  </>\n)}\n```\n\n## 참조\n- PerformanceCreateModal.client.tsx:102-153 (현재 Step 0)\n- PerformanceCreateForm.client.tsx:107-145 (폼 버전 밴드 선택)",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "1. 공연 마법사 Step 0에서 6개 밴드 그리드 표시\n2. 그리드 카드 클릭 → 칩에 추가 (토글)\n3. hasNext=true → '더 추가' 버튼 표시\n4. '더 추가' 클릭 → BandPickerModal(multiple) 오픈\n5. 모달에서 여러 밴드 선택 → selectedBands 갱신\n6. 선택된 밴드 칩에서 X 클릭 → 제거",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-26T01:31:37.383Z"
           },
           {
             "id": 4,
@@ -3535,12 +3538,13 @@
               3
             ],
             "details": "## 수정 파일\n1. `src/app/(main)/practices/new/PracticeCreateWizard.client.tsx` — Step 1 밴드 카드\n2. `src/domain/performance/components/PerformanceCreateModal.client.tsx` — Step 0 밴드 카드\n3. `src/domain/band/components/BandPickerModal.client.tsx` — 모달 내 renderItem\n\n## 시각 강조 패턴\n1. **기본 상태**: `border-border bg-card hover:bg-card-hover`\n2. **선택 상태**: \n   - `border-l-2 border-l-accent border-accent bg-accent-dim`\n   - 우상단 체크 아이콘: `<Check className=\"h-4 w-4 text-accent\" />`\n   - 아이콘 위치: `absolute top-2 right-2` 또는 flex justify-between\n\n## 공통 카드 구조 예시\n```tsx\n<button\n  className={\n    'relative border bg-card hover:bg-card-hover gap-s-3 px-s-4 py-s-3 flex w-full items-center rounded-md text-left transition-colors ' +\n    (selected ? 'border-l-2 border-l-accent border-accent bg-accent-dim' : 'border-border')\n  }\n  aria-pressed={selected}\n>\n  {selected && (\n    <span className=\"absolute top-2 right-2 text-accent\">\n      <Check className=\"h-4 w-4\" />\n    </span>\n  )}\n  {/* 카드 내용 */}\n</button>\n```\n\n## 참조\n- StepIndicator의 Check 아이콘 사용 패턴 (lucide-react)\n- 기존 선택 강조: `border-accent bg-accent-dim` (PracticeCreateWizard.client.tsx:145)",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "1. 합주 마법사 밴드 카드 선택 → 좌측 accent 보더 + 우상단 체크 아이콘 + 배경색 변경\n2. 공연 마법사 밴드 카드 동일 동작\n3. BandPickerModal 검색 결과 카드 동일 동작\n4. 선택 해제 시 기본 스타일로 복귀\n5. 키보드 접근성: aria-pressed 상태 정확히 반영",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-26T01:31:41.179Z"
           }
         ],
-        "updatedAt": "2026-04-26T01:29:27.785Z"
+        "updatedAt": "2026-04-26T01:31:41.179Z"
       },
       {
         "id": "8",
@@ -3550,7 +3554,7 @@
         "testStrategy": "### 8-1\n- 마법사 헤더에 \"밴드 → 곡 → 일정\" 문구 없음 확인\n\n### 8-2\n- 무한 스크롤 검증 리포트 작성 완료\n- 각 목록에서 스크롤 시 추가 데이터 로드 확인\n- hasNext=false 시 fetchNextPage 미호출\n\n### 8-3\n- 멤버 탭에서 실제 이름 표시 or 폴백 규칙 동작 확인\n- API 응답에 name 필드 포함 시 정상 표시\n\n### 8-4\n- 합주곡 검색 카드 선택 → 좌측 보더 + ✓ 아이콘 + 배경 변경\n- 밴드 그리드 카드, EntityPickerModal 동일 동작\n\n### 8-5\n- 마법사 Step 2 탭에 \"직접 입력\"만 표시 (\"자작곡\" 없음)",
         "priority": "medium",
         "dependencies": [],
-        "status": "pending",
+        "status": "done",
         "subtasks": [
           {
             "id": 1,
@@ -3558,9 +3562,10 @@
             "description": "PracticeCreateWizard에서 불필요한 안내 카피를 삭제하고 직접 입력 탭의 라벨을 수정한다.",
             "dependencies": [],
             "details": "PracticeCreateWizard.client.tsx 파일에서 두 가지 수정을 수행한다. 첫째, line 118의 `<p className=\"text-foreground-muted text-caption\">밴드 → 곡 → 일정 순서로 진행합니다.</p>` 요소를 삭제한다. 둘째, line 196의 `직접 입력 (자작곡)` 텍스트를 `직접 입력`으로 변경한다. 두 수정 모두 단순 문자열 변경이므로 별도의 로직 수정은 필요 없다.",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "마법사 헤더에 '밴드 → 곡 → 일정' 문구가 없는지 확인. 곡 선택 단계에서 탭 라벨이 '직접 입력'으로만 표시되는지 확인. 기존 기능(밴드 선택, 곡 검색/입력, 일정 설정)이 정상 동작하는지 확인.",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-26T01:36:04.306Z"
           },
           {
             "id": 2,
@@ -3568,9 +3573,10 @@
             "description": "선택 가능한 카드에 좌측 보더, 배경, 체크 아이콘을 적용하는 공통 컴포넌트를 만들고 마법사 및 EntityPickerModal에 적용한다.",
             "dependencies": [],
             "details": "src/components/ui/selectable-card.tsx에 SelectableCard 컴포넌트를 생성한다. Props: selected (boolean), children, 나머지 div 속성. 선택 시 스타일: `border-l-2 border-accent bg-accent-dim`, 우상단에 Check 아이콘(lucide-react) 표시. 기존 listItemClasses 유틸(src/lib/list-item-styles.ts)의 패턴을 참고하되 좌측 보더와 체크 아이콘을 추가한다. 적용 대상: PracticeCreateWizard의 밴드 카드(line 137-163), 곡 검색 카드(line 223-244), BandPickerModal의 renderItem(line 51-68), EntityPickerModal 내부 버튼 래퍼. 기존 인라인 스타일을 SelectableCard로 교체한다.",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "합주곡 검색 카드 선택 시 좌측 보더 + 체크 아이콘 + 배경 변경 확인. 밴드 그리드 카드에서 동일 동작 확인. EntityPickerModal에서 검색 결과 카드 선택 시 동일 시각 효과 확인. BandPickerModal에서 밴드 선택 시 시각 효과 확인.",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-26T01:36:07.763Z"
           },
           {
             "id": 3,
@@ -3578,9 +3584,10 @@
             "description": "밴드/합주/공연/멤버/가입 신청 목록의 무한 스크롤 동작을 백엔드와 함께 검증하고 리포트를 작성한다.",
             "dependencies": [],
             "details": "검증 대상 파일: BandsList.client.tsx(밴드), PracticesList.client.tsx(합주), PerformancesList.client.tsx(공연), BandDetailContent.client.tsx 내 MembersTab(멤버)/ApplicationsTab(가입 신청). 검증 방법: (1) 백엔드 pageSize=2로 설정 후 각 목록에 5개 이상 데이터 생성. (2) 화면 스크롤 → IntersectionObserver 트리거 확인. (3) fetchNextPage 호출 → 다음 페이지 로드 확인. (4) hasNext=false일 때 fetchNextPage 미호출 확인. 멤버/신청 목록은 IntersectionObserver 대신 '더 불러오기' 버튼 방식이므로 버튼 클릭 동작도 검증. 결과를 .taskmaster/reports/infinite-scroll-verification-2026-04-26.md에 작성하며, 각 목록별 판정(정상/이슈)과 스크린샷 또는 네트워크 로그를 포함한다.",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "각 목록에서 스크롤 시 추가 데이터 로드 확인. hasNext=false 상태에서 더 이상 요청이 발생하지 않음 확인. 빠른 스크롤 시 중복 요청 방지 확인(isFetchingNextPage 가드). 빈 목록 상태에서 IntersectionObserver가 무한 트리거되지 않음 확인.",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-26T01:36:11.230Z"
           },
           {
             "id": 4,
@@ -3588,18 +3595,20 @@
             "description": "멤버 #2718 폴백 표시 현상의 원인을 분석하고 필요 시 getMemberDisplayName 로직을 보강하거나 API 요청 문서를 업데이트한다.",
             "dependencies": [],
             "details": "분석 단계: (1) curl로 /api/v1/bands/{id}/members 실제 응답 확인. (2) BandMemberInfoResponse에 name 필드 존재 여부 및 값 확인(null, undefined, 빈 문자열 구분). (3) getMemberDisplayName.ts(src/domain/member/utils/) 로직 검토 - 현재 .trim() 처리는 되어 있으나 빈 문자열 케이스 추가 확인. 조치: 백엔드가 name을 응답하지 않는 경우 API_REQUIRED.md의 FE-API-012 항목 업데이트. 백엔드가 빈 문자열을 반환하는 경우 getMemberDisplayName에서 이미 처리되므로 추가 조치 불필요. 분석 결과와 조치 내용을 .taskmaster/reports/infinite-scroll-verification-2026-04-26.md의 멤버 이름 섹션에 추가로 기록한다.",
-            "status": "pending",
+            "status": "done",
             "testStrategy": "멤버 탭에서 백엔드가 name을 응답할 경우 실제 이름 표시 확인. name이 null/undefined/빈 문자열일 경우 '멤버 #XXXX' 폴백 정상 동작 확인. BandMemberRow, SessionRow, PracticeDetailContent 등 getMemberDisplayName 사용처에서 일관된 표시 확인.",
-            "parentId": "undefined"
+            "parentId": "undefined",
+            "updatedAt": "2026-04-26T01:36:14.465Z"
           }
-        ]
+        ],
+        "updatedAt": "2026-04-26T01:36:14.465Z"
       }
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-04-26T01:29:27.790Z",
+      "lastModified": "2026-04-26T01:36:14.466Z",
       "taskCount": 8,
-      "completedCount": 5,
+      "completedCount": 7,
       "tags": [
         "mvp-1-fix-v4"
       ]

--- a/API_REQUIRED.md
+++ b/API_REQUIRED.md
@@ -2,20 +2,20 @@
 
 본 문서는 mvp-1-fix Task 15 실서버 검증과 Task 18~20 구현 과정에서 발견된, 현재 백엔드(`http://localhost:8080`)에 **존재하지 않거나 계약이 어긋나** 프론트가 mock 또는 우회 구현으로 대체한 API 항목을 정리한 것입니다. 백엔드 구현이 완료되면 프론트의 `domain/{name}/api/`만 교체하면 즉시 활성화됩니다.
 
-작성일: 2026-04-26 (mvp-1-fix-v3 Task 8 검증 결과 반영) / 영향 범위: Bandage MVP 1차 보정 v3
+작성일: 2026-04-26 (BE API_SPEC v3 갱신 반영) / 영향 범위: Bandage MVP 1차 보정 v3 / v4
 
-## 0. mvp-1-fix-v3 Task 8 검증 (2026-04-26) 요약
+## 0. mvp-1-fix-v3 Task 8 검증 결과 (2026-04-26) — BE 후속 대응 완료
 
 상세 리포트: [`.taskmaster/reports/create-api-verification-2026-04-26.md`](./.taskmaster/reports/create-api-verification-2026-04-26.md)
 
-| 항목                                                                              | 우선순위 | 상태                                                    |
-| --------------------------------------------------------------------------------- | -------- | ------------------------------------------------------- |
-| `/bands/me` myRole 포함                                                           | —        | 해소 (정상 동작 확인)                                   |
-| `/practices/me`, `/performances/me`, `/bands/search` 등 me/search 엔드포인트 일괄 | —        | 해소                                                    |
-| `POST /performances` `bandIds` non-null 강제 (§6-1 명세 vs 실제 불일치)           | P0       | FE 즉시 수정 (항상 배열 전송) + BE 의 default 처리 권고 |
-| Practice ↔ PracticeSong 닭-달걀 (FE-API-020)                                      | P0       | 미해소 — 본 라운드 마법사 end-to-end 차단               |
-| 입력 검증 메시지 raw 노출                                                         | P1       | 검토 필요                                               |
-| 공연/합주 startAt 과거 허용                                                       | P2       | 백엔드 검증 권고                                        |
+| 항목                                                                              | 우선순위 | 상태                                                                                                |
+| --------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `/bands/me` myRole 포함                                                           | —        | 해소 (정상 동작 확인)                                                                               |
+| `/practices/me`, `/performances/me`, `/bands/search` 등 me/search 엔드포인트 일괄 | —        | 해소                                                                                                |
+| `POST /performances` `bandIds` non-null 강제 (§6-1 명세 vs 실제 불일치)           | P0       | **해소** — BE 가 `bandIds: List<UUID>? = null` 로 변경 + 빈 배열 보정 (API_SPEC §6-1)               |
+| Practice ↔ PracticeSong 닭-달걀 (FE-API-020)                                      | P0       | **해소** — BE §5-2/§5-3 의 `practiceId` 옵셔널화. FE 마법사가 PracticeSong 선행 생성 후 songId 전달 |
+| 입력 검증 메시지 raw 노출                                                         | P1       | **해소** — BE `HttpMessageNotReadableException` 핸들러가 한국어 + fieldErrors 매핑                  |
+| 공연/합주 startAt 과거 허용                                                       | P2       | **해소** — BE Practice/Performance 생성·수정·일정 변경 DTO 에 `@Future` 적용                        |
 
 ---
 
@@ -124,16 +124,12 @@ mvp-1-fix-v3 Task 5 의 BandPickerModal 결과를 적용할 백엔드 엔드포�
 - **응답**: `BandMemberInfoResponse[]` (또는 `MemberInfoResponse[]`)
 - **프론트 사용처**: `MemberPickerModal` (현재는 신규 사용처 없음 — 합주 멤버 추가 picker 도입 시 활성화)
 
-### 8-6. 합주곡 검색 + Practice 생성 닭-달걀 해결 (FE-API-020)
+### 8-6. 합주곡 검색 + Practice 생성 닭-달걀 해결 (FE-API-020) — **✅ 해소 (2026-04-26)**
 
-§4-1 `POST /practices` 의 `song` 필드는 songId(UUID) 를 요구하지만, §5-2/§5-3 합주곡 생성은 `practiceId` 가 선행되어야 한다. 마법사 UX 상 곡을 먼저 선택/입력한 후 합주를 만드는 흐름이 자연스러운데, 백엔드 계약이 이를 막고 있음.
+BE 가 §5-2/§5-3 의 `practiceId` 를 옵셔널화 (해결안 2 채택). 마법사는 PracticeSong 선행 생성 후 응답 `songId` 를 §4-1 의 `song` 으로 전달하는 시퀀스로 동작.
 
-해결안 (택일):
-
-1. **§4-1 `song` 필드 확장** — UUID 외에 `SongSearchItem` 객체 또는 `{ title, artist, album, duration, refLink }` 풀 메타도 허용. 백엔드는 songId 가 없으면 새 PracticeSong 을 함께 생성.
-2. **§5-2/§5-3 `practiceId` 선택화** — practiceId 없이 PracticeSong 만 먼저 만들고 응답의 songId 를 §4-1 에 전달.
-
-- **프론트 사용처**: `PracticeCreateWizard.submit` (현재 임시로 `<title> — <artist>` 텍스트 식별자 전송)
+- **프론트 사용처**: `PracticeCreateWizard.submit` — `createPracticeSongFromSong({song})` 또는 `createPracticeSongFromFields({...})` 호출 후 응답 songId 를 `useCreatePractice` 의 `song` 으로 전달
+- 후속 라운드에서 실서버 재검증 필요
 
 ### 8-8. 밴드 정보 수정 / 삭제 (FE-API-022, FE-API-023)
 

--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -21,9 +21,9 @@ Base URL: `/api/v1`
 
 ---
 
-## 0. 프론트 검증 리포트 대응 현황 (2026-04-25)
+## 0. 프론트 검증 리포트 대응 현황 (2026-04-26)
 
-`bandage-fe/.taskmaster/reports/` 의 5개 검증 리포트에서 제기된 이슈에 대한 처리 현황입니다.
+`bandage-fe/.taskmaster/reports/` 의 5개 검증 리포트 + `API_ISSUE_REPORT.md` (mvp-1-fix-v3 Task 8) 에서 제기된 이슈에 대한 처리 현황입니다.
 
 | # | 이슈 | 출처 | 상태 | 비고 |
 |---|---|---|---|---|
@@ -36,6 +36,10 @@ Base URL: `/api/v1`
 | 7 | `ApiResponse`에 `code` / `fieldErrors` 추가 | Auth §D | ✅ 해소 | 본 문서 상단 응답 스키마 참조. `code`는 `ErrorCode` enum 이름. 유효성 오류 시 `fieldErrors` 맵 동봉 |
 | 8 | `PerformanceDetailResponse` 요약 필드 (밴드명/합주 제목) | Performance §3-D | ✅ 해소 | `bandIds`, `practiceIds` → `bands: [{bandId, bandName}]`, `practices: [{practiceId, title, startAt}]`로 확장 (6-3 참조) |
 | 9 | `GET /bands/me` 응답에 본인 역할 (`myRole`) 포함 | Band §3-D | ✅ 해소 (옵션 9-C) | 응답 항목 타입을 `MyBandInfoResponse`로 변경, `myRole: BandRole` 필드 추가 (3-3-1 참조) |
+| 10 | `PerformanceCreateRequest.bandIds` non-null 차단 (T6) | API_ISSUE_REPORT §4-1 | ✅ 해소 | `bandIds: List<UUID>? = null` 로 변경, 미전달 시 빈 배열로 보정 (6-1 참조) |
+| 11 | Practice ↔ PracticeSong 닭-달걀 (FE-API-020) | API_ISSUE_REPORT §4-2 | ✅ 해소 (§5-2 안 채택) | PracticeSong 생성 API의 `practiceId` 옵셔널화 → FE는 PracticeSong 선행 생성 후 응답 `songId` 를 `/practices` 에 전달 (5-2/5-3/4-1 참조) |
+| 12 | 입력 검증 메시지 정제 (T3, T6) | API_ISSUE_REPORT §4-3 | ✅ 해소 | `HttpMessageNotReadableException` 핸들러가 `KotlinInvalidNullException`/`InvalidFormatException` 을 한국어 메시지 + `fieldErrors` 로 매핑 |
+| 13 | 과거 시각 startAt 검증 (T17) | API_ISSUE_REPORT §4-4 | ✅ 해소 | Practice/Performance 생성·수정·합주 일정 변경 DTO 의 `startAt` 에 `@Future` 적용 (4-1/4-8/6-1/6-4 참조) |
 
 ### 미해소 / 프론트 책임
 
@@ -349,7 +353,8 @@ Base URL: `/api/v1`
   ```
   - `title`: optional
   - `venue`: optional
-  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준)
+  - `song`: **UUID 만 허용** (PracticeSong ID). 검색 결과의 텍스트/임시 식별자는 받지 않음.
+  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준). **현재 이후만 허용** (`@Future`); 과거 시각은 400 + `fieldErrors.startAt`.
 - **Response**
   ```json
   {
@@ -357,6 +362,9 @@ Base URL: `/api/v1`
     "practiceTitle": "TuNA 정기공연 1주차 합주"
   }
   ```
+- **합주 시작하기 마법사 호출 시퀀스 (FE-API-020)**: PracticeSong 을 먼저 생성한 후 응답의 `songId` 를 `song` 필드로 전달. Practice 와 PracticeSong 의 1:1 바인딩은 PracticeSong 생성 시점에 `practiceId` 를 함께 전달하거나 (선바인딩), 본 API 의 `song` 으로 후바인딩.
+  1. 외부 검색 결과 사용: `POST /practice-songs/from-song` (practiceId 생략) → `songId` 획득 → `POST /practices` 의 `song` 으로 전달
+  2. 자작곡 입력: `POST /practice-songs` (practiceId 생략) → `songId` 획득 → `POST /practices` 의 `song` 으로 전달
 
 ---
 
@@ -524,7 +532,7 @@ Base URL: `/api/v1`
     "durationMinutes": 90
   }
   ```
-  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준)
+  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준). **현재 이후만 허용** (`@Future`).
 
 ---
 
@@ -589,6 +597,7 @@ Base URL: `/api/v1`
     "refLink": null
   }
   ```
+  - `practiceId`: **optional**. 미제공 시 PracticeSong 만 생성하고 Practice 바인딩은 수행하지 않음 (마법사 시나리오에서 응답 `songId` 를 `POST /practices` 의 `song` 으로 전달).
   - `refLink`: optional
 - **Response**: `PracticeSongResponse`
   ```json
@@ -621,8 +630,9 @@ Base URL: `/api/v1`
     }
   }
   ```
+  - `practiceId`: **optional**. 미제공 시 PracticeSong 만 생성 (5-2와 동일 마법사 시나리오 지원).
 - **Response**: `PracticeSongResponse` (5-2와 동일 구조)
-- **비고**: 외부 시스템에서 받아온 Song 객체를 그대로 사용하여 합주곡을 생성. 생성된 합주곡은 `practiceId`의 합주에 1:1 바인딩. `song` 필드는 [5-1](#5-1-합주곡-검색-song) 응답의 항목을 재가공 없이 그대로 사용 가능.
+- **비고**: 외부 시스템에서 받아온 Song 객체를 그대로 사용하여 합주곡을 생성. `practiceId` 가 있으면 해당 합주에 1:1 바인딩, 없으면 응답 `songId` 를 [4-1](#4-1-합주-생성) 의 `song` 으로 전달하여 후바인딩. `song` 필드는 [5-1](#5-1-합주곡-검색-song) 응답의 항목을 재가공 없이 그대로 사용 가능.
 
 ---
 
@@ -698,9 +708,9 @@ Base URL: `/api/v1`
     "venue": "Club FF"
   }
   ```
-  - `bandIds`: optional (기본값 빈 배열)
+  - `bandIds`: optional (미전달/`null`/빈 배열 모두 허용 — 빈 배열로 보정)
   - `venue`: optional
-  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준)
+  - `startAt` 형식: `yyyy-MM-dd HH:mm` (Asia/Seoul 기준). **현재 이후만 허용** (`@Future`); 과거 시각은 400 + `fieldErrors.startAt`.
 - **Response**
   ```json
   {
@@ -804,6 +814,7 @@ Base URL: `/api/v1`
   }
   ```
   - 모든 필드 optional. 미전달 필드는 기존 값 유지.
+  - `startAt`: 전달 시 **현재 이후만 허용** (`@Future`).
 
 ---
 
@@ -823,6 +834,7 @@ Base URL: `/api/v1`
   ```
   - `title`: optional (미입력 시 곡 제목으로 대체)
   - `venue`: optional
+  - `startAt`: **현재 이후만 허용** (`@Future`).
 - **Response**
   ```json
   {

--- a/src/app/(main)/practices/new/PracticeCreateWizard.client.tsx
+++ b/src/app/(main)/practices/new/PracticeCreateWizard.client.tsx
@@ -13,6 +13,8 @@ import { StepIndicator } from '@/components/ui/step-indicator';
 import { WizardSummaryCard } from '@/components/ui/wizard-summary-card';
 import { useMyBands } from '@/domain/band/hooks/useMyBands';
 import { useCreatePractice } from '@/domain/practice/hooks/useCreatePractice';
+import { createPracticeSongFromFields } from '@/domain/practice-song/api/createPracticeSongFromFields';
+import { createPracticeSongFromSong } from '@/domain/practice-song/api/createPracticeSongFromSong';
 import { useSearchSongs } from '@/domain/practice-song/hooks/useSearchSongs';
 import type { SongSearchItem } from '@/domain/practice-song/types';
 import { ROUTES } from '@/global/config/routes';
@@ -117,23 +119,32 @@ export function PracticeCreateWizard() {
     if (step > 0) setStep((step - 1) as Step);
   }
 
-  function submit() {
+  async function submit() {
     if (!songPick) return;
     if (!startAt) return toast.error('시작 시각을 설정해 주세요.');
-    // NOTE: §4-1 song 필드는 songId(UUID) 를 요구하지만 §5-2/§5-3 합주곡 생성은 practiceId 가 선행되어야 하는 닭-달걀
-    //       문제. 본 라운드는 곡 메타 텍스트(`title — artist`) 를 임시 식별자로 전송하고, 백엔드 응답을 Task 8 에서
-    //       검증 후 후속 보정 (FE-API-020 등록).
-    const songIdentifier =
-      songPick.mode === 'picked'
-        ? `${songPick.picked.title} — ${songPick.picked.artist}`
-        : `${songPick.custom.title} — ${songPick.custom.artist}`;
-    mutation.mutate({
-      title: title || undefined,
-      song: songIdentifier,
-      venue: venue || undefined,
-      startAt,
-      durationMinutes,
-    });
+    // API_SPEC v3 (FE-API-020 해소): practiceId 옵셔널 PracticeSong 생성 → 응답 songId → POST /practices.
+    try {
+      const song =
+        songPick.mode === 'picked'
+          ? await createPracticeSongFromSong({ song: songPick.picked })
+          : await createPracticeSongFromFields({
+              title: songPick.custom.title,
+              artist: songPick.custom.artist,
+              album: songPick.custom.album || '',
+              duration: songPick.custom.duration,
+              refLink: songPick.custom.refLink ?? null,
+            });
+      mutation.mutate({
+        title: title || undefined,
+        song: song.songId,
+        venue: venue || undefined,
+        startAt,
+        durationMinutes,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '합주곡 생성에 실패했습니다.';
+      toast.error(message);
+    }
   }
 
   return (

--- a/src/domain/practice-song/api/createPracticeSongFromFields.ts
+++ b/src/domain/practice-song/api/createPracticeSongFromFields.ts
@@ -3,7 +3,8 @@ import { apiClient } from '@/global/api/apiClient';
 import type { PracticeSongResponse } from '../types';
 
 type CreateFromFieldsRequest = {
-  practiceId: string;
+  /** Optional — 미제공 시 PracticeSong 만 생성, 응답 songId 를 POST /practices 의 song 으로 후바인딩. */
+  practiceId?: string;
   title: string;
   artist: string;
   album: string;
@@ -11,7 +12,10 @@ type CreateFromFieldsRequest = {
   refLink?: string | null;
 };
 
-/** API_SPEC §5-2 — 자작곡 등 외부 API 미사용 시 필드 직접 입력. */
+/**
+ * API_SPEC §5-2 — 자작곡 등 외부 API 미사용 시 필드 직접 입력.
+ * 마법사 시나리오에서는 practiceId 생략.
+ */
 export async function createPracticeSongFromFields(
   req: CreateFromFieldsRequest,
 ): Promise<PracticeSongResponse> {

--- a/src/domain/practice-song/api/createPracticeSongFromSong.ts
+++ b/src/domain/practice-song/api/createPracticeSongFromSong.ts
@@ -3,11 +3,15 @@ import { apiClient } from '@/global/api/apiClient';
 import type { PracticeSongResponse, SongSearchItem } from '../types';
 
 type CreateFromSongRequest = {
-  practiceId: string;
+  /** Optional — 미제공 시 PracticeSong 만 생성, 응답 songId 를 POST /practices 의 song 으로 후바인딩. */
+  practiceId?: string;
   song: SongSearchItem;
 };
 
-/** API_SPEC §5-3 — 외부 검색 결과(SongSearchItem) 을 그대로 전달해 합주곡 생성. */
+/**
+ * API_SPEC §5-3 — 외부 검색 결과(SongSearchItem) 를 그대로 전달해 합주곡 생성.
+ * 마법사 시나리오에서는 practiceId 생략 → 응답 songId 를 §4-1 호출에 사용.
+ */
 export async function createPracticeSongFromSong(
   req: CreateFromSongRequest,
 ): Promise<PracticeSongResponse> {


### PR DESCRIPTION
## Summary
BE 가 mvp-1-fix-v3 Task 8 의 P0 4건을 모두 해소하고 API_SPEC 갱신. FE 도 그에 맞게 정리.

### 동기화
- API_SPEC.md: v1 BE 저장소와 동기화
- API_REQUIRED.md §0 표 + §8-6 (FE-API-020) 해소 마킹

### FE 코드 변경
- practice-song fetcher 의 practiceId 옵셔널화
- PracticeCreateWizard.submit 재작성:
  - 임시 텍스트 식별자 hack 제거
  - picked → createPracticeSongFromSong({song}) → songId
  - custom → createPracticeSongFromFields({...}) → songId
  - 그 다음 POST /practices 에 song = songId 전달

## 실서버 검증 (BE localhost:8080 기동 상태에서 통과)
- T1: POST /performances bandIds null/missing → 200 (이전 400)
- T2: POST /performances startAt 과거 → 400 + fieldErrors.startAt + 한국어 메시지
- T3: POST /practice-songs/from-song without practiceId → 200 + songId 반환
- T4: POST /practices with songId from T3 → 200 (마법사 end-to-end 통과)

closes #118