### PR TITLE
feat: 채팅 분리 복원 + 한글 IME Enter 가드 + 곡 삭제 버튼

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -60,6 +60,7 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
   const setSelectedMeeting = useSetlistStore((s) => s.setSelectedMeeting);
   const setSelectedSong = useSetlistStore((s) => s.setSelectedSong);
   const setFocusedSession = useSetlistStore((s) => s.setFocusedSession);
+  const deleteSong = useSetlistStore((s) => s.deleteSong);
 
   const isManager = meeting ? meeting.managerId === currentUserId : false;
 
@@ -153,6 +154,7 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
             selectedSongId={selectedSongId}
             focusedSessionId={focusedSessionId}
             currentUserId={currentUserId}
+            isManager={isManager}
             onSelectSong={(id) => {
               setSelectedSong(id);
               setSessionPanelOpen(true);
@@ -162,23 +164,25 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
               setFocusedSession(sessionId);
               setSessionPanelOpen(true);
             }}
+            onDeleteSong={(id) => deleteSong(id)}
           />
         </div>
+        {/* 메인 컬럼 하단 채팅 — 우측 패널과 sessionPanelOpen 으로 동기 토글. */}
+        {selectedSongId && sessionPanelOpen && <MeetingChatBox songId={selectedSongId} />}
       </div>
 
-      {/* 우측 오버레이: SessionPanel + MeetingChatBox 가 한 덩어리로 묶여 함께 슬라이드. */}
+      {/* 우측 오버레이 SessionPanel — 메인 차트 위로 absolute. */}
       {selectedSongId && (
-        <div
+        <aside
           aria-hidden={!sessionPanelOpen}
           className={cn(
-            'absolute inset-y-0 right-0 z-20 hidden flex-col shadow-lg transition-transform duration-200 ease-out lg:flex',
+            'absolute inset-y-0 right-0 z-20 hidden shadow-lg transition-transform duration-200 ease-out lg:flex',
             sessionPanelOpen ? 'translate-x-0' : 'pointer-events-none translate-x-full',
           )}
           style={{ width: 380 }}
         >
           <SessionPanel songId={selectedSongId} onClose={() => setSessionPanelOpen(false)} />
-          <MeetingChatBox songId={selectedSongId} />
-        </div>
+        </aside>
       )}
 
       {/* 닫혔을 때 다시 열기 핸들. */}

--- a/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
+++ b/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
@@ -41,6 +41,9 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
   };
 
   const onKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // 한글 등 IME 조합 중에는 Enter 가 글자 확정용으로 쓰여 e.key 가 'Enter' 로 들어옴.
+    // 그대로 submit 하면 마지막 글자가 한 번 더 메시지로 전송되는 버그 발생 → 조합 중이면 무시.
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       submit();
@@ -50,7 +53,7 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
   return (
     <section
       data-slot="meeting-chat-box"
-      className="bg-surface border-border flex h-[280px] shrink-0 flex-col border-t border-l"
+      className="bg-surface border-border flex h-[280px] shrink-0 flex-col border-t"
       aria-label={`${song.title} 의견 채팅`}
     >
       <header className="border-border px-s-5 py-s-2 gap-s-2 flex items-center border-b">

--- a/src/domain/setlist-meeting/components/SongTable.client.tsx
+++ b/src/domain/setlist-meeting/components/SongTable.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check } from 'lucide-react';
+import { Check, Trash2 } from 'lucide-react';
 
 import { cn } from '@/lib/cn';
 
@@ -15,8 +15,11 @@ export interface SongTableProps {
   selectedSongId: string | null;
   focusedSessionId: string | null;
   currentUserId: string;
+  /** true 이면 모든 곡에 삭제 버튼 노출(매니저). false 이면 본인이 제안한 곡만. */
+  isManager?: boolean;
   onSelectSong: (songId: string) => void;
   onFocusSession: (songId: string, sessionId: string) => void;
+  onDeleteSong?: (songId: string) => void;
 }
 
 function memberName(members: Member[], id: string): string {
@@ -29,8 +32,10 @@ export function SongTable({
   selectedSongId,
   focusedSessionId,
   currentUserId,
+  isManager = false,
   onSelectSong,
   onFocusSession,
+  onDeleteSong,
 }: SongTableProps) {
   if (songs.length === 0) {
     return (
@@ -58,6 +63,7 @@ export function SongTable({
             <th className="px-s-2 py-s-2 hidden font-semibold tracking-wider lg:table-cell">
               추천자 의견
             </th>
+            <th className="px-s-2 py-s-2 w-10" aria-label="삭제" />
           </tr>
         </thead>
         <tbody>
@@ -143,6 +149,23 @@ export function SongTable({
                     </span>
                   ) : (
                     <span className="text-foreground-muted">-</span>
+                  )}
+                </td>
+                <td className="px-s-2 py-s-2 text-right align-middle">
+                  {(isManager || song.proposerId === currentUserId) && onDeleteSong && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (window.confirm(`'${song.title}' 을 삭제하시겠습니까?`)) {
+                          onDeleteSong(song.id);
+                        }
+                      }}
+                      aria-label={`${song.title} 삭제`}
+                      className="text-foreground-muted hover:bg-danger-dim hover:text-danger inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
                   )}
                 </td>
               </tr>

--- a/src/domain/setlist-meeting/store/setlistStore.test.ts
+++ b/src/domain/setlist-meeting/store/setlistStore.test.ts
@@ -64,6 +64,19 @@ describe('setlistStore — chat / addSong / addCustomSession', () => {
     }
   });
 
+  it('deleteSong 은 곡을 제거하고, 선택 상태였다면 selection/focus 를 정리한다', () => {
+    const { addSong, setSelectedSong, setFocusedSession, deleteSong } = useSetlistStore.getState();
+    const id = addSong('mt1', { title: 'X', artist: 'Y', proposerId: 'u1' });
+    setSelectedSong(id);
+    setFocusedSession('V');
+    expect(useSetlistStore.getState().selectedSongId).toBe(id);
+    deleteSong(id);
+    const state = useSetlistStore.getState();
+    expect(state.songs.find((s) => s.id === id)).toBeUndefined();
+    expect(state.selectedSongId).toBeNull();
+    expect(state.focusedSessionId).toBeNull();
+  });
+
   it('addCustomSession 은 custom 플래그를 강제하고 동일 id 중복 추가를 막는다', () => {
     const { addCustomSession } = useSetlistStore.getState();
     addCustomSession('s1', { id: 'K', label: '키보드', short: 'K', need: 1 });

--- a/src/domain/setlist-meeting/store/setlistStore.ts
+++ b/src/domain/setlist-meeting/store/setlistStore.ts
@@ -42,6 +42,7 @@ type Actions = {
       sessions?: SessionDef[];
     },
   ) => string;
+  deleteSong: (songId: string) => void;
   addCustomSession: (songId: string, session: SessionDef) => void;
   addMeeting: (meeting: Omit<Meeting, 'id' | 'createdAt' | 'updatedAt'>) => string;
   /** 테스트/디버그용. seed 로 되돌림. */
@@ -162,6 +163,14 @@ export const useSetlistStore = create<SetlistStore>()(
         set((state) => ({ songs: [...state.songs, next] }));
         return id;
       },
+
+      deleteSong: (songId) =>
+        set((state) => ({
+          songs: state.songs.filter((s) => s.id !== songId),
+          // 삭제 곡이 현재 선택 상태였다면 선택 해제.
+          selectedSongId: state.selectedSongId === songId ? null : state.selectedSongId,
+          focusedSessionId: state.selectedSongId === songId ? null : state.focusedSessionId,
+        })),
 
       addCustomSession: (songId, session) =>
         set((state) => ({


### PR DESCRIPTION
## 작업 내용
1. **채팅 분리 복원** — MeetingChatBox 를 우측 오버레이에서 분리해 메인 컬럼 하단으로 복원. `sessionPanelOpen` 으로 우측 패널과 동시 토글되어 함께 등장/사라짐.
2. **한글 IME Enter 중복 입력 수정** — `e.nativeEvent.isComposing` / keyCode 229 가드로 IME 조합 중 Enter 무시. '안녕' 입력 후 Enter 시 마지막 '녕' 이 추가 메시지로 전송되던 버그 해소.
3. **곡 삭제 버튼** — `setlistStore.deleteSong` + SongTable 마지막 컬럼 휴지통 버튼. 매니저 또는 곡 제안자(`proposerId === currentUserId`) 만 노출, `window.confirm` 후 실행. 선택 중인 곡 삭제 시 selection/focus 자동 정리.

## 검증
- pnpm typecheck / lint / test 통과 (61 passed, 신규 deleteSong 테스트 1건 추가)

Closes #149