### PR TITLE
fix: SongTable 추천자 의견 컬럼 복원

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -53,6 +53,7 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
     () => songs.filter((song) => song.meetingId === meetingId),
     [songs, meetingId],
   );
+  const members = useSetlistStore((s) => s.members);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
   const selectedSongId = useSetlistStore((s) => s.selectedSongId);
   const focusedSessionId = useSetlistStore((s) => s.focusedSessionId);
@@ -148,6 +149,7 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
         <div className="flex-1 overflow-y-auto">
           <SongTable
             songs={visible}
+            members={members}
             selectedSongId={selectedSongId}
             focusedSessionId={focusedSessionId}
             currentUserId={currentUserId}

--- a/src/domain/setlist-meeting/components/SongTable.client.tsx
+++ b/src/domain/setlist-meeting/components/SongTable.client.tsx
@@ -4,13 +4,14 @@ import { Check } from 'lucide-react';
 
 import { cn } from '@/lib/cn';
 
-import type { Song } from '../types';
+import type { Member, Song } from '../types';
 import { confirmedCount, isReady, totalNeed } from '../utils';
 
 import { SessionTrack } from './SessionTrack';
 
 export interface SongTableProps {
   songs: Song[];
+  members: Member[];
   selectedSongId: string | null;
   focusedSessionId: string | null;
   currentUserId: string;
@@ -18,8 +19,13 @@ export interface SongTableProps {
   onFocusSession: (songId: string, sessionId: string) => void;
 }
 
+function memberName(members: Member[], id: string): string {
+  return members.find((m) => m.id === id)?.name ?? '?';
+}
+
 export function SongTable({
   songs,
+  members,
   selectedSongId,
   focusedSessionId,
   currentUserId,
@@ -49,6 +55,9 @@ export function SongTable({
             </th>
             <th className="px-s-2 py-s-2 font-semibold tracking-wider">세션</th>
             <th className="px-s-2 py-s-2 w-28 text-right font-semibold tracking-wider">진행도</th>
+            <th className="px-s-2 py-s-2 hidden font-semibold tracking-wider lg:table-cell">
+              추천자 의견
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -123,6 +132,18 @@ export function SongTable({
                       {done}/{total}
                     </span>
                   </div>
+                </td>
+                <td className="px-s-2 py-s-2 text-foreground-muted text-caption hidden max-w-[280px] lg:table-cell">
+                  {song.note ? (
+                    <span className="block truncate" title={song.note}>
+                      <span className="text-foreground-sub font-semibold">
+                        {memberName(members, song.proposerId)} ·{' '}
+                      </span>
+                      {song.note}
+                    </span>
+                  ) : (
+                    <span className="text-foreground-muted">-</span>
+                  )}
                 </td>
               </tr>
             );


### PR DESCRIPTION
이전 PR #146 에서 잘못 제거. 사용자 의도는 '우측 패널이 오버레이로 올라타니 가려져도 된다'였음 — 컬럼 자체는 유지. Closes #147