### PR TITLE
refactor: 우측 패널 오버레이 + 채팅 동기화 + 추천자 의견 컬럼 제거

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -12,6 +12,7 @@ import { SongTable } from '@/domain/setlist-meeting/components/SongTable.client'
 import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
 import type { Song } from '@/domain/setlist-meeting/types';
 import { isReady } from '@/domain/setlist-meeting/utils';
+import { cn } from '@/lib/cn';
 
 type Filter = 'all' | 'ready' | 'pending' | 'mine';
 
@@ -52,7 +53,6 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
     () => songs.filter((song) => song.meetingId === meetingId),
     [songs, meetingId],
   );
-  const members = useSetlistStore((s) => s.members);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
   const selectedSongId = useSetlistStore((s) => s.selectedSongId);
   const focusedSessionId = useSetlistStore((s) => s.focusedSessionId);
@@ -148,7 +148,6 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
         <div className="flex-1 overflow-y-auto">
           <SongTable
             songs={visible}
-            members={members}
             selectedSongId={selectedSongId}
             focusedSessionId={focusedSessionId}
             currentUserId={currentUserId}
@@ -163,17 +162,30 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
             }}
           />
         </div>
-        {selectedSongId && <MeetingChatBox songId={selectedSongId} />}
       </div>
-      {selectedSongId && sessionPanelOpen && (
-        <SessionPanel songId={selectedSongId} onClose={() => setSessionPanelOpen(false)} />
+
+      {/* 우측 오버레이: SessionPanel + MeetingChatBox 가 한 덩어리로 묶여 함께 슬라이드. */}
+      {selectedSongId && (
+        <div
+          aria-hidden={!sessionPanelOpen}
+          className={cn(
+            'absolute inset-y-0 right-0 z-20 hidden flex-col shadow-lg transition-transform duration-200 ease-out lg:flex',
+            sessionPanelOpen ? 'translate-x-0' : 'pointer-events-none translate-x-full',
+          )}
+          style={{ width: 380 }}
+        >
+          <SessionPanel songId={selectedSongId} onClose={() => setSessionPanelOpen(false)} />
+          <MeetingChatBox songId={selectedSongId} />
+        </div>
       )}
+
+      {/* 닫혔을 때 다시 열기 핸들. */}
       {selectedSongId && !sessionPanelOpen && (
         <button
           type="button"
           onClick={() => setSessionPanelOpen(true)}
           aria-label="세션 패널 열기"
-          className="bg-surface border-border text-foreground-sub hover:bg-card hover:text-foreground top-s-3 right-s-3 absolute z-10 hidden h-8 w-8 items-center justify-center rounded-md border shadow-sm transition-colors lg:inline-flex"
+          className="bg-surface border-border text-foreground-sub hover:bg-card hover:text-foreground top-s-3 right-s-3 absolute z-30 hidden h-8 w-8 items-center justify-center rounded-md border shadow-sm transition-colors lg:inline-flex"
         >
           <PanelRightOpen className="h-4 w-4" />
         </button>

--- a/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
+++ b/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
@@ -50,7 +50,7 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
   return (
     <section
       data-slot="meeting-chat-box"
-      className="bg-surface border-border hidden h-[280px] flex-col border-t lg:flex"
+      className="bg-surface border-border flex h-[280px] shrink-0 flex-col border-t border-l"
       aria-label={`${song.title} 의견 채팅`}
     >
       <header className="border-border px-s-5 py-s-2 gap-s-2 flex items-center border-b">

--- a/src/domain/setlist-meeting/components/SessionPanel.client.tsx
+++ b/src/domain/setlist-meeting/components/SessionPanel.client.tsx
@@ -48,8 +48,7 @@ export function SessionPanel({ songId, onClose }: SessionPanelProps) {
   return (
     <aside
       data-slot="session-panel"
-      className="bg-surface border-border hidden flex-col overflow-hidden border-l lg:flex"
-      style={{ width: 380 }}
+      className="bg-surface border-border flex min-h-0 flex-1 flex-col overflow-hidden border-l"
       aria-label="세션 지원 패널"
     >
       <header className="border-border px-s-5 py-s-4 gap-s-3 flex items-start justify-between border-b">

--- a/src/domain/setlist-meeting/components/SongTable.client.tsx
+++ b/src/domain/setlist-meeting/components/SongTable.client.tsx
@@ -4,14 +4,13 @@ import { Check } from 'lucide-react';
 
 import { cn } from '@/lib/cn';
 
-import type { Member, Song } from '../types';
+import type { Song } from '../types';
 import { confirmedCount, isReady, totalNeed } from '../utils';
 
 import { SessionTrack } from './SessionTrack';
 
 export interface SongTableProps {
   songs: Song[];
-  members: Member[];
   selectedSongId: string | null;
   focusedSessionId: string | null;
   currentUserId: string;
@@ -19,13 +18,8 @@ export interface SongTableProps {
   onFocusSession: (songId: string, sessionId: string) => void;
 }
 
-function memberName(members: Member[], id: string): string {
-  return members.find((m) => m.id === id)?.name ?? '?';
-}
-
 export function SongTable({
   songs,
-  members,
   selectedSongId,
   focusedSessionId,
   currentUserId,
@@ -54,10 +48,7 @@ export function SongTable({
               앨범
             </th>
             <th className="px-s-2 py-s-2 font-semibold tracking-wider">세션</th>
-            <th className="px-s-2 py-s-2 hidden font-semibold tracking-wider lg:table-cell">
-              추천자 의견
-            </th>
-            <th className="px-s-2 py-s-2 w-24 text-right font-semibold tracking-wider">진행도</th>
+            <th className="px-s-2 py-s-2 w-28 text-right font-semibold tracking-wider">진행도</th>
           </tr>
         </thead>
         <tbody>
@@ -113,18 +104,6 @@ export function SongTable({
                       />
                     ))}
                   </div>
-                </td>
-                <td className="px-s-2 py-s-2 text-foreground-muted text-caption hidden max-w-[280px] lg:table-cell">
-                  {song.note ? (
-                    <span className="block truncate" title={song.note}>
-                      <span className="text-foreground-sub font-semibold">
-                        {memberName(members, song.proposerId)} ·{' '}
-                      </span>
-                      {song.note}
-                    </span>
-                  ) : (
-                    <span className="text-foreground-muted">-</span>
-                  )}
                 </td>
                 <td className="px-s-2 py-s-2 align-middle">
                   <div className="gap-s-2 flex items-center justify-end">


### PR DESCRIPTION
## 작업 내용
1. SessionPanel + MeetingChatBox 를 한 덩어리(380px absolute 컨테이너)로 묶어 함께 슬라이드 토글.
2. 컨테이너가 메인 차트 위로 오버레이 → 패널 열려도 차트 너비 변동 없음.
3. SongTable 의 '추천자 의견' 컬럼 제거 — 우측 패널에 동일 정보가 있어 중복.

## 변경 파일
- `MeetingDetail.client.tsx` — absolute 컨테이너 + transition (`translate-x-full ↔ 0`)
- `SessionPanel.client.tsx` — 자체 너비/breakpoint 제거, 부모에 위임
- `MeetingChatBox.client.tsx` — 자체 breakpoint 제거
- `SongTable.client.tsx` — 추천자 의견 컬럼 + members prop 제거

## 검증
- pnpm typecheck / lint / test 통과 (60 passed)

Closes #145