### PR TITLE
refactor: 선곡 회의 좌/우 패널 접기 — 메인 차트 공간 확보

### DIFF
--- a/src/app/(main)/setlist-meetings/SetlistMeetingsListPane.client.tsx
+++ b/src/app/(main)/setlist-meetings/SetlistMeetingsListPane.client.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { Plus } from 'lucide-react';
+import { Plus, X } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useMemo } from 'react';
+
+import { cn } from '@/lib/cn';
 
 import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
@@ -69,7 +71,18 @@ function MeetingRow({ summary, active }: { summary: MeetingSummary; active: bool
   );
 }
 
-export function SetlistMeetingsListPane() {
+export interface SetlistMeetingsListPaneProps {
+  /** 'overlay' 모드: absolute 로 메인 위에 띄우고 open 으로 표시 토글. default: 'fixed' (기존 sidecar). */
+  mode?: 'overlay' | 'fixed';
+  open?: boolean;
+  onClose?: () => void;
+}
+
+export function SetlistMeetingsListPane({
+  mode = 'fixed',
+  open = false,
+  onClose,
+}: SetlistMeetingsListPaneProps = {}) {
   const pathname = usePathname() ?? '';
   const meetings = useSetlistStore((s) => s.meetings);
   const songs = useSetlistStore((s) => s.songs);
@@ -83,25 +96,48 @@ export function SetlistMeetingsListPane() {
     });
   }, [meetings, songs]);
 
+  const overlay = mode === 'overlay';
+
   return (
     <aside
-      className="bg-surface border-border hidden shrink-0 flex-col border-r lg:flex"
+      className={cn(
+        'bg-surface border-border shrink-0 flex-col border-r shadow-lg',
+        overlay
+          ? cn(
+              'absolute top-0 left-0 z-30 h-full transition-transform duration-200 ease-out',
+              open ? 'flex translate-x-0' : 'pointer-events-none flex -translate-x-full',
+            )
+          : 'hidden lg:flex',
+      )}
       style={{ width: 'var(--list-pane-w)' }}
       data-slot="setlist-meetings-list-pane"
       aria-label="선곡 회의 목록"
+      aria-hidden={overlay && !open ? true : undefined}
     >
-      <div className="border-border px-s-3 py-s-3 flex items-center justify-between border-b">
+      <div className="border-border px-s-3 py-s-3 gap-s-2 flex items-center justify-between border-b">
         <div className="min-w-0">
           <h2 className="text-body font-bold">선곡 회의</h2>
           <p className="text-foreground-muted text-micro mt-0.5">{meetings.length}건 참여</p>
         </div>
-        <MeetingCreateModal
-          trigger={
-            <Button size="sm" variant="accent-outline" aria-label="새 선곡 회의 만들기">
-              <Plus className="h-4 w-4" /> 회의 만들기
-            </Button>
-          }
-        />
+        <div className="gap-s-1 flex items-center">
+          <MeetingCreateModal
+            trigger={
+              <Button size="sm" variant="accent-outline" aria-label="새 선곡 회의 만들기">
+                <Plus className="h-4 w-4" /> 회의 만들기
+              </Button>
+            }
+          />
+          {overlay && onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-foreground-muted hover:text-foreground rounded-md p-1"
+              aria-label="목록 닫기"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
       </div>
       <div className="px-s-2 py-s-2 flex-1 overflow-y-auto">
         {summaries.length === 0 ? (

--- a/src/app/(main)/setlist-meetings/SetlistMeetingsShell.client.tsx
+++ b/src/app/(main)/setlist-meetings/SetlistMeetingsShell.client.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { PanelLeftOpen } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import { Suspense, useEffect, useState, type ReactNode } from 'react';
+
+import { SetlistMeetingsListPane } from './SetlistMeetingsListPane.client';
+
+/**
+ * 선곡 회의 영역 셸.
+ * - 좌측 회의 목록 패널은 기본 접힘. 토글 버튼 클릭 시 메인 위로 오버레이.
+ * - 회의 선택(=pathname 변경) 시 자동 닫힘. backdrop 클릭 / Esc 도 닫힘.
+ * - 1280px 환경에서 가운데 차트 공간을 최대로 확보하는 것이 목적.
+ */
+export function SetlistMeetingsShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname() ?? '';
+  const [listOpen, setListOpen] = useState(false);
+
+  // 경로 변경 시 자동 닫기.
+  useEffect(() => {
+    setListOpen(false);
+  }, [pathname]);
+
+  // Esc 닫기.
+  useEffect(() => {
+    if (!listOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setListOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [listOpen]);
+
+  return (
+    <div className="relative flex h-full">
+      {/* 좌측 토글 — lg 이상에서만 노출 (모바일은 BottomNav). */}
+      <button
+        type="button"
+        onClick={() => setListOpen((v) => !v)}
+        aria-expanded={listOpen}
+        aria-label="회의 목록 열기/닫기"
+        className="bg-surface border-border text-foreground-sub hover:bg-card hover:text-foreground top-s-3 left-s-3 absolute z-30 hidden h-8 w-8 items-center justify-center rounded-md border shadow-sm transition-colors lg:inline-flex"
+      >
+        <PanelLeftOpen className="h-4 w-4" />
+      </button>
+
+      {/* Backdrop — open 일 때만. */}
+      {listOpen && (
+        <div
+          aria-hidden="true"
+          onClick={() => setListOpen(false)}
+          className="bg-bg/40 absolute inset-0 z-20 backdrop-blur-sm lg:block"
+        />
+      )}
+
+      {/* 회의 목록 패널 — 오버레이로 absolute. */}
+      <Suspense fallback={null}>
+        <SetlistMeetingsListPane
+          open={listOpen}
+          onClose={() => setListOpen(false)}
+          mode="overlay"
+        />
+      </Suspense>
+
+      <div className="min-w-0 flex-1 overflow-y-auto">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Plus, Search } from 'lucide-react';
+import { PanelRightOpen, Plus, Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -64,6 +64,8 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
 
   const [filter, setFilter] = useState<Filter>('all');
   const [query, setQuery] = useState('');
+  // 우측 세션 패널 토글. 곡을 새로 선택하면 자동 열림.
+  const [sessionPanelOpen, setSessionPanelOpen] = useState(false);
 
   useEffect(() => {
     setSelectedMeeting(meetingId);
@@ -89,7 +91,7 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
   }
 
   return (
-    <div className="flex h-full">
+    <div className="relative flex h-full">
       <div className="flex min-w-0 flex-1 flex-col">
         <header className="border-border px-s-5 py-s-4 border-b">
           <div className="gap-s-3 flex items-start justify-between">
@@ -150,16 +152,32 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
             selectedSongId={selectedSongId}
             focusedSessionId={focusedSessionId}
             currentUserId={currentUserId}
-            onSelectSong={(id) => setSelectedSong(id)}
+            onSelectSong={(id) => {
+              setSelectedSong(id);
+              setSessionPanelOpen(true);
+            }}
             onFocusSession={(songId, sessionId) => {
               setSelectedSong(songId);
               setFocusedSession(sessionId);
+              setSessionPanelOpen(true);
             }}
           />
         </div>
         {selectedSongId && <MeetingChatBox songId={selectedSongId} />}
       </div>
-      {selectedSongId && <SessionPanel songId={selectedSongId} />}
+      {selectedSongId && sessionPanelOpen && (
+        <SessionPanel songId={selectedSongId} onClose={() => setSessionPanelOpen(false)} />
+      )}
+      {selectedSongId && !sessionPanelOpen && (
+        <button
+          type="button"
+          onClick={() => setSessionPanelOpen(true)}
+          aria-label="세션 패널 열기"
+          className="bg-surface border-border text-foreground-sub hover:bg-card hover:text-foreground top-s-3 right-s-3 absolute z-10 hidden h-8 w-8 items-center justify-center rounded-md border shadow-sm transition-colors lg:inline-flex"
+        >
+          <PanelRightOpen className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/app/(main)/setlist-meetings/layout.tsx
+++ b/src/app/(main)/setlist-meetings/layout.tsx
@@ -1,19 +1,11 @@
-import { Suspense, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
-import { SetlistMeetingsListPane } from './SetlistMeetingsListPane.client';
+import { SetlistMeetingsShell } from './SetlistMeetingsShell.client';
 
 /**
- * /setlist-meetings 영역 마스터-디테일 레이아웃.
- * - lg(>=960px): 좌측 ListPane(280px) + 우측 children
- * - 모바일: ListPane 비노출 (BottomNav 로 회의 목록 ↔ 디테일 전환은 후속 PR 에서)
+ * /setlist-meetings 라우트 레이아웃.
+ * 좌측 회의 목록 패널은 SetlistMeetingsShell 가 오버레이 모드로 토글.
  */
 export default function SetlistMeetingsLayout({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex h-full flex-col lg:flex-row">
-      <Suspense fallback={null}>
-        <SetlistMeetingsListPane />
-      </Suspense>
-      <div className="min-w-0 flex-1 lg:overflow-y-auto">{children}</div>
-    </div>
-  );
+  return <SetlistMeetingsShell>{children}</SetlistMeetingsShell>;
 }

--- a/src/domain/setlist-meeting/components/SessionPanel.client.tsx
+++ b/src/domain/setlist-meeting/components/SessionPanel.client.tsx
@@ -48,7 +48,7 @@ export function SessionPanel({ songId, onClose }: SessionPanelProps) {
   return (
     <aside
       data-slot="session-panel"
-      className="bg-surface border-border hidden flex-col overflow-hidden border-l xl:flex"
+      className="bg-surface border-border hidden flex-col overflow-hidden border-l lg:flex"
       style={{ width: 380 }}
       aria-label="세션 지원 패널"
     >


### PR DESCRIPTION
## 작업 내용
1280px 환경에서 좌(280) + 우(380) 패널이 항상 보이면 가운데 차트가 ~420px 로 구겨지는 문제 해소.

## 동작 변경
### 좌측 회의 목록 패널 — 오버레이 모드
- 기본 접힘. 좌상단 토글 버튼으로 열기.
- 열리면 메인 위에 absolute 로 슬라이드 인 + backdrop.
- 회의 선택(=pathname 변경) 시 자동 닫힘. backdrop 클릭 / Esc 도 닫힘.

### 우측 세션 패널 — 토글
- 곡을 새로 선택하면 자동 열림.
- 헤더의 X 버튼으로 닫기.
- 닫혀있을 때 우상단에 fold 핸들 노출 → 다시 열기.

## 신규 파일
- `src/app/(main)/setlist-meetings/SetlistMeetingsShell.client.tsx`

## 변경 파일
- `layout.tsx` — Shell 로 위임
- `SetlistMeetingsListPane.client.tsx` — `mode='overlay'`/`open`/`onClose` prop
- `MeetingDetail.client.tsx` — `sessionPanelOpen` 상태 + fold 핸들
- `SessionPanel.client.tsx` — xl→lg 브레이크포인트 하향

## 검증
- pnpm typecheck / lint / test 통과 (60 passed)

Closes #143