### PR TITLE
refactor: 레이아웃 비율 축소 — 사이드바/마스터 슬림화

### DIFF
--- a/src/app/(main)/bands/BandsListPane.client.tsx
+++ b/src/app/(main)/bands/BandsListPane.client.tsx
@@ -55,7 +55,7 @@ function BandRow({
         <IconTile icon={<BandIcon />} size="sm" tone={DOMAIN_TONES.band} />
         <div className="min-w-0 flex-1">
           <div className="gap-s-2 flex items-center">
-            <span className="text-body truncate font-semibold">{band.bandName}</span>
+            <span className="text-caption truncate font-semibold">{band.bandName}</span>
             {myRole && <BandRoleBadge role={myRole} />}
           </div>
           {band.description && (
@@ -103,8 +103,8 @@ export function BandsListPane() {
       data-slot="bands-list-pane"
       aria-label="밴드 탐색"
     >
-      <div className="border-border px-s-5 py-s-4 flex items-center justify-between border-b">
-        <h2 className="text-subtitle font-bold">밴드 탐색</h2>
+      <div className="border-border px-s-3 py-s-3 flex items-center justify-between border-b">
+        <h2 className="text-body font-bold">밴드 탐색</h2>
         <BandCreateModal
           trigger={
             <Button size="sm" variant="accent-outline" aria-label="새 밴드 만들기">

--- a/src/app/(main)/performances/PerformancesListPane.client.tsx
+++ b/src/app/(main)/performances/PerformancesListPane.client.tsx
@@ -38,7 +38,7 @@ function PerformanceRow({ p, pathname }: { p: PerformanceListItemResponse; pathn
       >
         <IconTile icon={<PerformanceIcon />} size="sm" tone={DOMAIN_TONES.performance} />
         <div className="min-w-0 flex-1">
-          <div className="text-body truncate font-semibold">{p.title}</div>
+          <div className="text-caption truncate font-semibold">{p.title}</div>
           <div className="text-foreground-muted text-caption mt-0.5 truncate">{p.startAt}</div>
         </div>
       </Link>
@@ -74,8 +74,8 @@ export function PerformancesListPane() {
       data-slot="performances-list-pane"
       aria-label="공연 탐색"
     >
-      <div className="border-border px-s-5 py-s-4 flex items-center justify-between border-b">
-        <h2 className="text-subtitle font-bold">공연 탐색</h2>
+      <div className="border-border px-s-3 py-s-3 flex items-center justify-between border-b">
+        <h2 className="text-body font-bold">공연 탐색</h2>
         <Button asChild size="sm" variant="accent-outline" aria-label="공연 생성">
           <Link href={ROUTES.PERFORMANCE_NEW}>
             <Plus className="h-4 w-4" /> 공연 생성

--- a/src/app/(main)/practices/PracticesListPane.client.tsx
+++ b/src/app/(main)/practices/PracticesListPane.client.tsx
@@ -41,7 +41,7 @@ function PracticeRow({ p, pathname }: { p: PracticeListItemResponse; pathname: s
       >
         <IconTile icon={<PracticeIcon />} size="sm" tone={DOMAIN_TONES.practice} />
         <div className="min-w-0 flex-1">
-          <div className="text-body truncate font-semibold">{p.title}</div>
+          <div className="text-caption truncate font-semibold">{p.title}</div>
           <div className="text-foreground-muted text-caption gap-s-2 mt-0.5 flex items-center">
             <span>{when}</span>
             {p.venue && <span className="truncate">· {p.venue}</span>}
@@ -80,8 +80,8 @@ export function PracticesListPane() {
       data-slot="practices-list-pane"
       aria-label="합주 탐색"
     >
-      <div className="border-border px-s-5 py-s-4 flex items-center justify-between border-b">
-        <h2 className="text-subtitle font-bold">합주 탐색</h2>
+      <div className="border-border px-s-3 py-s-3 flex items-center justify-between border-b">
+        <h2 className="text-body font-bold">합주 탐색</h2>
         <Button asChild size="sm" variant="accent-outline" aria-label="합주 시작하기">
           <Link href={ROUTES.PRACTICE_NEW}>
             <Plus className="h-4 w-4" /> 합주 시작하기

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,10 +55,11 @@
   --spacing-s-10: 40px;
   --spacing-s-12: 48px;
 
-  /* Layout widths (Shell / Pane-Split. CSS 변수로 소비: w-[var(--sidebar-w)] 또는 style) */
-  --sidebar-w: 240px;
-  --list-pane-w: 340px;
-  --band-list-pane-w: 360px;
+  /* Layout widths (Shell / Pane-Split. CSS 변수로 소비: w-[var(--sidebar-w)] 또는 style)
+     mvp-1-fix-v5 Task 1: MBA 13(1280px) 기준 사이드바+마스터 합 ≤ 38% 가 되도록 축소 (이전 240+360=600px → 200+280=480px). */
+  --sidebar-w: 200px;
+  --list-pane-w: 280px;
+  --band-list-pane-w: 280px;
 
   /* Typography scale (semantic, design/dist 기반) */
   --text-display: 40px;

--- a/src/components/layout/__snapshots__/sidebar.test.tsx.snap
+++ b/src/components/layout/__snapshots__/sidebar.test.tsx.snap
@@ -4,21 +4,21 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
 <DocumentFragment>
   <aside
     aria-label="주 탐색"
-    class="bg-surface border-border py-s-5 px-s-4 gap-s-1 hidden shrink-0 flex-col border-r lg:flex"
+    class="bg-surface border-border py-s-4 px-s-3 gap-s-1 hidden shrink-0 flex-col border-r lg:flex"
     data-slot="sidebar"
     style="width: var(--sidebar-w);"
   >
     <div
-      class="border-border mb-s-3 gap-s-3 pb-s-5 px-s-2 pt-s-1 flex items-center border-b"
+      class="border-border mb-s-2 gap-s-2 pb-s-4 px-s-2 pt-s-1 flex items-center border-b"
     >
       <span
         aria-hidden="true"
-        class="bg-accent-dim flex h-10 w-10 items-center justify-center rounded-md border"
+        class="bg-accent-dim flex h-8 w-8 items-center justify-center rounded-md border"
         style="border-color: oklch(0.62 0.22 250 / 0.2);"
       >
         <svg
           aria-hidden="true"
-          class="lucide lucide-guitar text-accent h-[22px] w-[22px]"
+          class="lucide lucide-guitar text-accent h-[18px] w-[18px]"
           fill="none"
           height="24"
           stroke="currentColor"
@@ -44,13 +44,13 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
         </svg>
       </span>
       <span
-        class="text-accent text-title font-black tracking-tight"
+        class="text-accent text-body font-black tracking-tight"
       >
         Bandage
       </span>
     </div>
     <div
-      class="text-foreground-muted px-s-3 pb-s-3 pt-s-2 text-micro font-bold tracking-wider uppercase"
+      class="text-foreground-muted px-s-3 pb-s-2 pt-s-1 text-micro font-bold tracking-wider uppercase"
     >
       Navigation
     </div>
@@ -58,12 +58,12 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
       class="gap-s-1 flex flex-1 flex-col"
     >
       <a
-        class="gap-s-4 px-s-4 py-s-3 flex items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
+        class="gap-s-3 px-s-3 py-s-2 flex items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
         href="/home"
       >
         <svg
           aria-hidden="true"
-          class="lucide lucide-house h-[18px] w-[18px] shrink-0"
+          class="lucide lucide-house h-4 w-4 shrink-0"
           fill="none"
           height="24"
           stroke="currentColor"
@@ -89,12 +89,12 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
       </a>
       <a
         aria-current="page"
-        class="gap-s-4 px-s-4 py-s-3 flex items-center rounded-md transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none bg-accent-dim text-accent font-bold"
+        class="gap-s-3 px-s-3 py-s-2 flex items-center rounded-md transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none bg-accent-dim text-accent font-bold"
         href="/bands"
       >
         <svg
           aria-hidden="true"
-          class="lucide lucide-users h-[18px] w-[18px] shrink-0"
+          class="lucide lucide-users h-4 w-4 shrink-0"
           fill="none"
           height="24"
           stroke="currentColor"
@@ -129,12 +129,12 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
       <div>
         <button
           aria-expanded="false"
-          class="gap-s-4 px-s-4 py-s-3 flex w-full items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
+          class="gap-s-3 px-s-3 py-s-2 flex w-full items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="lucide lucide-music h-[18px] w-[18px] shrink-0"
+            class="lucide lucide-music h-4 w-4 shrink-0"
             fill="none"
             height="24"
             stroke="currentColor"
@@ -186,12 +186,12 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
       <div>
         <button
           aria-expanded="false"
-          class="gap-s-4 px-s-4 py-s-3 flex w-full items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
+          class="gap-s-3 px-s-3 py-s-2 flex w-full items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="lucide lucide-calendar-days h-[18px] w-[18px] shrink-0"
+            class="lucide lucide-calendar-days h-4 w-4 shrink-0"
             fill="none"
             height="24"
             stroke="currentColor"
@@ -262,12 +262,12 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
         </button>
       </div>
       <a
-        class="gap-s-4 px-s-4 py-s-3 flex items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
+        class="gap-s-3 px-s-3 py-s-2 flex items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
         href="/me"
       >
         <svg
           aria-hidden="true"
-          class="lucide lucide-user h-[18px] w-[18px] shrink-0"
+          class="lucide lucide-user h-4 w-4 shrink-0"
           fill="none"
           height="24"
           stroke="currentColor"
@@ -299,11 +299,11 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
     >
       <a
         aria-label="마이페이지로 이동"
-        class="hover:bg-card gap-s-2 px-s-2 py-s-2 flex min-w-0 flex-1 items-center rounded-md transition-colors"
+        class="hover:bg-card gap-s-2 px-s-2 py-s-1 flex min-w-0 flex-1 items-center rounded-md transition-colors"
         href="/me"
       >
         <span
-          class="bg-card-hover text-foreground-sub rounded-pill inline-flex items-center justify-center overflow-hidden font-semibold select-none h-8 w-8 text-xs"
+          class="bg-card-hover text-foreground-sub rounded-pill inline-flex items-center justify-center overflow-hidden font-semibold select-none h-6 w-6 text-[10px]"
         >
           <span
             aria-label="수연"

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -83,25 +83,25 @@ export function Sidebar({ className }: SidebarProps) {
   return (
     <aside
       className={cn(
-        'bg-surface border-border py-s-5 px-s-4 gap-s-1 hidden shrink-0 flex-col border-r lg:flex',
+        'bg-surface border-border py-s-4 px-s-3 gap-s-1 hidden shrink-0 flex-col border-r lg:flex',
         className,
       )}
       style={{ width: 'var(--sidebar-w)' }}
       data-slot="sidebar"
       aria-label="주 탐색"
     >
-      <div className="border-border mb-s-3 gap-s-3 pb-s-5 px-s-2 pt-s-1 flex items-center border-b">
+      <div className="border-border mb-s-2 gap-s-2 pb-s-4 px-s-2 pt-s-1 flex items-center border-b">
         <span
-          className="bg-accent-dim flex h-10 w-10 items-center justify-center rounded-md border"
+          className="bg-accent-dim flex h-8 w-8 items-center justify-center rounded-md border"
           style={{ borderColor: 'oklch(0.62 0.22 250 / 0.2)' }}
           aria-hidden="true"
         >
-          <Guitar className="text-accent h-[22px] w-[22px]" />
+          <Guitar className="text-accent h-[18px] w-[18px]" />
         </span>
-        <span className="text-accent text-title font-black tracking-tight">Bandage</span>
+        <span className="text-accent text-body font-black tracking-tight">Bandage</span>
       </div>
 
-      <div className="text-foreground-muted px-s-3 pb-s-3 pt-s-2 text-micro font-bold tracking-wider uppercase">
+      <div className="text-foreground-muted px-s-3 pb-s-2 pt-s-1 text-micro font-bold tracking-wider uppercase">
         Navigation
       </div>
       <nav className="gap-s-1 flex flex-1 flex-col">
@@ -125,10 +125,10 @@ export function Sidebar({ className }: SidebarProps) {
         ) : (
           <Link
             href={ROUTES.ME}
-            className="hover:bg-card gap-s-2 px-s-2 py-s-2 flex min-w-0 flex-1 items-center rounded-md transition-colors"
+            className="hover:bg-card gap-s-2 px-s-2 py-s-1 flex min-w-0 flex-1 items-center rounded-md transition-colors"
             aria-label="마이페이지로 이동"
           >
-            <Avatar size="md" fallback={me?.name ?? me?.email ?? '게스트'} />
+            <Avatar size="sm" fallback={me?.name ?? me?.email ?? '게스트'} />
             <div className="min-w-0 flex-1">
               <div className="text-foreground text-caption truncate font-semibold">
                 {me?.name ?? '게스트'}
@@ -161,14 +161,14 @@ function NavRow({ item, pathname }: { item: NavItem; pathname: string }) {
         href={href}
         aria-current={active ? 'page' : undefined}
         className={cn(
-          'gap-s-4 px-s-4 py-s-3 text-body flex items-center rounded-md font-medium transition-colors',
+          'gap-s-3 px-s-3 py-s-2 text-caption flex items-center rounded-md font-medium transition-colors',
           'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
           active
             ? 'bg-accent-dim text-accent font-bold'
             : 'text-foreground-sub hover:bg-card hover:text-foreground',
         )}
       >
-        <Icon className="h-[18px] w-[18px] shrink-0" aria-hidden="true" />
+        <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
         <span className="truncate">{label}</span>
       </Link>
     );
@@ -181,14 +181,14 @@ function NavRow({ item, pathname }: { item: NavItem; pathname: string }) {
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         className={cn(
-          'gap-s-4 px-s-4 py-s-3 text-body flex w-full items-center rounded-md font-medium transition-colors',
+          'gap-s-3 px-s-3 py-s-2 text-caption flex w-full items-center rounded-md font-medium transition-colors',
           'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
           active
             ? 'bg-accent-dim text-accent font-bold'
             : 'text-foreground-sub hover:bg-card hover:text-foreground',
         )}
       >
-        <Icon className="h-[18px] w-[18px] shrink-0" aria-hidden="true" />
+        <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
         <span className="flex-1 truncate text-left">{label}</span>
         <ChevronDown
           className={cn('h-4 w-4 shrink-0 transition-transform', open && 'rotate-180')}
@@ -196,7 +196,7 @@ function NavRow({ item, pathname }: { item: NavItem; pathname: string }) {
         />
       </button>
       {open && (
-        <ul className="mt-s-1 ml-s-6 gap-s-1 flex flex-col">
+        <ul className="mt-s-1 ml-s-5 flex flex-col gap-0.5">
           {subs!.map((s) => {
             const subActive = isSubActive(pathname, s.href);
             return (
@@ -205,7 +205,7 @@ function NavRow({ item, pathname }: { item: NavItem; pathname: string }) {
                   href={s.href}
                   aria-current={subActive ? 'page' : undefined}
                   className={cn(
-                    'px-s-3 py-s-2 text-caption block rounded-md transition-colors',
+                    'px-s-3 text-micro block rounded-md py-1 transition-colors',
                     'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
                     subActive
                       ? 'text-accent font-semibold'


### PR DESCRIPTION
## Summary
- globals.css: sidebar 240→200, list-pane 340→280, band-list-pane 360→280
- 합 480px (이전 600px) — MBA 13(1280px) 기준 38%, 1440px 기준 33%
- 사이드바 로고/Nav item/서브메뉴/하단 프로필 비례 슬림
- ListPane 헤더(text-subtitle→text-body), Row 제목(text-body→text-caption) 축소
- 모바일/본문 영향 없음

## Test plan
- [x] typecheck/lint/test
- [ ] MBA 13(1280px)에서 사이드바+마스터 ≤ 38%
- [ ] 1440px에서 ≤ 33%
- [ ] 모바일 BottomNav 영향 없음

closes #123