### PR TITLE
fix: 선곡 회의 store selector 무한 루프 해소

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -43,8 +43,15 @@ function applySearch(songs: Song[], q: string): Song[] {
 }
 
 export function MeetingDetail({ meetingId }: { meetingId: string }) {
-  const meeting = useSetlistStore((s) => s.meetings.find((m) => m.id === meetingId));
-  const allSongs = useSetlistStore((s) => s.songs.filter((song) => song.meetingId === meetingId));
+  // selector 내부에서 find/filter 같은 새 참조를 만들면 useSyncExternalStore 가 매 렌더마다 변경으로 인식해 무한 루프.
+  // 배열 자체(stable reference)를 select 하고 파생값은 useMemo 로 계산.
+  const meetings = useSetlistStore((s) => s.meetings);
+  const songs = useSetlistStore((s) => s.songs);
+  const meeting = useMemo(() => meetings.find((m) => m.id === meetingId), [meetings, meetingId]);
+  const allSongs = useMemo(
+    () => songs.filter((song) => song.meetingId === meetingId),
+    [songs, meetingId],
+  );
   const members = useSetlistStore((s) => s.members);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
   const selectedSongId = useSetlistStore((s) => s.selectedSongId);

--- a/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
+++ b/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { MessageSquare, Send } from 'lucide-react';
-import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 
 import { cn } from '@/lib/cn';
 
@@ -14,7 +14,9 @@ export interface MeetingChatBoxProps {
 }
 
 export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
-  const song = useSetlistStore((s) => s.songs.find((x) => x.id === songId));
+  // selector 내부 find 가 매 렌더마다 새 참조 → 무한 루프. 배열 select + useMemo 로 분리.
+  const songs = useSetlistStore((s) => s.songs);
+  const song = useMemo(() => songs.find((x) => x.id === songId), [songs, songId]);
   const members = useSetlistStore((s) => s.members);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
   const sendChat = useSetlistStore((s) => s.sendChat);

--- a/src/domain/setlist-meeting/components/SessionPanel.client.tsx
+++ b/src/domain/setlist-meeting/components/SessionPanel.client.tsx
@@ -20,9 +20,13 @@ export interface SessionPanelProps {
 }
 
 export function SessionPanel({ songId, onClose }: SessionPanelProps) {
-  const song = useSetlistStore((s) => s.songs.find((x) => x.id === songId));
-  const meeting = useSetlistStore((s) =>
-    song ? s.meetings.find((m) => m.id === song.meetingId) : null,
+  // 배열 자체(stable ref) 만 select 하고 find 는 useMemo 로 — selector 내부 find/filter 는 매 렌더마다 새 참조라 무한 루프.
+  const songs = useSetlistStore((s) => s.songs);
+  const meetings = useSetlistStore((s) => s.meetings);
+  const song = useMemo(() => songs.find((x) => x.id === songId), [songs, songId]);
+  const meeting = useMemo(
+    () => (song ? (meetings.find((m) => m.id === song.meetingId) ?? null) : null),
+    [meetings, song],
   );
   const members = useSetlistStore((s) => s.members);
   const currentUserId = useSetlistStore((s) => s.currentUserId);


### PR DESCRIPTION
## 증상
선곡 회의 디테일 진입 시 React 콘솔 에러:
- `The result of getSnapshot should be cached to avoid an infinite loop`
- `Maximum update depth exceeded`

## 원인
`useSetlistStore((s) => s.songs.find(...))` / `s.meetings.find(...)` 처럼 selector 내부에서 새 참조를 반환 → `useSyncExternalStore` 가 매 렌더마다 변경으로 인식 → 무한 루프.

## 수정
배열 자체(stable ref)를 select 하고 find/filter 는 컴포넌트에서 useMemo 로 계산.

영향 파일:
- MeetingDetail.client.tsx
- SessionPanel.client.tsx
- MeetingChatBox.client.tsx

## 검증
- pnpm typecheck / lint / test 통과 (60 passed)

Closes #141