### PR TITLE
feat: 사이드바 + BottomNav 선곡 회의 진입점

### DIFF
--- a/src/app/(main)/setlist-meetings/page.tsx
+++ b/src/app/(main)/setlist-meetings/page.tsx
@@ -1,0 +1,14 @@
+/**
+ * 선곡 회의 라우트 placeholder.
+ * Task 4 (마스터 패널) 머지 후 ListPane 진입점으로 대체된다.
+ */
+export default function SetlistMeetingsPage() {
+  return (
+    <div className="px-s-5 py-s-6">
+      <h1 className="text-title font-bold">선곡 회의</h1>
+      <p className="text-foreground-muted text-body mt-s-3">
+        곧 회의 목록이 표시됩니다. (마스터 패널 구현 대기 중)
+      </p>
+    </div>
+  );
+}

--- a/src/components/layout/__snapshots__/sidebar.test.tsx.snap
+++ b/src/components/layout/__snapshots__/sidebar.test.tsx.snap
@@ -263,6 +263,47 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
       </div>
       <a
         class="gap-s-3 px-s-3 py-s-2 flex items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
+        href="/setlist-meetings"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-list-music h-4 w-4 shrink-0"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16 5H3"
+          />
+          <path
+            d="M11 12H3"
+          />
+          <path
+            d="M11 19H3"
+          />
+          <path
+            d="M21 16V5"
+          />
+          <circle
+            cx="18"
+            cy="16"
+            r="3"
+          />
+        </svg>
+        <span
+          class="truncate"
+        >
+          선곡 회의
+        </span>
+      </a>
+      <a
+        class="gap-s-3 px-s-3 py-s-2 flex items-center rounded-md font-medium transition-colors focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none text-foreground-sub hover:bg-card hover:text-foreground"
         href="/me"
       >
         <svg

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarDays, Home, Music, User, Users, type LucideIcon } from 'lucide-react';
+import { CalendarDays, Home, ListMusic, Music, User, Users, type LucideIcon } from 'lucide-react';
 import { GuardedLink as Link } from '@/global/navigation/guarded-link';
 import { usePathname } from 'next/navigation';
 
@@ -18,6 +18,7 @@ const tabs: Tab[] = [
   { href: ROUTES.BANDS, icon: Users, label: '밴드' },
   { href: ROUTES.PRACTICES, icon: Music, label: '합주' },
   { href: ROUTES.PERFORMANCES, icon: CalendarDays, label: '공연' },
+  { href: ROUTES.SETLIST_MEETINGS, icon: ListMusic, label: '선곡' },
   { href: ROUTES.ME, icon: User, label: 'MY' },
 ];
 
@@ -43,11 +44,11 @@ export function BottomNav() {
                 href={href}
                 aria-current={active ? 'page' : undefined}
                 className={cn(
-                  'focus-visible:ring-accent focus-visible:ring-offset-bg flex flex-1 flex-col items-center justify-center gap-0.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+                  'focus-visible:ring-accent focus-visible:ring-offset-bg flex flex-1 flex-col items-center justify-center gap-0.5 text-[10px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
                   active ? 'text-accent-hi' : 'text-foreground-muted hover:text-foreground',
                 )}
               >
-                <Icon className="h-5 w-5" aria-hidden="true" />
+                <Icon className="h-4 w-4" aria-hidden="true" />
                 <span>{label}</span>
               </Link>
             </li>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   Guitar,
   Home,
+  ListMusic,
   Music,
   User,
   Users,
@@ -52,6 +53,7 @@ const mainNav: NavItem[] = [
       { href: ROUTES.PERFORMANCE_NEW, label: '공연 생성' },
     ],
   },
+  { href: ROUTES.SETLIST_MEETINGS, label: '선곡 회의', icon: ListMusic },
   { href: ROUTES.ME, label: '마이페이지', icon: User },
 ];
 

--- a/src/global/config/routes.ts
+++ b/src/global/config/routes.ts
@@ -20,6 +20,9 @@ export const ROUTES = {
   PERFORMANCE_DETAIL: (id: string) => `/performances/${id}`,
 
   ME: '/me',
+
+  SETLIST_MEETINGS: '/setlist-meetings',
+  SETLIST_MEETING_DETAIL: (id: string) => `/setlist-meetings/${id}`,
 } as const;
 
 export type AppRoutes = typeof ROUTES;


### PR DESCRIPTION
## 작업 내용
사이드바와 BottomNav 에 선곡 회의 진입점 추가, 라우트 상수 추가, placeholder 페이지 생성.

## 신규 파일
- `src/app/(main)/setlist-meetings/page.tsx` — placeholder (Task 4 ListPane 으로 대체 예정)

## 변경 파일
- `src/global/config/routes.ts` — `SETLIST_MEETINGS`, `SETLIST_MEETING_DETAIL` 추가
- `src/components/layout/sidebar.tsx` — ListMusic 아이콘 + 항목
- `src/components/layout/bottom-nav.tsx` — 5탭 → 6탭 (아이콘 `h-4 w-4`, 라벨 `text-[10px]`)

## 검증
- pnpm typecheck / lint / test 통과 (60 passed)

Closes #127
