### PR TITLE
feat: 선곡 회의 곡별 채팅 분할 패널

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { MeetingChatBox } from '@/domain/setlist-meeting/components/MeetingChatBox.client';
 import { SessionPanel } from '@/domain/setlist-meeting/components/SessionPanel.client';
 import { SongTable } from '@/domain/setlist-meeting/components/SongTable.client';
 import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
@@ -146,6 +147,7 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
             }}
           />
         </div>
+        {selectedSongId && <MeetingChatBox songId={selectedSongId} />}
       </div>
       {selectedSongId && <SessionPanel songId={selectedSongId} />}
     </div>

--- a/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
+++ b/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { MessageSquare, Send } from 'lucide-react';
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { useSetlistStore } from '../store/setlistStore';
+
+import { MemberAvatar } from './MemberAvatar';
+
+export interface MeetingChatBoxProps {
+  songId: string;
+}
+
+export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
+  const song = useSetlistStore((s) => s.songs.find((x) => x.id === songId));
+  const members = useSetlistStore((s) => s.members);
+  const currentUserId = useSetlistStore((s) => s.currentUserId);
+  const sendChat = useSetlistStore((s) => s.sendChat);
+
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const [draft, setDraft] = useState('');
+
+  // 새 메시지 추가 시 자동 스크롤.
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [song?.chat.length]);
+
+  if (!song) return null;
+
+  const submit = () => {
+    const text = draft.trim();
+    if (!text) return;
+    sendChat(song.id, currentUserId, text);
+    setDraft('');
+  };
+
+  const onKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <section
+      data-slot="meeting-chat-box"
+      className="bg-surface border-border hidden h-[280px] flex-col border-t lg:flex"
+      aria-label={`${song.title} 의견 채팅`}
+    >
+      <header className="border-border px-s-5 py-s-2 gap-s-2 flex items-center border-b">
+        <MessageSquare className="text-foreground-muted h-4 w-4" />
+        <span className="text-caption font-bold">{song.title}</span>
+        <span className="text-foreground-muted text-micro">의견 {song.chat.length}개</span>
+      </header>
+
+      <div ref={listRef} className="px-s-5 py-s-3 flex-1 overflow-y-auto">
+        {song.chat.length === 0 ? (
+          <div className="text-foreground-muted py-s-6 text-caption text-center">
+            첫 의견을 남겨주세요.
+          </div>
+        ) : (
+          <ul className="gap-s-3 flex flex-col">
+            {song.chat.map((msg, idx) => {
+              const m = members.find((mm) => mm.id === msg.userId);
+              const mine = msg.userId === currentUserId;
+              return (
+                <li
+                  key={`${msg.userId}-${msg.at}-${idx}`}
+                  className={cn('gap-s-2 flex items-start', mine && 'flex-row-reverse')}
+                >
+                  <MemberAvatar member={m} size="sm" />
+                  <div className={cn('max-w-[70%]', mine && 'text-right')}>
+                    <div
+                      className={cn(
+                        'gap-s-2 text-micro flex items-center',
+                        mine && 'flex-row-reverse',
+                      )}
+                    >
+                      <span className="text-foreground-sub font-semibold">
+                        {m?.name ?? '?'}
+                        {mine && <span className="text-accent ml-s-1">나</span>}
+                      </span>
+                      <span className="text-foreground-muted">{msg.at}</span>
+                    </div>
+                    <div
+                      className={cn(
+                        'text-caption mt-s-1 px-s-3 py-s-2 inline-block rounded-lg text-left whitespace-pre-wrap',
+                        mine
+                          ? 'bg-accent-dim text-foreground'
+                          : 'bg-card text-foreground border-border border',
+                      )}
+                    >
+                      {msg.msg}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="border-border px-s-4 py-s-3 gap-s-2 flex items-end border-t">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKey}
+          rows={1}
+          placeholder="의견을 남겨보세요. Enter 전송, Shift+Enter 줄바꿈."
+          className="bg-card border-border text-caption placeholder:text-foreground-muted px-s-3 py-s-2 max-h-24 min-h-[36px] flex-1 resize-none rounded-md border outline-none"
+          aria-label="채팅 입력"
+        />
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!draft.trim()}
+          className="bg-accent text-foreground gap-s-1 px-s-3 py-s-2 text-caption inline-flex shrink-0 items-center rounded-md font-semibold disabled:opacity-40"
+          aria-label="메시지 전송"
+        >
+          <Send className="h-3.5 w-3.5" />
+          전송
+        </button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 작업 내용
선곡 회의 디테일에서 곡을 선택했을 때 곡 표 아래 280px 채팅 박스를 노출. Zustand `sendChat` 으로 메시지 추가.

## 신규 컴포넌트
- `src/domain/setlist-meeting/components/MeetingChatBox.client.tsx`

## 변경
- `MeetingDetail.client.tsx` — 곡 선택 시 SongTable 아래 MeetingChatBox 렌더

## 동작
- 본인 메시지: 우측 정렬 + accent-dim 버블, 타인: 좌측 + card 배경
- Enter 전송 / Shift+Enter 줄바꿈
- 새 메시지 추가 시 자동 스크롤
- lg 이상에서만 노출 (모바일은 비노출 — v5 범위)

## 검증
- pnpm typecheck / lint / test 통과 (60 passed)

Closes #135
