### PR TITLE
feat: 선곡 회의 만들기 / 곡 추가 모달 + 매니저 가드

### DIFF
--- a/src/app/(main)/setlist-meetings/SetlistMeetingsListPane.client.tsx
+++ b/src/app/(main)/setlist-meetings/SetlistMeetingsListPane.client.tsx
@@ -7,11 +7,11 @@ import { useMemo } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
+import { MeetingCreateModal } from '@/domain/setlist-meeting/components/MeetingCreateModal.client';
 import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
 import type { Meeting, Song } from '@/domain/setlist-meeting/types';
 import { isReady } from '@/domain/setlist-meeting/utils';
 import { ROUTES } from '@/global/config/routes';
-import { useToast } from '@/hooks/useToast';
 import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
 import { listItemClasses } from '@/lib/list-item-styles';
 
@@ -73,7 +73,6 @@ export function SetlistMeetingsListPane() {
   const pathname = usePathname() ?? '';
   const meetings = useSetlistStore((s) => s.meetings);
   const songs = useSetlistStore((s) => s.songs);
-  const toast = useToast();
 
   const summaries = useMemo<MeetingSummary[]>(() => {
     return meetings.map((meeting) => {
@@ -96,14 +95,13 @@ export function SetlistMeetingsListPane() {
           <h2 className="text-body font-bold">선곡 회의</h2>
           <p className="text-foreground-muted text-micro mt-0.5">{meetings.length}건 참여</p>
         </div>
-        <Button
-          size="sm"
-          variant="accent-outline"
-          onClick={() => toast.info('회의 만들기 기능은 곧 제공됩니다.')}
-          aria-label="새 선곡 회의 만들기"
-        >
-          <Plus className="h-4 w-4" /> 회의 만들기
-        </Button>
+        <MeetingCreateModal
+          trigger={
+            <Button size="sm" variant="accent-outline" aria-label="새 선곡 회의 만들기">
+              <Plus className="h-4 w-4" /> 회의 만들기
+            </Button>
+          }
+        />
       </div>
       <div className="px-s-2 py-s-2 flex-1 overflow-y-auto">
         {summaries.length === 0 ? (

--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -5,13 +5,13 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AddSongModal } from '@/domain/setlist-meeting/components/AddSongModal.client';
 import { MeetingChatBox } from '@/domain/setlist-meeting/components/MeetingChatBox.client';
 import { SessionPanel } from '@/domain/setlist-meeting/components/SessionPanel.client';
 import { SongTable } from '@/domain/setlist-meeting/components/SongTable.client';
 import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
 import type { Song } from '@/domain/setlist-meeting/types';
 import { isReady } from '@/domain/setlist-meeting/utils';
-import { useToast } from '@/hooks/useToast';
 
 type Filter = 'all' | 'ready' | 'pending' | 'mine';
 
@@ -52,7 +52,8 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
   const setSelectedMeeting = useSetlistStore((s) => s.setSelectedMeeting);
   const setSelectedSong = useSetlistStore((s) => s.setSelectedSong);
   const setFocusedSession = useSetlistStore((s) => s.setFocusedSession);
-  const toast = useToast();
+
+  const isManager = meeting ? meeting.managerId === currentUserId : false;
 
   const [filter, setFilter] = useState<Filter>('all');
   const [query, setQuery] = useState('');
@@ -100,14 +101,16 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
                 </span>
               </div>
             </div>
-            <Button
-              size="sm"
-              variant="accent-outline"
-              onClick={() => toast.info('곡 추가 모달은 곧 제공됩니다.')}
-              aria-label="새 곡 추가"
-            >
-              <Plus className="h-4 w-4" /> 곡 추가
-            </Button>
+            {isManager && (
+              <AddSongModal
+                meetingId={meetingId}
+                trigger={
+                  <Button size="sm" variant="accent-outline" aria-label="새 곡 추가">
+                    <Plus className="h-4 w-4" /> 곡 추가
+                  </Button>
+                }
+              />
+            )}
           </div>
 
           <div className="gap-s-3 mt-s-4 flex flex-col items-stretch md:flex-row md:items-center md:justify-between">

--- a/src/domain/setlist-meeting/components/AddSongModal.client.tsx
+++ b/src/domain/setlist-meeting/components/AddSongModal.client.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Plus, X } from 'lucide-react';
+import { useState, type ReactNode } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetClose,
+  ResponsiveSheetContent,
+  ResponsiveSheetFooter,
+  ResponsiveSheetHeader,
+  ResponsiveSheetTitle,
+  ResponsiveSheetTrigger,
+} from '@/components/ui/responsive-sheet';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/useToast';
+
+import { DEFAULT_SESSIONS } from '../mock/seed';
+import { useSetlistStore } from '../store/setlistStore';
+import type { SessionDef } from '../types';
+import { addSongSchema, type AddSongSchema } from '../types/schema';
+
+export interface AddSongModalProps {
+  meetingId: string;
+  trigger: ReactNode;
+}
+
+function makeSessionId(label: string, existing: SessionDef[]): string {
+  const base = label
+    .replace(/[^A-Za-z0-9가-힣]/g, '')
+    .slice(0, 4)
+    .toUpperCase();
+  let id = base || `S${existing.length + 1}`;
+  let n = 1;
+  while (existing.some((s) => s.id === id)) {
+    id = `${base}${n++}`;
+  }
+  return id;
+}
+
+export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
+  const [open, setOpen] = useState(false);
+  const [extras, setExtras] = useState<SessionDef[]>([]);
+  const [extraDraft, setExtraDraft] = useState('');
+  const addSong = useSetlistStore((s) => s.addSong);
+  const currentUserId = useSetlistStore((s) => s.currentUserId);
+  const toast = useToast();
+
+  const form = useForm<AddSongSchema>({
+    resolver: zodResolver(addSongSchema),
+    defaultValues: { title: '', artist: '', album: '', note: '' },
+    mode: 'onTouched',
+  });
+
+  const reset = () => {
+    form.reset();
+    setExtras([]);
+    setExtraDraft('');
+  };
+
+  const addExtra = () => {
+    const label = extraDraft.trim();
+    if (!label) return;
+    const all = [...DEFAULT_SESSIONS, ...extras];
+    const id = makeSessionId(label, all);
+    const short = label.slice(0, 2);
+    setExtras((prev) => [...prev, { id, label, short, need: 1, custom: true }]);
+    setExtraDraft('');
+  };
+
+  const removeExtra = (id: string) => setExtras((prev) => prev.filter((s) => s.id !== id));
+
+  const onSubmit = form.handleSubmit((values) => {
+    addSong(meetingId, {
+      title: values.title,
+      artist: values.artist,
+      album: values.album,
+      note: values.note,
+      proposerId: currentUserId,
+      sessions: [...DEFAULT_SESSIONS, ...extras],
+    });
+    toast.success('곡이 추가되었습니다.');
+    setOpen(false);
+    reset();
+  });
+
+  return (
+    <ResponsiveSheet
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) reset();
+      }}
+    >
+      <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>
+      <ResponsiveSheetContent>
+        <ResponsiveSheetHeader>
+          <ResponsiveSheetTitle>곡 추가</ResponsiveSheetTitle>
+        </ResponsiveSheetHeader>
+        <form onSubmit={onSubmit}>
+          <ResponsiveSheetBody>
+            <div className="gap-s-3 flex flex-col">
+              <Input
+                label="곡명"
+                required
+                error={form.formState.errors.title?.message}
+                placeholder="예: Vicarious"
+                autoFocus
+                {...form.register('title')}
+              />
+              <Input
+                label="아티스트"
+                required
+                error={form.formState.errors.artist?.message}
+                placeholder="예: Tool"
+                {...form.register('artist')}
+              />
+              <Input
+                label="앨범"
+                error={form.formState.errors.album?.message}
+                placeholder="선택"
+                {...form.register('album')}
+              />
+              <Textarea
+                label="추천자 의견"
+                error={form.formState.errors.note?.message}
+                rows={3}
+                placeholder="이 곡을 추천하는 이유, 합주 시 유의사항 등"
+                {...form.register('note')}
+              />
+
+              <div>
+                <div className="text-foreground-sub text-caption mb-s-2 font-semibold">
+                  세션 구성
+                </div>
+                <div className="text-foreground-muted text-micro mb-s-2">
+                  기본 4세션(보컬/기타/베이스/드럼) 외에 필요한 세션을 추가할 수 있습니다.
+                </div>
+                <div className="gap-s-2 flex">
+                  <Input
+                    value={extraDraft}
+                    onChange={(e) => setExtraDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        addExtra();
+                      }
+                    }}
+                    placeholder="예: 키보드, 퍼커션"
+                  />
+                  <Button type="button" variant="secondary" size="sm" onClick={addExtra}>
+                    <Plus className="h-4 w-4" /> 추가
+                  </Button>
+                </div>
+                {extras.length > 0 && (
+                  <ul className="gap-s-2 mt-s-2 flex flex-wrap">
+                    {extras.map((s) => (
+                      <li
+                        key={s.id}
+                        className="bg-amber-dim text-amber border-amber/30 px-s-2 gap-s-1 text-micro inline-flex items-center rounded-full border py-0.5 font-bold"
+                      >
+                        {s.label}
+                        <button
+                          type="button"
+                          onClick={() => removeExtra(s.id)}
+                          aria-label={`${s.label} 세션 제거`}
+                          className="hover:text-foreground"
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          </ResponsiveSheetBody>
+          <ResponsiveSheetFooter>
+            <ResponsiveSheetClose asChild>
+              <Button type="button" variant="ghost">
+                취소
+              </Button>
+            </ResponsiveSheetClose>
+            <Button type="submit" variant="primary" disabled={!form.formState.isValid}>
+              곡 추가
+            </Button>
+          </ResponsiveSheetFooter>
+        </form>
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}

--- a/src/domain/setlist-meeting/components/MeetingCreateModal.client.tsx
+++ b/src/domain/setlist-meeting/components/MeetingCreateModal.client.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useState, type ReactNode } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetClose,
+  ResponsiveSheetContent,
+  ResponsiveSheetFooter,
+  ResponsiveSheetHeader,
+  ResponsiveSheetTitle,
+  ResponsiveSheetTrigger,
+} from '@/components/ui/responsive-sheet';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+import { useSetlistStore } from '../store/setlistStore';
+import { createMeetingSchema, type CreateMeetingSchema } from '../types/schema';
+
+export interface MeetingCreateModalProps {
+  trigger: ReactNode;
+}
+
+/**
+ * 백엔드 미지원(FE-API-024) 단계의 클라이언트-only 회의 생성.
+ * BE 도입 시 BandPickerModal 로 bandId 선택 + POST /api/v1/setlist-meetings 로 교체.
+ */
+export function MeetingCreateModal({ trigger }: MeetingCreateModalProps) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  const toast = useToast();
+  const addMeeting = useSetlistStore((s) => s.addMeeting);
+  const currentUserId = useSetlistStore((s) => s.currentUserId);
+
+  const form = useForm<CreateMeetingSchema>({
+    resolver: zodResolver(createMeetingSchema),
+    defaultValues: { title: '', bandName: '' },
+    mode: 'onTouched',
+  });
+
+  const onSubmit = form.handleSubmit((values) => {
+    const id = addMeeting({
+      title: values.title,
+      bandId: `local_${Date.now()}`,
+      bandName: values.bandName,
+      managerId: currentUserId,
+    });
+    toast.success('선곡 회의가 만들어졌습니다.');
+    setOpen(false);
+    form.reset();
+    router.push(ROUTES.SETLIST_MEETING_DETAIL(id));
+  });
+
+  return (
+    <ResponsiveSheet
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) form.reset();
+      }}
+    >
+      <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>
+      <ResponsiveSheetContent>
+        <ResponsiveSheetHeader>
+          <ResponsiveSheetTitle>선곡 회의 만들기</ResponsiveSheetTitle>
+        </ResponsiveSheetHeader>
+        <form onSubmit={onSubmit}>
+          <ResponsiveSheetBody>
+            <div className="gap-s-3 flex flex-col">
+              <Input
+                label="회의 제목"
+                required
+                error={form.formState.errors.title?.message}
+                placeholder="예: 여름 공연 셋리스트"
+                autoFocus
+                {...form.register('title')}
+              />
+              <Input
+                label="연결 밴드"
+                required
+                error={form.formState.errors.bandName?.message}
+                hint="실제 밴드 연결은 백엔드 도입 후 BandPickerModal 로 교체됩니다 (FE-API-024)."
+                placeholder="예: TOOL TRIBUTE"
+                {...form.register('bandName')}
+              />
+            </div>
+          </ResponsiveSheetBody>
+          <ResponsiveSheetFooter>
+            <ResponsiveSheetClose asChild>
+              <Button type="button" variant="ghost">
+                취소
+              </Button>
+            </ResponsiveSheetClose>
+            <Button type="submit" variant="primary" disabled={!form.formState.isValid}>
+              회의 만들기
+            </Button>
+          </ResponsiveSheetFooter>
+        </form>
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}

--- a/src/domain/setlist-meeting/types/schema.ts
+++ b/src/domain/setlist-meeting/types/schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const addSongSchema = z.object({
+  title: z.string().min(1, '곡명을 입력해 주세요.').max(100, '곡명은 100자 이하로 입력해 주세요.'),
+  artist: z.string().min(1, '아티스트를 입력해 주세요.').max(100),
+  album: z
+    .string()
+    .max(100)
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+  note: z
+    .string()
+    .max(500)
+    .optional()
+    .or(z.literal('').transform(() => undefined)),
+});
+export type AddSongSchema = z.infer<typeof addSongSchema>;
+
+export const createMeetingSchema = z.object({
+  title: z.string().min(1, '회의 제목을 입력해 주세요.').max(80),
+  bandName: z.string().min(1, '연결할 밴드 이름을 입력해 주세요.').max(40),
+});
+export type CreateMeetingSchema = z.infer<typeof createMeetingSchema>;


### PR DESCRIPTION
## 작업 내용
선곡 회의 만들기 / 곡 추가 모달을 부착하고 매니저 권한 가드 적용.

## 신규 파일
- `src/domain/setlist-meeting/types/schema.ts` (zod)
- `src/domain/setlist-meeting/components/AddSongModal.client.tsx`
- `src/domain/setlist-meeting/components/MeetingCreateModal.client.tsx`

## 변경
- `SetlistMeetingsListPane.client.tsx` — '회의 만들기' 버튼이 MeetingCreateModal 트리거
- `MeetingDetail.client.tsx` — 매니저일 때만 AddSongModal 노출

## 동작
- 곡 추가: 곡명/아티스트(필수) + 앨범/추천자 의견 + 커스텀 세션 추가/삭제 → store.addSong → 표 즉시 갱신
- 회의 만들기: 제목 + 연결 밴드(텍스트, BE 도입 후 BandPickerModal 교체 예정) → store.addMeeting + 자동 라우팅
- 매니저 권한 가드: meeting.managerId === currentUserId 일 때만 '곡 추가' 노출

## 검증
- pnpm typecheck / lint / test 통과 (60 passed)

Closes #137
