### PR TITLE
feat: 세션 카드 멤버 강조 + 지원 경쟁률 + 우측 패널 높이 가드

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -191,8 +191,10 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
       {selectedSongId && (
         <aside
           aria-hidden={!sessionPanelOpen}
+          // 하단 채팅(h-280)과 동시에 열리므로 우측 패널은 채팅 영역을 침범하지 않도록 bottom-[280px].
+          // 패널 body 는 자체 overflow-y-auto 라 작은 뷰포트에서도 자연 스크롤.
           className={cn(
-            'absolute inset-y-0 right-0 z-20 hidden shadow-lg transition-transform duration-200 ease-out lg:flex',
+            'absolute top-0 right-0 bottom-[280px] z-20 hidden shadow-lg transition-transform duration-200 ease-out lg:flex',
             sessionPanelOpen ? 'translate-x-0' : 'pointer-events-none translate-x-full',
           )}
           style={{ width: 380 }}

--- a/src/domain/setlist-meeting/components/SessionPanel.client.tsx
+++ b/src/domain/setlist-meeting/components/SessionPanel.client.tsx
@@ -157,13 +157,22 @@ function OverviewSessionView({
               : state === 'partial'
                 ? 'border-warn/30 bg-warn-dim/40'
                 : 'border-border bg-card';
+          // 카드의 정체성: 누가 이 세션을 맡는지 한눈에 보여주는 것.
+          // 1순위: 확정자(이름·아바타). 2순위: 지원자 미니 그룹. 3순위: '미확정'.
+          const confirmedMembers = conf
+            .map((uid) => members.find((m) => m.id === uid))
+            .filter((m): m is Member => Boolean(m));
+          const applicantMembers = apps
+            .filter((uid) => !conf.includes(uid))
+            .map((uid) => members.find((m) => m.id === uid))
+            .filter((m): m is Member => Boolean(m));
           return (
             <li key={s.id}>
               <button
                 type="button"
                 onClick={() => onFocus(s.id)}
                 className={cn(
-                  'gap-s-3 px-s-3 py-s-3 hover:border-border-hi flex w-full items-center rounded-lg border transition-colors',
+                  'gap-s-3 px-s-3 py-s-3 hover:border-border-hi flex w-full items-start rounded-lg border transition-colors',
                   tone,
                 )}
               >
@@ -181,34 +190,71 @@ function OverviewSessionView({
                   {s.custom && <span className="text-amber ml-0.5">*</span>}
                 </span>
                 <div className="min-w-0 flex-1 text-left">
-                  <div className="text-caption gap-s-2 flex items-center font-bold">
-                    {s.label}
-                    {s.custom && <span className="text-amber text-micro font-bold">커스텀</span>}
-                  </div>
-                  <div className="text-foreground-muted text-micro gap-s-2 mt-0.5 flex items-center">
+                  {/* 1행: 라벨 + 우측 경쟁률 칩 */}
+                  <div className="gap-s-2 flex items-center justify-between">
+                    <div className="text-caption gap-s-2 flex items-center font-bold">
+                      {s.label}
+                      {s.custom && <span className="text-amber text-micro font-bold">커스텀</span>}
+                    </div>
                     <span
                       className={cn(
-                        'font-mono font-bold',
+                        'px-s-2 text-micro rounded-full py-0.5 font-mono font-bold',
                         state === 'full'
-                          ? 'text-success'
-                          : state === 'partial'
-                            ? 'text-warn'
-                            : 'text-foreground-muted',
+                          ? 'bg-success-dim text-success'
+                          : apps.length > 0
+                            ? 'bg-warn-dim text-warn'
+                            : 'bg-card text-foreground-muted',
                       )}
                     >
-                      확정 {conf.length}/{s.need}
+                      지원 {apps.length}/{s.need}
                     </span>
-                    <span>·</span>
-                    <span>지원 {apps.length}명</span>
-                    {isMineConfirmed && (
-                      <span className="text-accent font-bold">· 내가 확정됨</span>
+                  </div>
+                  {/* 2행: 멤버 표시 — 확정자 우선, 없으면 지원자 미니 그룹 */}
+                  <div className="mt-s-2 gap-s-2 flex flex-wrap items-center">
+                    {confirmedMembers.length > 0 ? (
+                      confirmedMembers.map((m) => (
+                        <span
+                          key={m.id}
+                          className="bg-success/15 border-success/35 gap-s-1 px-s-2 inline-flex items-center rounded-full border py-0.5"
+                        >
+                          <MemberAvatar member={m} size="sm" className="-ml-1" />
+                          <span className="text-caption font-semibold">{m.name}</span>
+                          {m.id === currentUserId && (
+                            <span className="text-accent text-micro font-bold">나</span>
+                          )}
+                          <span className="text-success text-micro font-bold">확정</span>
+                        </span>
+                      ))
+                    ) : applicantMembers.length > 0 ? (
+                      <span className="gap-s-1 flex items-center">
+                        <span className="flex -space-x-1.5">
+                          {applicantMembers.slice(0, 4).map((m) => (
+                            <MemberAvatar
+                              key={m.id}
+                              member={m}
+                              size="sm"
+                              className="border-card border-2"
+                            />
+                          ))}
+                        </span>
+                        <span className="text-foreground-muted text-micro">
+                          {applicantMembers.length === 1
+                            ? applicantMembers[0]!.name
+                            : `${applicantMembers[0]!.name} 외 ${applicantMembers.length - 1}명`}
+                          {' 지원'}
+                        </span>
+                      </span>
+                    ) : (
+                      <span className="text-foreground-muted text-micro">미확정 · 지원자 없음</span>
                     )}
-                    {!isMineConfirmed && isMine && (
-                      <span className="text-accent font-bold">· 내가 지원함</span>
+                    {isMine && !isMineConfirmed && (
+                      <span className="bg-accent-dim text-accent text-micro px-s-2 rounded-full py-0.5 font-bold">
+                        내 지원
+                      </span>
                     )}
                   </div>
                 </div>
-                <ChevronRight className="text-foreground-muted h-4 w-4 shrink-0" />
+                <ChevronRight className="text-foreground-muted mt-s-1 h-4 w-4 shrink-0" />
               </button>
             </li>
           );


### PR DESCRIPTION
## 변경
### 0. 세션 오버뷰 카드 재디자인
- 우측 칩: '확정 N/M' → **'지원 N/M'** 경쟁률 표기 (need 가 곧 정원).
- 멤버 표시 2행:
  - 확정자 있음 → 아바타+이름+'확정' 칩 (success 톤).
  - 확정자 없음 + 지원자 있음 → 중첩 아바타 + '{첫 이름} 외 N명 지원'.
  - 둘 다 없음 → '미확정 · 지원자 없음'.
- 본인이 지원자(미확정)일 때 '내 지원' 칩 별도 노출.
- 결과: 한 곡을 펼치면 어떤 멤버가 어느 세션에 들어가는지 한눈에 파악.

### 1. 우측 패널 반응형
- SessionPanel 컨테이너 `inset-y-0` → `top-0 bottom-[280px]`. 하단 채팅(h-280)이 동시에 열리므로 패널이 채팅 영역을 침범하지 않음.
- 패널 body 는 이미 `overflow-y-auto` 라 작은 뷰포트에서도 자연 스크롤.

## 검증
- pnpm typecheck / lint / test 통과 (61 passed)

Closes #153