### PR TITLE
feat: 선곡 회의 마스터 패널 + 디테일 라우팅 골격

### DIFF
--- a/src/app/(main)/setlist-meetings/SetlistMeetingsListPane.client.tsx
+++ b/src/app/(main)/setlist-meetings/SetlistMeetingsListPane.client.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useMemo } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { IconTile } from '@/components/ui/icon-tile';
+import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
+import type { Meeting, Song } from '@/domain/setlist-meeting/types';
+import { isReady } from '@/domain/setlist-meeting/utils';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
+import { listItemClasses } from '@/lib/list-item-styles';
+
+const SetlistIcon = DOMAIN_ICONS['setlist-meeting'];
+
+type MeetingSummary = {
+  meeting: Meeting;
+  total: number;
+  ready: number;
+};
+
+function progress({ total, ready }: { total: number; ready: number }): number {
+  if (total === 0) return 0;
+  return Math.round((ready / total) * 100);
+}
+
+function MeetingRow({ summary, active }: { summary: MeetingSummary; active: boolean }) {
+  const { meeting, total, ready } = summary;
+  const pct = progress({ total, ready });
+  return (
+    <li>
+      <Link
+        href={ROUTES.SETLIST_MEETING_DETAIL(meeting.id)}
+        aria-current={active ? 'page' : undefined}
+        data-slot="setlist-meeting-row"
+        className={listItemClasses(
+          active,
+          DOMAIN_LIST_SELECTED_TONES['setlist-meeting'],
+          'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+        )}
+      >
+        <IconTile icon={<SetlistIcon />} size="sm" tone={DOMAIN_TONES['setlist-meeting']} />
+        <div className="min-w-0 flex-1">
+          <div className="text-accent text-micro truncate font-semibold">{meeting.bandName}</div>
+          <div className="text-caption mt-0.5 truncate font-bold">{meeting.title}</div>
+          <div className="mt-s-2 gap-s-2 flex items-center">
+            <div
+              className="bg-card border-border h-1.5 flex-1 overflow-hidden rounded-full border"
+              role="progressbar"
+              aria-valuenow={pct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${meeting.title} 확정률 ${pct}%`}
+            >
+              <div className="bg-accent h-full" style={{ width: `${pct}%` }} />
+            </div>
+            <span className="text-foreground-muted text-micro shrink-0 tabular-nums">
+              {ready}/{total}
+            </span>
+          </div>
+          <div className="text-foreground-muted text-micro mt-0.5">{meeting.updatedAt}</div>
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+export function SetlistMeetingsListPane() {
+  const pathname = usePathname() ?? '';
+  const meetings = useSetlistStore((s) => s.meetings);
+  const songs = useSetlistStore((s) => s.songs);
+  const toast = useToast();
+
+  const summaries = useMemo<MeetingSummary[]>(() => {
+    return meetings.map((meeting) => {
+      const ms = songs.filter((song: Song) => song.meetingId === meeting.id);
+      const total = ms.length;
+      const ready = ms.filter(isReady).length;
+      return { meeting, total, ready };
+    });
+  }, [meetings, songs]);
+
+  return (
+    <aside
+      className="bg-surface border-border hidden shrink-0 flex-col border-r lg:flex"
+      style={{ width: 'var(--list-pane-w)' }}
+      data-slot="setlist-meetings-list-pane"
+      aria-label="선곡 회의 목록"
+    >
+      <div className="border-border px-s-3 py-s-3 flex items-center justify-between border-b">
+        <div className="min-w-0">
+          <h2 className="text-body font-bold">선곡 회의</h2>
+          <p className="text-foreground-muted text-micro mt-0.5">{meetings.length}건 참여</p>
+        </div>
+        <Button
+          size="sm"
+          variant="accent-outline"
+          onClick={() => toast.info('회의 만들기 기능은 곧 제공됩니다.')}
+          aria-label="새 선곡 회의 만들기"
+        >
+          <Plus className="h-4 w-4" /> 회의 만들기
+        </Button>
+      </div>
+      <div className="px-s-2 py-s-2 flex-1 overflow-y-auto">
+        {summaries.length === 0 ? (
+          <p className="text-foreground-muted p-s-3 text-caption">
+            참여 중인 선곡 회의가 없습니다.
+          </p>
+        ) : (
+          <ul className="gap-s-1 flex flex-col">
+            {summaries.map((s) => {
+              const href = ROUTES.SETLIST_MEETING_DETAIL(s.meeting.id);
+              const active = pathname === href || pathname.startsWith(`${href}/`);
+              return <MeetingRow key={s.meeting.id} summary={s} active={active} />;
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/app/(main)/setlist-meetings/[meetingId]/SetlistMeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/SetlistMeetingDetail.client.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
+
+/**
+ * Task 4 단계의 placeholder. 회의 메타만 노출.
+ * Task 5(곡 표) / Task 6(우측 세션 패널) / Task 7(채팅) 머지로 본격 구성됨.
+ */
+export function SetlistMeetingDetail({ meetingId }: { meetingId: string }) {
+  const setSelectedMeeting = useSetlistStore((s) => s.setSelectedMeeting);
+  const meeting = useSetlistStore((s) => s.meetings.find((m) => m.id === meetingId));
+  const songCount = useSetlistStore(
+    (s) => s.songs.filter((song) => song.meetingId === meetingId).length,
+  );
+
+  useEffect(() => {
+    setSelectedMeeting(meetingId);
+  }, [meetingId, setSelectedMeeting]);
+
+  if (!meeting) {
+    return (
+      <div className="px-s-5 py-s-6">
+        <p className="text-foreground-muted text-caption">회의를 찾을 수 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-s-5 py-s-6">
+      <div className="text-accent text-caption font-semibold">{meeting.bandName}</div>
+      <h1 className="text-title mt-s-1 font-bold">{meeting.title}</h1>
+      <p className="text-foreground-muted text-caption mt-s-2">
+        곡 {songCount}개 · 업데이트 {meeting.updatedAt}
+      </p>
+      <p className="text-foreground-muted text-body mt-s-5">
+        곡 표 · 우측 세션 패널 · 채팅 패널은 곧 추가됩니다.
+      </p>
+    </div>
+  );
+}

--- a/src/app/(main)/setlist-meetings/[meetingId]/page.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/page.tsx
@@ -1,0 +1,14 @@
+import { SetlistMeetingDetail } from './SetlistMeetingDetail.client';
+
+/**
+ * /setlist-meetings/{meetingId} 디테일 placeholder.
+ * Task 5~7 에서 곡 표 / 채팅 / 우측 세션 패널이 채워진다.
+ */
+export default async function SetlistMeetingDetailPage({
+  params,
+}: {
+  params: Promise<{ meetingId: string }>;
+}) {
+  const { meetingId } = await params;
+  return <SetlistMeetingDetail meetingId={meetingId} />;
+}

--- a/src/app/(main)/setlist-meetings/layout.tsx
+++ b/src/app/(main)/setlist-meetings/layout.tsx
@@ -1,0 +1,19 @@
+import { Suspense, type ReactNode } from 'react';
+
+import { SetlistMeetingsListPane } from './SetlistMeetingsListPane.client';
+
+/**
+ * /setlist-meetings 영역 마스터-디테일 레이아웃.
+ * - lg(>=960px): 좌측 ListPane(280px) + 우측 children
+ * - 모바일: ListPane 비노출 (BottomNav 로 회의 목록 ↔ 디테일 전환은 후속 PR 에서)
+ */
+export default function SetlistMeetingsLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full flex-col lg:flex-row">
+      <Suspense fallback={null}>
+        <SetlistMeetingsListPane />
+      </Suspense>
+      <div className="min-w-0 flex-1 lg:overflow-y-auto">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(main)/setlist-meetings/page.tsx
+++ b/src/app/(main)/setlist-meetings/page.tsx
@@ -1,14 +1,14 @@
+import { redirect } from 'next/navigation';
+
+import { SEED_MEETINGS } from '@/domain/setlist-meeting/mock/seed';
+import { ROUTES } from '@/global/config/routes';
+
 /**
- * 선곡 회의 라우트 placeholder.
- * Task 4 (마스터 패널) 머지 후 ListPane 진입점으로 대체된다.
+ * /setlist-meetings 진입 시 첫 번째 mock 회의로 자동 redirect.
+ * 빈 상태 UX 는 layout 의 children empty fallback 에서 처리.
  */
 export default function SetlistMeetingsPage() {
-  return (
-    <div className="px-s-5 py-s-6">
-      <h1 className="text-title font-bold">선곡 회의</h1>
-      <p className="text-foreground-muted text-body mt-s-3">
-        곧 회의 목록이 표시됩니다. (마스터 패널 구현 대기 중)
-      </p>
-    </div>
-  );
+  const first = SEED_MEETINGS[0];
+  if (first) redirect(ROUTES.SETLIST_MEETING_DETAIL(first.id));
+  return null;
 }

--- a/src/lib/domain-icons.tsx
+++ b/src/lib/domain-icons.tsx
@@ -1,20 +1,22 @@
-import { Clock3, Guitar, Music2, type LucideIcon } from 'lucide-react';
+import { Clock3, Guitar, ListMusic, Music2, type LucideIcon } from 'lucide-react';
 
 import type { IconTileTone } from '@/components/ui/icon-tile';
 import type { ListItemSelectedTone } from '@/lib/list-item-styles';
 
-export type DomainType = 'band' | 'practice' | 'performance';
+export type DomainType = 'band' | 'practice' | 'performance' | 'setlist-meeting';
 
 export const DOMAIN_ICONS: Record<DomainType, LucideIcon> = {
   band: Guitar,
   practice: Clock3,
   performance: Music2,
+  'setlist-meeting': ListMusic,
 };
 
 export const DOMAIN_TONES: Record<DomainType, IconTileTone> = {
   band: 'accent',
   practice: 'success',
   performance: 'amber',
+  'setlist-meeting': 'accent',
 };
 
 /** 리스트 선택 상태 톤은 design/dist/css/screens.css 기준으로 accent / amber 두 가지만 사용. */
@@ -22,4 +24,5 @@ export const DOMAIN_LIST_SELECTED_TONES: Record<DomainType, ListItemSelectedTone
   band: 'accent',
   practice: 'accent',
   performance: 'amber',
+  'setlist-meeting': 'accent',
 };


### PR DESCRIPTION
## 작업 내용
선곡 회의 마스터-디테일 라우트 + 회의 목록 마스터 패널 + 디테일 placeholder.

## 신규 파일
- `src/app/(main)/setlist-meetings/layout.tsx`
- `src/app/(main)/setlist-meetings/SetlistMeetingsListPane.client.tsx`
- `src/app/(main)/setlist-meetings/[meetingId]/page.tsx`
- `src/app/(main)/setlist-meetings/[meetingId]/SetlistMeetingDetail.client.tsx` (placeholder)

## 변경 파일
- `src/app/(main)/setlist-meetings/page.tsx` — placeholder → 첫 회의 redirect
- `src/lib/domain-icons.tsx` — `setlist-meeting` 도메인 추가

## 동작
- /setlist-meetings → 첫 mock 회의 (`mt1`) 로 redirect
- 마스터 패널: 회의 2건 카드 (TOOL TRIBUTE, 마그마) + 진행률 막대(ready/total)
- 카드 클릭 → /setlist-meetings/{id}
- '회의 만들기' 버튼 → toast.info ("곧 제공됩니다")
- 디테일은 곡 표/채팅/세션 패널 자리만 잡고 후속 PR 에서 채움

## 검증
- pnpm typecheck / lint / test 통과 (60 passed)

Closes #129
