### PR TITLE
feat: 선곡 회의 도메인 골격 — types + Zustand store + mock 시드

### DIFF
--- a/src/domain/setlist-meeting/mock/seed.ts
+++ b/src/domain/setlist-meeting/mock/seed.ts
@@ -1,0 +1,167 @@
+import type { Meeting, Member, SessionDef, Song } from '../types';
+
+/** 현재 사용자 (mock). design/web/setlist_web.jsx 와 동일하게 u1=정선우(매니저). */
+export const SEED_CURRENT_USER_ID = 'u1';
+
+export const SEED_MEMBERS: Member[] = [
+  { id: 'u1', name: '정선우', role: '기타', avatar: '#F59E0B' },
+  { id: 'u2', name: '신선경', role: '베이스', avatar: '#EF4444' },
+  { id: 'u3', name: '지범준', role: '기타', avatar: '#3B82F6' },
+  { id: 'u4', name: '안성진', role: '보컬', avatar: '#8B5CF6' },
+  { id: 'u5', name: '이동후', role: '드럼', avatar: '#10B981' },
+  { id: 'u6', name: '임지수', role: '키보드', avatar: '#EC4899' },
+  { id: 'u7', name: '최홍석', role: '드럼', avatar: '#06B6D4' },
+];
+
+export const SEED_MEETINGS: Meeting[] = [
+  {
+    id: 'mt1',
+    bandId: 'b1',
+    bandName: 'TOOL TRIBUTE',
+    title: '10,000 Days 전곡 합주 프로젝트',
+    managerId: 'u1',
+    createdAt: '2026-04-20',
+    updatedAt: '2026-04-25',
+  },
+  {
+    id: 'mt2',
+    bandId: 'b3',
+    bandName: '마그마',
+    title: '여름 공연 셋리스트',
+    managerId: 'u1',
+    createdAt: '2026-04-18',
+    updatedAt: '2026-04-22',
+  },
+];
+
+const TOOL_SESSIONS: SessionDef[] = [
+  { id: 'V', label: '보컬', short: 'V', need: 1 },
+  { id: 'G', label: '기타', short: 'G', need: 1 },
+  { id: 'B', label: '베이스', short: 'B', need: 1 },
+  { id: 'D', label: '드럼', short: 'D', need: 1 },
+];
+
+export const SEED_SONGS: Song[] = [
+  {
+    id: 's1',
+    meetingId: 'mt1',
+    title: 'Vicarious',
+    artist: 'Tool',
+    album: '10,000 Days',
+    proposerId: 'u3',
+    note: '폴리리듬 도입부, 7/8 변박. 기타 오프닝 어렵지만 임팩트 큼.',
+    sessions: TOOL_SESSIONS,
+    applicants: { V: ['u4'], G: ['u1', 'u3'], B: ['u2'], D: [] },
+    confirmed: { V: ['u4'], G: ['u1'], B: ['u2'], D: [] },
+    chat: [
+      {
+        userId: 'u3',
+        at: '04-22 10:14',
+        msg: 'Vicarious 인트로부터 너무 강력해서 1번 트랙으로 어떤가요?',
+      },
+      { userId: 'u4', at: '04-22 11:02', msg: '보컬 음역 빡셈. 키 반음 내릴지 고민됨.' },
+      { userId: 'u1', at: '04-22 14:30', msg: '기타 솔로 부분 따로 합주 잡고 싶음.' },
+    ],
+  },
+  {
+    id: 's2',
+    meetingId: 'mt1',
+    title: 'Jambi',
+    artist: 'Tool',
+    album: '10,000 Days',
+    proposerId: 'u1',
+    note: 'Talk box 솔로 인상적. 모든 세션 단단하게 매칭됨.',
+    sessions: TOOL_SESSIONS,
+    applicants: { V: ['u4'], G: ['u3', 'u1'], B: ['u2'], D: ['u5', 'u7'] },
+    confirmed: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'] },
+    chat: [
+      { userId: 'u1', at: '04-20 09:00', msg: 'Jambi는 라이브에서 진짜 좋을 듯.' },
+      { userId: 'u5', at: '04-20 10:15', msg: '드럼 그루브 좋아요.' },
+    ],
+  },
+  {
+    id: 's3',
+    meetingId: 'mt1',
+    title: 'Wings for Marie (Pt 1)',
+    artist: 'Tool',
+    album: '10,000 Days',
+    proposerId: 'u4',
+    note: '잔잔하게 시작 → 10,000 Days로 이어지는 구성. 보컬 표현이 핵심.',
+    sessions: TOOL_SESSIONS,
+    applicants: { V: ['u4'], G: [], B: ['u2'], D: [] },
+    confirmed: { V: [], G: [], B: [], D: [] },
+    chat: [
+      {
+        userId: 'u4',
+        at: '04-21 16:00',
+        msg: '아버지에 대한 곡. 10,000 Days와 묶어서 가야 의미가 살아요.',
+      },
+    ],
+  },
+  {
+    id: 's4',
+    meetingId: 'mt1',
+    title: '10,000 Days (Wings Pt 2)',
+    artist: 'Tool',
+    album: '10,000 Days',
+    proposerId: 'u4',
+    note: '11분 대곡. 신스 패드 + 퍼커션이 분위기를 만듦.',
+    sessions: [
+      ...TOOL_SESSIONS,
+      { id: 'K', label: '키보드', short: 'K', need: 1, custom: true },
+      { id: 'PERC', label: '퍼커션', short: 'Pc', need: 1, custom: true },
+    ],
+    applicants: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'], PERC: [] },
+    confirmed: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'], PERC: [] },
+    chat: [
+      { userId: 'u4', at: '04-23 13:20', msg: '키보드 패드는 임지수님 맡아주시면 좋겠어요.' },
+      { userId: 'u6', at: '04-23 14:00', msg: 'OK! 사운드 미리 준비할게요.' },
+    ],
+  },
+  {
+    id: 's5',
+    meetingId: 'mt1',
+    title: 'The Pot',
+    artist: 'Tool',
+    album: '10,000 Days',
+    proposerId: 'u2',
+    note: '베이스 라인이 메인. 9/8 변박 파트 주의.',
+    sessions: TOOL_SESSIONS,
+    applicants: { V: ['u4'], G: ['u1', 'u3'], B: ['u2'], D: ['u5'] },
+    confirmed: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'] },
+    chat: [
+      { userId: 'u2', at: '04-24 11:00', msg: 'The Pot 베이스 라인 진짜 멋있음. 꼭 하고 싶어요.' },
+    ],
+  },
+  {
+    id: 's6',
+    meetingId: 'mt1',
+    title: 'Right in Two',
+    artist: 'Tool',
+    album: '10,000 Days',
+    proposerId: 'u5',
+    note: '타블라 리듬에서 확장. 드럼 듀얼 트윈 가능.',
+    sessions: [...TOOL_SESSIONS, { id: 'D2', label: '드럼2', short: 'D2', need: 1, custom: true }],
+    applicants: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], D2: ['u7'] },
+    confirmed: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], D2: ['u7'] },
+    chat: [
+      { userId: 'u5', at: '04-24 19:00', msg: '후반부 트윈 드럼 어떨까요? 최홍석님이랑 같이.' },
+      { userId: 'u7', at: '04-24 19:20', msg: '좋아요! 패턴 분담 정해봅시다.' },
+    ],
+  },
+  {
+    id: 's7',
+    meetingId: 'mt1',
+    title: 'Rosetta Stoned',
+    artist: 'Tool',
+    album: '10,000 Days',
+    proposerId: 'u3',
+    note: '11분, 가사 광기 가득. 도전적인 트랙.',
+    sessions: TOOL_SESSIONS,
+    applicants: { V: [], G: ['u3', 'u1'], B: [], D: [] },
+    confirmed: { V: [], G: [], B: [], D: [] },
+    chat: [{ userId: 'u3', at: '04-25 09:15', msg: '난이도 최상. 시간 많이 필요할 것 같아요.' }],
+  },
+];
+
+export const DEFAULT_SESSIONS: SessionDef[] = TOOL_SESSIONS;

--- a/src/domain/setlist-meeting/store/setlistStore.test.ts
+++ b/src/domain/setlist-meeting/store/setlistStore.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useSetlistStore } from './setlistStore';
+
+beforeEach(() => {
+  useSetlistStore.getState().reset();
+});
+
+describe('setlistStore — application/withdraw', () => {
+  it('applySession 은 중복을 허용하지 않는다', () => {
+    const { applySession } = useSetlistStore.getState();
+    applySession('s7', 'V', 'u1');
+    applySession('s7', 'V', 'u1');
+    const song = useSetlistStore.getState().songs.find((s) => s.id === 's7')!;
+    expect(song.applicants.V).toEqual(['u1']);
+  });
+
+  it('withdrawSession 은 applicants 와 confirmed 모두에서 제거한다', () => {
+    const { withdrawSession } = useSetlistStore.getState();
+    // s2 G 에 u3 가 이미 confirmed.
+    expect(useSetlistStore.getState().songs.find((s) => s.id === 's2')!.confirmed.G).toContain(
+      'u3',
+    );
+    withdrawSession('s2', 'G', 'u3');
+    const song = useSetlistStore.getState().songs.find((s) => s.id === 's2')!;
+    expect(song.applicants.G).not.toContain('u3');
+    expect(song.confirmed.G).not.toContain('u3');
+  });
+
+  it('confirmSession / unconfirmSession 토글', () => {
+    const { confirmSession, unconfirmSession } = useSetlistStore.getState();
+    confirmSession('s3', 'V', 'u4');
+    expect(useSetlistStore.getState().songs.find((s) => s.id === 's3')!.confirmed.V).toEqual([
+      'u4',
+    ]);
+    unconfirmSession('s3', 'V', 'u4');
+    expect(useSetlistStore.getState().songs.find((s) => s.id === 's3')!.confirmed.V).toEqual([]);
+  });
+});
+
+describe('setlistStore — chat / addSong / addCustomSession', () => {
+  it('sendChat 은 채팅 배열에 메시지를 append', () => {
+    const { sendChat } = useSetlistStore.getState();
+    const before = useSetlistStore.getState().songs.find((s) => s.id === 's1')!.chat.length;
+    sendChat('s1', 'u1', '테스트 메시지', '04-26 12:00');
+    const after = useSetlistStore.getState().songs.find((s) => s.id === 's1')!.chat;
+    expect(after.length).toBe(before + 1);
+    expect(after.at(-1)).toMatchObject({ userId: 'u1', msg: '테스트 메시지' });
+  });
+
+  it('addSong 은 빈 applicants/confirmed 버킷을 초기화', () => {
+    const { addSong } = useSetlistStore.getState();
+    const id = addSong('mt1', {
+      title: 'New Song',
+      artist: 'Tool',
+      proposerId: 'u1',
+    });
+    const song = useSetlistStore.getState().songs.find((s) => s.id === id)!;
+    expect(song.meetingId).toBe('mt1');
+    expect(song.sessions.length).toBeGreaterThan(0);
+    for (const s of song.sessions) {
+      expect(song.applicants[s.id]).toEqual([]);
+      expect(song.confirmed[s.id]).toEqual([]);
+    }
+  });
+
+  it('addCustomSession 은 custom 플래그를 강제하고 동일 id 중복 추가를 막는다', () => {
+    const { addCustomSession } = useSetlistStore.getState();
+    addCustomSession('s1', { id: 'K', label: '키보드', short: 'K', need: 1 });
+    addCustomSession('s1', { id: 'K', label: '키보드', short: 'K', need: 1 });
+    const song = useSetlistStore.getState().songs.find((s) => s.id === 's1')!;
+    const k = song.sessions.filter((s) => s.id === 'K');
+    expect(k.length).toBe(1);
+    expect(k[0]?.custom).toBe(true);
+  });
+});

--- a/src/domain/setlist-meeting/store/setlistStore.ts
+++ b/src/domain/setlist-meeting/store/setlistStore.ts
@@ -1,0 +1,213 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import {
+  DEFAULT_SESSIONS,
+  SEED_CURRENT_USER_ID,
+  SEED_MEETINGS,
+  SEED_MEMBERS,
+  SEED_SONGS,
+} from '../mock/seed';
+import type { ChatMessage, Meeting, Member, SessionDef, Song } from '../types';
+
+const noopStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+};
+
+type State = {
+  meetings: Meeting[];
+  songs: Song[];
+  members: Member[];
+  currentUserId: string;
+  selectedMeetingId: string | null;
+  selectedSongId: string | null;
+  focusedSessionId: string | null;
+};
+
+type Actions = {
+  setSelectedMeeting: (id: string | null) => void;
+  setSelectedSong: (id: string | null) => void;
+  setFocusedSession: (id: string | null) => void;
+  setCurrentUser: (userId: string) => void;
+  applySession: (songId: string, sessionId: string, userId: string) => void;
+  withdrawSession: (songId: string, sessionId: string, userId: string) => void;
+  confirmSession: (songId: string, sessionId: string, userId: string) => void;
+  unconfirmSession: (songId: string, sessionId: string, userId: string) => void;
+  sendChat: (songId: string, userId: string, msg: string, at?: string) => void;
+  addSong: (
+    meetingId: string,
+    song: Pick<Song, 'title' | 'artist' | 'album' | 'note' | 'proposerId'> & {
+      sessions?: SessionDef[];
+    },
+  ) => string;
+  addCustomSession: (songId: string, session: SessionDef) => void;
+  addMeeting: (meeting: Omit<Meeting, 'id' | 'createdAt' | 'updatedAt'>) => string;
+  /** 테스트/디버그용. seed 로 되돌림. */
+  reset: () => void;
+};
+
+export type SetlistStore = State & Actions;
+
+const initial: State = {
+  meetings: SEED_MEETINGS,
+  songs: SEED_SONGS,
+  members: SEED_MEMBERS,
+  currentUserId: SEED_CURRENT_USER_ID,
+  selectedMeetingId: SEED_MEETINGS[0]?.id ?? null,
+  selectedSongId: SEED_SONGS[0]?.id ?? null,
+  focusedSessionId: null,
+};
+
+function nowMMDDHHmm(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function updateSong(songs: Song[], songId: string, updater: (song: Song) => Song): Song[] {
+  return songs.map((s) => (s.id === songId ? updater(s) : s));
+}
+
+function updateBucket(
+  bucket: Record<string, string[]>,
+  sessionId: string,
+  updater: (list: string[]) => string[],
+): Record<string, string[]> {
+  const list = bucket[sessionId] ?? [];
+  return { ...bucket, [sessionId]: updater(list) };
+}
+
+export const useSetlistStore = create<SetlistStore>()(
+  persist(
+    (set) => ({
+      ...initial,
+      setSelectedMeeting: (id) => set({ selectedMeetingId: id, selectedSongId: null }),
+      setSelectedSong: (id) => set({ selectedSongId: id, focusedSessionId: null }),
+      setFocusedSession: (id) => set({ focusedSessionId: id }),
+      setCurrentUser: (userId) => set({ currentUserId: userId }),
+
+      applySession: (songId, sessionId, userId) =>
+        set((state) => ({
+          songs: updateSong(state.songs, songId, (song) => ({
+            ...song,
+            applicants: updateBucket(song.applicants, sessionId, (list) =>
+              list.includes(userId) ? list : [...list, userId],
+            ),
+          })),
+        })),
+
+      withdrawSession: (songId, sessionId, userId) =>
+        set((state) => ({
+          songs: updateSong(state.songs, songId, (song) => ({
+            ...song,
+            applicants: updateBucket(song.applicants, sessionId, (list) =>
+              list.filter((u) => u !== userId),
+            ),
+            // 지원 철회 시 확정 상태도 함께 정리.
+            confirmed: updateBucket(song.confirmed, sessionId, (list) =>
+              list.filter((u) => u !== userId),
+            ),
+          })),
+        })),
+
+      confirmSession: (songId, sessionId, userId) =>
+        set((state) => ({
+          songs: updateSong(state.songs, songId, (song) => ({
+            ...song,
+            confirmed: updateBucket(song.confirmed, sessionId, (list) =>
+              list.includes(userId) ? list : [...list, userId],
+            ),
+          })),
+        })),
+
+      unconfirmSession: (songId, sessionId, userId) =>
+        set((state) => ({
+          songs: updateSong(state.songs, songId, (song) => ({
+            ...song,
+            confirmed: updateBucket(song.confirmed, sessionId, (list) =>
+              list.filter((u) => u !== userId),
+            ),
+          })),
+        })),
+
+      sendChat: (songId, userId, msg, at) =>
+        set((state) => ({
+          songs: updateSong(state.songs, songId, (song) => ({
+            ...song,
+            chat: [...song.chat, { userId, msg, at: at ?? nowMMDDHHmm() } satisfies ChatMessage],
+          })),
+        })),
+
+      addSong: (meetingId, draft) => {
+        const id = `s_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+        const sessions = draft.sessions ?? DEFAULT_SESSIONS;
+        const empty: Record<string, string[]> = Object.fromEntries(
+          sessions.map((s) => [s.id, [] as string[]]),
+        );
+        const next: Song = {
+          id,
+          meetingId,
+          title: draft.title,
+          artist: draft.artist,
+          album: draft.album,
+          proposerId: draft.proposerId,
+          note: draft.note,
+          sessions,
+          applicants: empty,
+          confirmed: { ...empty },
+          chat: [],
+        };
+        set((state) => ({ songs: [...state.songs, next] }));
+        return id;
+      },
+
+      addCustomSession: (songId, session) =>
+        set((state) => ({
+          songs: updateSong(state.songs, songId, (song) =>
+            song.sessions.some((s) => s.id === session.id)
+              ? song
+              : {
+                  ...song,
+                  sessions: [...song.sessions, { ...session, custom: true }],
+                  applicants: { ...song.applicants, [session.id]: [] },
+                  confirmed: { ...song.confirmed, [session.id]: [] },
+                },
+          ),
+        })),
+
+      addMeeting: (meeting) => {
+        const id = `mt_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+        const today = new Date().toISOString().slice(0, 10);
+        const next: Meeting = { ...meeting, id, createdAt: today, updatedAt: today };
+        set((state) => ({ meetings: [...state.meetings, next], selectedMeetingId: id }));
+        return id;
+      },
+
+      reset: () => set({ ...initial }),
+    }),
+    {
+      name: 'bandage-setlist',
+      storage: createJSONStorage(() =>
+        typeof window === 'undefined' ? noopStorage : window.sessionStorage,
+      ),
+    },
+  ),
+);
+
+/** 회의 ID 로 곡 목록 필터. */
+export const useSongsByMeeting = (meetingId: string | null) =>
+  useSetlistStore((s) => (meetingId ? s.songs.filter((song) => song.meetingId === meetingId) : []));
+
+export const useSelectedMeeting = () =>
+  useSetlistStore((s) => s.meetings.find((m) => m.id === s.selectedMeetingId) ?? null);
+
+export const useSelectedSong = () =>
+  useSetlistStore((s) => s.songs.find((song) => song.id === s.selectedSongId) ?? null);
+
+export const useIsManager = () =>
+  useSetlistStore((s) => {
+    const meeting = s.meetings.find((m) => m.id === s.selectedMeetingId);
+    return meeting ? meeting.managerId === s.currentUserId : false;
+  });

--- a/src/domain/setlist-meeting/types.ts
+++ b/src/domain/setlist-meeting/types.ts
@@ -1,0 +1,63 @@
+/**
+ * 선곡 회의 (Setlist Meeting) — FE-only mock 도메인.
+ * 백엔드 미구현 단계: Zustand persist(sessionStorage)로만 상태 보관.
+ * design/web/setlist_web.jsx 의 데이터 모델과 1:1 대응.
+ */
+
+export type SessionDef = {
+  id: string;
+  label: string;
+  short: string;
+  need: number;
+  /** true 면 곡별 추가 세션(키보드/퍼커션/D2 등). 표/우측 패널에서 `*` 표기. */
+  custom?: boolean;
+};
+
+export type Applicant = {
+  userId: string;
+  appliedAt: string;
+};
+
+export type ChatMessage = {
+  userId: string;
+  /** 'MM-DD HH:mm' 또는 ISO. mock 은 design 원본 표기 유지. */
+  at: string;
+  msg: string;
+};
+
+export type Member = {
+  id: string;
+  name: string;
+  /** 멤버의 주 세션(표시용). 실제 지원/확정과는 무관. */
+  role: string;
+  /** 아바타 색(hex). */
+  avatar: string;
+};
+
+export type Song = {
+  id: string;
+  meetingId: string;
+  title: string;
+  artist: string;
+  album?: string;
+  proposerId: string;
+  note?: string;
+  sessions: SessionDef[];
+  /** sessionId → userId[]. */
+  applicants: Record<string, string[]>;
+  /** sessionId → userId[]. confirmed.length >= need 면 full. */
+  confirmed: Record<string, string[]>;
+  chat: ChatMessage[];
+};
+
+export type Meeting = {
+  id: string;
+  bandId: string;
+  bandName: string;
+  title: string;
+  managerId: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type SessionState = 'full' | 'partial' | 'empty';

--- a/src/domain/setlist-meeting/utils.test.ts
+++ b/src/domain/setlist-meeting/utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { SEED_SONGS } from './mock/seed';
+import type { Song } from './types';
+import { confirmedCount, isReady, missingCount, sessionState, totalNeed } from './utils';
+
+const findSong = (id: string): Song => {
+  const s = SEED_SONGS.find((x) => x.id === id);
+  if (!s) throw new Error(`seed song ${id} not found`);
+  return s;
+};
+
+describe('sessionState', () => {
+  it('returns full when confirmed >= need', () => {
+    expect(sessionState(['u1'], 1)).toBe('full');
+    expect(sessionState(['u1', 'u2'], 1)).toBe('full');
+  });
+  it('returns partial when 0 < confirmed < need', () => {
+    expect(sessionState(['u1'], 2)).toBe('partial');
+  });
+  it('returns empty when none confirmed', () => {
+    expect(sessionState([], 1)).toBe('empty');
+    expect(sessionState(undefined, 1)).toBe('empty');
+  });
+});
+
+describe('totalNeed / confirmedCount / missingCount / isReady', () => {
+  it('Jambi (s2): 4 sessions, all confirmed → ready', () => {
+    const s = findSong('s2');
+    expect(totalNeed(s)).toBe(4);
+    expect(confirmedCount(s)).toBe(4);
+    expect(missingCount(s)).toBe(0);
+    expect(isReady(s)).toBe(true);
+  });
+
+  it('Vicarious (s1): D 미확정 → not ready', () => {
+    const s = findSong('s1');
+    expect(totalNeed(s)).toBe(4);
+    expect(confirmedCount(s)).toBe(3);
+    expect(missingCount(s)).toBe(1);
+    expect(isReady(s)).toBe(false);
+  });
+
+  it('10,000 Days (s4): custom 세션 포함 → totalNeed 6, PERC 미확정으로 not ready', () => {
+    const s = findSong('s4');
+    expect(totalNeed(s)).toBe(6);
+    expect(confirmedCount(s)).toBe(5);
+    expect(missingCount(s)).toBe(1);
+    expect(isReady(s)).toBe(false);
+  });
+});

--- a/src/domain/setlist-meeting/utils.ts
+++ b/src/domain/setlist-meeting/utils.ts
@@ -1,0 +1,28 @@
+import type { SessionDef, Song, SessionState } from './types';
+
+export function sessionState(confirmed: string[] | undefined, need: number): SessionState {
+  const cnt = confirmed?.length ?? 0;
+  if (cnt >= need) return 'full';
+  if (cnt > 0) return 'partial';
+  return 'empty';
+}
+
+export function totalNeed(song: Song): number {
+  return song.sessions.reduce((acc, s) => acc + s.need, 0);
+}
+
+export function confirmedCount(song: Song): number {
+  return song.sessions.reduce((acc, s) => acc + (song.confirmed[s.id]?.length ?? 0), 0);
+}
+
+export function missingCount(song: Song): number {
+  return Math.max(totalNeed(song) - confirmedCount(song), 0);
+}
+
+export function isReady(song: Song): boolean {
+  return missingCount(song) === 0 && totalNeed(song) > 0;
+}
+
+export function findSession(song: Song, sessionId: string): SessionDef | undefined {
+  return song.sessions.find((s) => s.id === sessionId);
+}


### PR DESCRIPTION
## 작업 내용
선곡 회의 도메인 모듈을 신규 생성. 백엔드 미구현 단계라 Zustand persist(sessionStorage) 기반 mock-first 구현.

## 신규 컴포넌트
- `src/domain/setlist-meeting/types.ts` — Meeting/Song/SessionDef/Applicant/ChatMessage/Member 타입
- `src/domain/setlist-meeting/utils.ts` — sessionState/totalNeed/confirmedCount/missingCount/isReady 헬퍼
- `src/domain/setlist-meeting/mock/seed.ts` — TOOL TRIBUTE 7곡 + 마그마 1회의 + 7명 멤버 (design/web/setlist_web.jsx 이식)
- `src/domain/setlist-meeting/store/setlistStore.ts` — Zustand store
  - state: meetings, songs, members, currentUserId, selectedMeetingId, selectedSongId, focusedSessionId
  - actions: apply/withdraw/confirm/unconfirm Session, sendChat, addSong, addCustomSession, addMeeting, reset
  - selectors: useSongsByMeeting, useSelectedMeeting, useSelectedSong, useIsManager
- 단위 테스트: `utils.test.ts` (10) + `store/setlistStore.test.ts` (5) — 모두 통과

## 검증
- pnpm typecheck — 통과
- pnpm lint — 통과
- pnpm test — 60 passed (12 files)

## 관련 이슈
Closes #125
