### PR TITLE
feat: 밴드 설정 모달 mutation 연결 (mvp-1-fix-v4 Task 4 완성)

### DIFF
--- a/src/domain/band/api/deleteBand.ts
+++ b/src/domain/band/api/deleteBand.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/global/api/apiClient';
+
+/**
+ * API_REQUIRED FE-API-023 — `DELETE /api/v1/bands/{bandId}` (백엔드 미지원 시 4xx).
+ * 권한: 리더만. 응답 204.
+ */
+export async function deleteBand(bandId: string): Promise<void> {
+  await apiClient.delete(`/api/v1/bands/${bandId}`);
+}

--- a/src/domain/band/api/updateBand.ts
+++ b/src/domain/band/api/updateBand.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export interface UpdateBandRequest {
+  name?: string;
+  description?: string;
+  profileImg?: string | null;
+}
+
+/**
+ * API_REQUIRED FE-API-022 — `PATCH /api/v1/bands/{bandId}` (백엔드 미지원 시 4xx).
+ * 백엔드 도입 후 fetcher 변경 없이 즉시 활성화.
+ */
+export async function updateBand(bandId: string, req: UpdateBandRequest): Promise<void> {
+  await apiClient.patch(`/api/v1/bands/${bandId}`, req);
+}

--- a/src/domain/band/api/uploadBandProfileImage.ts
+++ b/src/domain/band/api/uploadBandProfileImage.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/global/api/apiClient';
+
+/**
+ * API_REQUIRED FE-API-009 (P2 활성화) — 멀티파트 또는 사전서명 URL.
+ * 본 라운드는 stub — 실제 업로드 엔드포인트가 추가되면 multipart 호출로 교체.
+ */
+export async function uploadBandProfileImage(
+  bandId: string,
+  // 향후 multipart 변환 — 현재는 placeholder.
+  _file: File, // eslint-disable-line @typescript-eslint/no-unused-vars
+): Promise<{ profileImg: string }> {
+  // 백엔드 미지원 — apiClient 가 404/501 등으로 throw 하도록 형태만 갖춤.
+  const data = await apiClient.post<{ profileImg: string }>(
+    `/api/v1/bands/${bandId}/profile-image`,
+    {},
+  );
+  if (!data) throw new Error('프로필 이미지 업로드 응답이 비어 있습니다.');
+  return data;
+}

--- a/src/domain/band/components/BandSettingsModal.client.tsx
+++ b/src/domain/band/components/BandSettingsModal.client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -14,6 +15,9 @@ import {
 } from '@/components/ui/responsive-sheet';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
+import { useDeleteBand } from '@/domain/band/hooks/useDeleteBand';
+import { useUpdateBand } from '@/domain/band/hooks/useUpdateBand';
+import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
 
 interface Props {
@@ -28,6 +32,7 @@ interface Props {
  * 본 라운드는 UI 완성 + toast 안내, 백엔드 도입 시 mutation 만 교체.
  */
 export function BandSettingsModal({ open, onOpenChange, band }: Props) {
+  const router = useRouter();
   const toast = useToast();
   const [tab, setTab] = useState<'info' | 'image' | 'delete'>('info');
 
@@ -41,14 +46,32 @@ export function BandSettingsModal({ open, onOpenChange, band }: Props) {
   // 삭제
   const [confirmText, setConfirmText] = useState('');
 
+  const updateMutation = useUpdateBand(band.bandId, {
+    onSuccess: () => {
+      toast.success('밴드 정보를 저장했습니다.');
+      onOpenChange(false);
+    },
+    onError: (err) =>
+      toast.error(err.message || '저장에 실패했습니다 (FE-API-022 백엔드 도입 대기 중).'),
+  });
+
+  const deleteMutation = useDeleteBand(band.bandId, {
+    onSuccess: () => {
+      toast.success('밴드를 삭제했습니다.');
+      onOpenChange(false);
+      router.replace(ROUTES.BANDS);
+    },
+    onError: (err) =>
+      toast.error(err.message || '삭제에 실패했습니다 (FE-API-023 백엔드 도입 대기 중).'),
+  });
+
   function handleSaveInfo() {
-    toast.info('정보 수정 API 가 백엔드에 추가되면 자동 반영됩니다 (FE-API-022).');
-    onOpenChange(false);
+    updateMutation.mutate({ name: name.trim(), description: description.trim() || undefined });
   }
 
   function handleSaveImage() {
-    toast.info('프로필 이미지 업로드 API 가 백엔드에 추가되면 자동 반영됩니다 (FE-API-009).');
-    onOpenChange(false);
+    // FE-API-009 업로드 엔드포인트 도입 전까지는 URL 만 PATCH 로 함께 전송 (BE 가 profileImg 필드 받을 경우).
+    updateMutation.mutate({ profileImg: profileImg.trim() || null });
   }
 
   function handleDelete() {
@@ -56,8 +79,7 @@ export function BandSettingsModal({ open, onOpenChange, band }: Props) {
       toast.error('밴드 이름을 정확히 입력해 주세요.');
       return;
     }
-    toast.info('밴드 삭제 API 가 백엔드에 추가되면 자동 반영됩니다 (FE-API-023).');
-    onOpenChange(false);
+    deleteMutation.mutate();
   }
 
   return (
@@ -124,13 +146,22 @@ export function BandSettingsModal({ open, onOpenChange, band }: Props) {
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             취소
           </Button>
-          {tab === 'info' && <Button onClick={handleSaveInfo}>저장</Button>}
-          {tab === 'image' && <Button onClick={handleSaveImage}>저장</Button>}
+          {tab === 'info' && (
+            <Button onClick={handleSaveInfo} loading={updateMutation.isPending}>
+              저장
+            </Button>
+          )}
+          {tab === 'image' && (
+            <Button onClick={handleSaveImage} loading={updateMutation.isPending}>
+              저장
+            </Button>
+          )}
           {tab === 'delete' && (
             <Button
               variant="danger"
               onClick={handleDelete}
               disabled={confirmText !== band.bandName}
+              loading={deleteMutation.isPending}
             >
               삭제
             </Button>

--- a/src/domain/band/hooks/useDeleteBand.ts
+++ b/src/domain/band/hooks/useDeleteBand.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deleteBand } from '../api/deleteBand';
+
+type UseDeleteBandOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDeleteBand(bandId: string, options?: UseDeleteBandOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => deleteBand(bandId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.my()] });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.list()] });
+      queryClient.removeQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/band/hooks/useUpdateBand.ts
+++ b/src/domain/band/hooks/useUpdateBand.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateBand, type UpdateBandRequest } from '../api/updateBand';
+
+type UseUpdateBandOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useUpdateBand(bandId: string, options?: UseUpdateBandOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, UpdateBandRequest>({
+    mutationFn: (req) => updateBand(bandId, req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.my()] });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.list()] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}


### PR DESCRIPTION
## Summary
Task 4 의 누락 부분 보완. 모달 UI 는 PR #108 에서 만들었지만 API 함수/훅 stub 누락 → 실제 mutation 연결.

## 신규 파일
- src/domain/band/api/updateBand.ts (PATCH /bands/{id})
- src/domain/band/api/deleteBand.ts (DELETE /bands/{id})
- src/domain/band/api/uploadBandProfileImage.ts (FE-API-009 stub)
- src/domain/band/hooks/useUpdateBand.ts
- src/domain/band/hooks/useDeleteBand.ts

## BandSettingsModal 변경
- toast.info stub → 실 mutation
- 정보/사진 → useUpdateBand.mutate (queryKeys 자동 invalidate)
- 삭제 → useDeleteBand.mutate + /bands 라우팅
- 백엔드 미지원 시 onError 가 안내 토스트 표시
- 버튼 loading 상태 연결

closes #107