### PR TITLE
feat: 선곡 회의 우측 세션 패널 (지원/확정/해제)

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { SessionPanel } from '@/domain/setlist-meeting/components/SessionPanel.client';
 import { SongTable } from '@/domain/setlist-meeting/components/SongTable.client';
 import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
 import type { Song } from '@/domain/setlist-meeting/types';
@@ -79,71 +80,74 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
   }
 
   return (
-    <div className="flex h-full flex-col">
-      <header className="border-border px-s-5 py-s-4 border-b">
-        <div className="gap-s-3 flex items-start justify-between">
-          <div className="min-w-0">
-            <div className="text-accent text-caption font-semibold">{meeting.bandName}</div>
-            <h1 className="text-title-lg mt-s-1 font-bold">{meeting.title}</h1>
-            <div className="text-foreground-muted text-caption gap-s-3 mt-s-2 flex flex-wrap items-center">
-              <span>
-                전체 <strong className="text-foreground">{stats.total}</strong>곡
-              </span>
-              <span className="text-success">
-                합주 가능 <strong>{stats.ready}</strong>
-              </span>
-              <span className="text-warn">
-                모집 중 <strong>{stats.pending}</strong>
-              </span>
+    <div className="flex h-full">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="border-border px-s-5 py-s-4 border-b">
+          <div className="gap-s-3 flex items-start justify-between">
+            <div className="min-w-0">
+              <div className="text-accent text-caption font-semibold">{meeting.bandName}</div>
+              <h1 className="text-title-lg mt-s-1 font-bold">{meeting.title}</h1>
+              <div className="text-foreground-muted text-caption gap-s-3 mt-s-2 flex flex-wrap items-center">
+                <span>
+                  전체 <strong className="text-foreground">{stats.total}</strong>곡
+                </span>
+                <span className="text-success">
+                  합주 가능 <strong>{stats.ready}</strong>
+                </span>
+                <span className="text-warn">
+                  모집 중 <strong>{stats.pending}</strong>
+                </span>
+              </div>
+            </div>
+            <Button
+              size="sm"
+              variant="accent-outline"
+              onClick={() => toast.info('곡 추가 모달은 곧 제공됩니다.')}
+              aria-label="새 곡 추가"
+            >
+              <Plus className="h-4 w-4" /> 곡 추가
+            </Button>
+          </div>
+
+          <div className="gap-s-3 mt-s-4 flex flex-col items-stretch md:flex-row md:items-center md:justify-between">
+            <Tabs value={filter} onValueChange={(v) => setFilter(v as Filter)}>
+              <TabsList>
+                <TabsTrigger value="all">전체</TabsTrigger>
+                <TabsTrigger value="ready">합주 가능</TabsTrigger>
+                <TabsTrigger value="pending">모집 중</TabsTrigger>
+                <TabsTrigger value="mine">내 지원</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 flex items-center rounded-md border md:w-72">
+              <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="곡명 · 아티스트 · 앨범 검색"
+                aria-label="곡 검색"
+                className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+              />
             </div>
           </div>
-          <Button
-            size="sm"
-            variant="accent-outline"
-            onClick={() => toast.info('곡 추가 모달은 곧 제공됩니다.')}
-            aria-label="새 곡 추가"
-          >
-            <Plus className="h-4 w-4" /> 곡 추가
-          </Button>
-        </div>
+        </header>
 
-        <div className="gap-s-3 mt-s-4 flex flex-col items-stretch md:flex-row md:items-center md:justify-between">
-          <Tabs value={filter} onValueChange={(v) => setFilter(v as Filter)}>
-            <TabsList>
-              <TabsTrigger value="all">전체</TabsTrigger>
-              <TabsTrigger value="ready">합주 가능</TabsTrigger>
-              <TabsTrigger value="pending">모집 중</TabsTrigger>
-              <TabsTrigger value="mine">내 지원</TabsTrigger>
-            </TabsList>
-          </Tabs>
-          <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 flex items-center rounded-md border md:w-72">
-            <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
-            <input
-              type="search"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="곡명 · 아티스트 · 앨범 검색"
-              aria-label="곡 검색"
-              className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
-            />
-          </div>
+        <div className="flex-1 overflow-y-auto">
+          <SongTable
+            songs={visible}
+            members={members}
+            selectedSongId={selectedSongId}
+            focusedSessionId={focusedSessionId}
+            currentUserId={currentUserId}
+            onSelectSong={(id) => setSelectedSong(id)}
+            onFocusSession={(songId, sessionId) => {
+              setSelectedSong(songId);
+              setFocusedSession(sessionId);
+            }}
+          />
         </div>
-      </header>
-
-      <div className="flex-1 overflow-y-auto">
-        <SongTable
-          songs={visible}
-          members={members}
-          selectedSongId={selectedSongId}
-          focusedSessionId={focusedSessionId}
-          currentUserId={currentUserId}
-          onSelectSong={(id) => setSelectedSong(id)}
-          onFocusSession={(songId, sessionId) => {
-            setSelectedSong(songId);
-            setFocusedSession(sessionId);
-          }}
-        />
       </div>
+      {selectedSongId && <SessionPanel songId={selectedSongId} />}
     </div>
   );
 }

--- a/src/domain/setlist-meeting/components/MemberAvatar.tsx
+++ b/src/domain/setlist-meeting/components/MemberAvatar.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/cn';
+
+import type { Member } from '../types';
+
+export interface MemberAvatarProps {
+  member: Member | undefined;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+const sizeClasses: Record<'sm' | 'md', string> = {
+  sm: 'h-7 w-7 text-[11px]',
+  md: 'h-8 w-8 text-xs',
+};
+
+/**
+ * 시드 mock 의 hex avatar 색을 반영한 원형 아바타.
+ * 실제 사용자 아바타 도입 시 `Avatar` 로 일괄 치환 예정.
+ */
+export function MemberAvatar({ member, size = 'md', className }: MemberAvatarProps) {
+  const initial = (member?.name?.[0] ?? '?').toUpperCase();
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'inline-flex shrink-0 items-center justify-center rounded-full font-bold text-white select-none',
+        sizeClasses[size],
+        className,
+      )}
+      style={{ background: member?.avatar ?? 'var(--color-accent)' }}
+    >
+      {initial}
+    </span>
+  );
+}

--- a/src/domain/setlist-meeting/components/SessionPanel.client.tsx
+++ b/src/domain/setlist-meeting/components/SessionPanel.client.tsx
@@ -1,0 +1,380 @@
+'use client';
+
+import { ArrowLeft, ChevronRight, Crown, X } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/cn';
+
+import { useSetlistStore } from '../store/setlistStore';
+import type { Member, SessionDef, Song } from '../types';
+import { findSession, missingCount, sessionState } from '../utils';
+import { useToast } from '@/hooks/useToast';
+
+import { MemberAvatar } from './MemberAvatar';
+
+export interface SessionPanelProps {
+  songId: string;
+  /** 모바일에서 닫기 버튼 노출용. 데스크톱은 항상 노출. */
+  onClose?: () => void;
+}
+
+export function SessionPanel({ songId, onClose }: SessionPanelProps) {
+  const song = useSetlistStore((s) => s.songs.find((x) => x.id === songId));
+  const meeting = useSetlistStore((s) =>
+    song ? s.meetings.find((m) => m.id === song.meetingId) : null,
+  );
+  const members = useSetlistStore((s) => s.members);
+  const currentUserId = useSetlistStore((s) => s.currentUserId);
+  const focusedSessionId = useSetlistStore((s) => s.focusedSessionId);
+  const setFocusedSession = useSetlistStore((s) => s.setFocusedSession);
+  const applySession = useSetlistStore((s) => s.applySession);
+  const withdrawSession = useSetlistStore((s) => s.withdrawSession);
+  const confirmSession = useSetlistStore((s) => s.confirmSession);
+  const unconfirmSession = useSetlistStore((s) => s.unconfirmSession);
+  const toast = useToast();
+
+  const isManager = meeting ? meeting.managerId === currentUserId : false;
+  const focused = song && focusedSessionId ? findSession(song, focusedSessionId) : undefined;
+
+  if (!song) {
+    return null;
+  }
+
+  return (
+    <aside
+      data-slot="session-panel"
+      className="bg-surface border-border hidden flex-col overflow-hidden border-l xl:flex"
+      style={{ width: 380 }}
+      aria-label="세션 지원 패널"
+    >
+      <header className="border-border px-s-5 py-s-4 gap-s-3 flex items-start justify-between border-b">
+        <div className="min-w-0 flex-1">
+          <div className="text-foreground-muted text-micro gap-s-2 flex items-center font-bold tracking-wider uppercase">
+            <span>{focused ? `${focused.label} 세션` : '세션 지원'}</span>
+            {isManager && (
+              <span className="text-amber gap-s-1 inline-flex items-center font-semibold">
+                <Crown className="h-3 w-3" /> 매니저
+              </span>
+            )}
+          </div>
+          <div className="text-subtitle mt-s-1 truncate font-bold">{song.title}</div>
+          <div className="text-foreground-sub text-caption mt-0.5">{song.artist}</div>
+        </div>
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-foreground-muted hover:text-foreground rounded-md p-1"
+            aria-label="패널 닫기"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </header>
+
+      <div className="flex-1 overflow-y-auto">
+        {focused ? (
+          <FocusedSessionView
+            song={song}
+            session={focused}
+            members={members}
+            currentUserId={currentUserId}
+            isManager={isManager}
+            onBack={() => setFocusedSession(null)}
+            onApply={() => {
+              applySession(song.id, focused.id, currentUserId);
+              toast.success('세션에 지원했습니다.');
+            }}
+            onWithdraw={() => {
+              withdrawSession(song.id, focused.id, currentUserId);
+              toast.info('지원을 취소했습니다.');
+            }}
+            onConfirm={(uid) => {
+              confirmSession(song.id, focused.id, uid);
+              toast.success('세션이 확정되었습니다.');
+            }}
+            onUnconfirm={(uid) => {
+              unconfirmSession(song.id, focused.id, uid);
+              toast.info('확정이 해제되었습니다.');
+            }}
+          />
+        ) : (
+          <OverviewSessionView
+            song={song}
+            members={members}
+            onFocus={(sid) => setFocusedSession(sid)}
+            currentUserId={currentUserId}
+          />
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function OverviewSessionView({
+  song,
+  members,
+  onFocus,
+  currentUserId,
+}: {
+  song: Song;
+  members: Member[];
+  onFocus: (sessionId: string) => void;
+  currentUserId: string;
+}) {
+  const proposer = members.find((m) => m.id === song.proposerId);
+  const missing = missingCount(song);
+
+  return (
+    <div className="px-s-5 py-s-4">
+      {song.note && (
+        <div className="bg-accent-dim border-accent/25 px-s-4 py-s-3 mb-s-4 rounded-lg border">
+          <div className="text-accent text-micro font-bold">
+            추천자 의견 · {proposer?.name ?? '?'}
+          </div>
+          <p className="text-foreground text-caption mt-s-1 leading-relaxed">{song.note}</p>
+        </div>
+      )}
+
+      <div className="text-foreground-muted text-micro mb-s-3 font-bold tracking-wider uppercase">
+        세션 구성 · {missing === 0 ? '모두 확정됨' : `${missing}자리 미확정`}
+      </div>
+
+      <ul className="gap-s-2 flex flex-col">
+        {song.sessions.map((s) => {
+          const apps = song.applicants[s.id] ?? [];
+          const conf = song.confirmed[s.id] ?? [];
+          const state = sessionState(conf, s.need);
+          const isMine = apps.includes(currentUserId);
+          const isMineConfirmed = conf.includes(currentUserId);
+          const tone =
+            state === 'full'
+              ? 'border-success/30 bg-success-dim/40'
+              : state === 'partial'
+                ? 'border-warn/30 bg-warn-dim/40'
+                : 'border-border bg-card';
+          return (
+            <li key={s.id}>
+              <button
+                type="button"
+                onClick={() => onFocus(s.id)}
+                className={cn(
+                  'gap-s-3 px-s-3 py-s-3 hover:border-border-hi flex w-full items-center rounded-lg border transition-colors',
+                  tone,
+                )}
+              >
+                <span
+                  className={cn(
+                    'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border font-mono text-[11px] font-extrabold',
+                    state === 'full'
+                      ? 'border-success/40 text-success'
+                      : state === 'partial'
+                        ? 'border-warn/40 text-warn'
+                        : 'border-border text-foreground-muted',
+                  )}
+                >
+                  {s.short}
+                  {s.custom && <span className="text-amber ml-0.5">*</span>}
+                </span>
+                <div className="min-w-0 flex-1 text-left">
+                  <div className="text-caption gap-s-2 flex items-center font-bold">
+                    {s.label}
+                    {s.custom && <span className="text-amber text-micro font-bold">커스텀</span>}
+                  </div>
+                  <div className="text-foreground-muted text-micro gap-s-2 mt-0.5 flex items-center">
+                    <span
+                      className={cn(
+                        'font-mono font-bold',
+                        state === 'full'
+                          ? 'text-success'
+                          : state === 'partial'
+                            ? 'text-warn'
+                            : 'text-foreground-muted',
+                      )}
+                    >
+                      확정 {conf.length}/{s.need}
+                    </span>
+                    <span>·</span>
+                    <span>지원 {apps.length}명</span>
+                    {isMineConfirmed && (
+                      <span className="text-accent font-bold">· 내가 확정됨</span>
+                    )}
+                    {!isMineConfirmed && isMine && (
+                      <span className="text-accent font-bold">· 내가 지원함</span>
+                    )}
+                  </div>
+                </div>
+                <ChevronRight className="text-foreground-muted h-4 w-4 shrink-0" />
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function FocusedSessionView({
+  song,
+  session,
+  members,
+  currentUserId,
+  isManager,
+  onBack,
+  onApply,
+  onWithdraw,
+  onConfirm,
+  onUnconfirm,
+}: {
+  song: Song;
+  session: SessionDef;
+  members: Member[];
+  currentUserId: string;
+  isManager: boolean;
+  onBack: () => void;
+  onApply: () => void;
+  onWithdraw: () => void;
+  onConfirm: (userId: string) => void;
+  onUnconfirm: (userId: string) => void;
+}) {
+  const apps = useMemo(() => song.applicants[session.id] ?? [], [song.applicants, session.id]);
+  const conf = useMemo(() => song.confirmed[session.id] ?? [], [song.confirmed, session.id]);
+  const isMineApplied = apps.includes(currentUserId);
+  const isMineConfirmed = conf.includes(currentUserId);
+  const isFull = conf.length >= session.need;
+
+  // 확정된 사람을 위로 정렬.
+  const sortedApps = useMemo(() => {
+    return [...apps].sort((a, b) => {
+      const ac = conf.includes(a);
+      const bc = conf.includes(b);
+      if (ac && !bc) return -1;
+      if (!ac && bc) return 1;
+      return 0;
+    });
+  }, [apps, conf]);
+
+  return (
+    <div className="px-s-5 py-s-4">
+      <button
+        type="button"
+        onClick={onBack}
+        className="text-foreground-sub gap-s-1 mb-s-4 text-caption hover:text-foreground inline-flex items-center font-semibold"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" /> 모든 세션
+      </button>
+
+      <div className="bg-card border-border px-s-4 py-s-3 mb-s-4 rounded-lg border">
+        <div className="mb-s-2 flex items-center justify-between">
+          <div className="text-subtitle gap-s-2 flex items-center font-extrabold">
+            {session.label}
+            {session.custom && <span className="text-amber text-micro font-bold">커스텀</span>}
+          </div>
+          <span
+            className={cn(
+              'px-s-3 text-micro rounded-full py-0.5 font-mono font-bold',
+              isFull ? 'bg-success-dim text-success' : 'bg-warn-dim text-warn',
+            )}
+          >
+            {conf.length}/{session.need} {isFull ? '확정 완료' : '확정 대기'}
+          </span>
+        </div>
+        <div className="text-foreground-sub text-caption gap-s-2 flex items-center">
+          <span>
+            지원자 <strong className="text-foreground">{apps.length}명</strong>
+          </span>
+          <span className="text-foreground-muted">·</span>
+          <span>
+            필요 <strong className="text-foreground">{session.need}명</strong>
+          </span>
+        </div>
+      </div>
+
+      <div className="mb-s-3 flex items-center justify-between">
+        <span className="text-foreground-muted text-micro font-bold tracking-wider uppercase">
+          지원자 ({apps.length})
+        </span>
+        {isManager && apps.length > 0 && (
+          <span className="bg-amber-dim text-amber text-micro px-s-2 rounded-md py-0.5 font-bold">
+            매니저: 확정 가능
+          </span>
+        )}
+      </div>
+
+      {apps.length === 0 ? (
+        <div className="bg-card border-border text-foreground-muted px-s-4 py-s-6 text-caption rounded-lg border border-dashed text-center">
+          아직 지원자가 없습니다.
+        </div>
+      ) : (
+        <ul className="gap-s-2 flex flex-col">
+          {sortedApps.map((uid) => {
+            const m = members.find((mm) => mm.id === uid);
+            const userConfirmed = conf.includes(uid);
+            return (
+              <li
+                key={uid}
+                className={cn(
+                  'gap-s-3 px-s-3 py-s-2 flex items-center rounded-lg border',
+                  userConfirmed ? 'border-success/40 bg-success-dim/20' : 'border-border bg-card',
+                )}
+              >
+                <MemberAvatar member={m} />
+                <div className="min-w-0 flex-1">
+                  <div className="text-caption gap-s-2 flex items-center font-semibold">
+                    <span className="truncate">{m?.name ?? '?'}</span>
+                    {uid === currentUserId && (
+                      <span className="text-accent text-micro font-bold">나</span>
+                    )}
+                    {m?.role && (
+                      <span className="text-foreground-muted text-micro">· {m.role}</span>
+                    )}
+                  </div>
+                  <div
+                    className={cn(
+                      'text-micro mt-0.5 font-semibold',
+                      userConfirmed ? 'text-success' : 'text-foreground-muted',
+                    )}
+                  >
+                    {userConfirmed ? '확정됨' : '지원 완료'}
+                  </div>
+                </div>
+                {isManager &&
+                  (userConfirmed ? (
+                    <Button size="sm" variant="ghost" onClick={() => onUnconfirm(uid)}>
+                      해제
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="primary"
+                      disabled={isFull}
+                      onClick={() => onConfirm(uid)}
+                    >
+                      확정
+                    </Button>
+                  ))}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="border-border mt-s-5 pt-s-4 border-t">
+        {isMineConfirmed ? (
+          <div className="text-foreground-muted text-caption text-center">
+            확정된 세션은 본인이 직접 취소할 수 없습니다. 매니저에게 문의해 주세요.
+          </div>
+        ) : isMineApplied ? (
+          <Button variant="ghost" className="w-full" onClick={onWithdraw}>
+            지원 취소
+          </Button>
+        ) : (
+          <Button variant="primary" className="w-full" onClick={onApply} disabled={isFull}>
+            {isFull ? '확정 완료된 세션입니다' : '이 세션 지원하기'}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용
선곡 회의 디테일 우측에 세션 지원/확정 패널 추가. 매니저는 확정/해제, 일반 멤버는 지원/취소.

## 신규 컴포넌트
- `src/domain/setlist-meeting/components/SessionPanel.client.tsx` — overview / focused 두 모드
- `src/domain/setlist-meeting/components/MemberAvatar.tsx`

## 변경
- `MeetingDetail.client.tsx` — SessionPanel 통합 (xl 이상 380px 고정)

## 동작
- 곡 행 선택 → 우측 패널에 곡 헤더 + 세션 카드 그리드
- 세션 카드 클릭 → 단일 세션 focused 뷰 (지원자 리스트, 확정 칩, 액션 버튼)
- 본인 미지원 → '이 세션 지원하기' / 지원 + 미확정 → '지원 취소' / 확정 → 매니저 문의 안내
- 매니저: 각 지원자 행에 [확정]/[해제] 버튼 + toast.success
- 확정 정원 도달 시 신규 지원/확정 비활성

## 검증
- pnpm typecheck / lint / test 통과 (60 passed)

Closes #133
