### PR TITLE
feat: 채팅 최소높이 가드 + 메인 행 토글 단순화 + 키보드 nav + 멤버 검색 + 세션 프리셋

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -56,7 +56,6 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
   const members = useSetlistStore((s) => s.members);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
   const selectedSongId = useSetlistStore((s) => s.selectedSongId);
-  const focusedSessionId = useSetlistStore((s) => s.focusedSessionId);
   const setSelectedMeeting = useSetlistStore((s) => s.setSelectedMeeting);
   const setSelectedSong = useSetlistStore((s) => s.setSelectedSong);
   const setFocusedSession = useSetlistStore((s) => s.setFocusedSession);
@@ -66,6 +65,7 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
 
   const [filter, setFilter] = useState<Filter>('all');
   const [query, setQuery] = useState('');
+  const [memberQuery, setMemberQuery] = useState('');
   // 우측 세션 패널 토글. 곡을 새로 선택하면 자동 열림.
   const [sessionPanelOpen, setSessionPanelOpen] = useState(false);
 
@@ -79,10 +79,53 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
     return { total, ready: readyCount, pending: total - readyCount };
   }, [allSongs]);
 
-  const visible = useMemo(
-    () => applySearch(applyFilter(allSongs, filter, currentUserId), query),
-    [allSongs, filter, currentUserId, query],
-  );
+  // 멤버 이름 부분 매칭 → userId 집합. 빈 검색이면 빈 Set.
+  const matchedUserIds = useMemo(() => {
+    const t = memberQuery.trim().toLowerCase();
+    if (!t) return new Set<string>();
+    return new Set(members.filter((m) => m.name.toLowerCase().includes(t)).map((m) => m.id));
+  }, [members, memberQuery]);
+
+  const visible = useMemo(() => {
+    let result = applySearch(applyFilter(allSongs, filter, currentUserId), query);
+    if (matchedUserIds.size > 0) {
+      // 곡 필터 + 멤버 필터 AND: 매칭 유저가 어떤 세션이든 들어있는 곡만.
+      result = result.filter(
+        (s) =>
+          Object.values(s.applicants).some((list) => list.some((u) => matchedUserIds.has(u))) ||
+          Object.values(s.confirmed).some((list) => list.some((u) => matchedUserIds.has(u))),
+      );
+    }
+    return result;
+  }, [allSongs, filter, currentUserId, query, matchedUserIds]);
+
+  // ↑/↓ 키보드 네비게이션 — 입력 필드 포커스 시에는 무시. 이동 시 focusedSession 정리(overview 모드).
+  useEffect(() => {
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+      const tag = (e.target as HTMLElement | null)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (visible.length === 0) return;
+      e.preventDefault();
+      const idx = selectedSongId ? visible.findIndex((s) => s.id === selectedSongId) : -1;
+      let nextIdx: number;
+      if (idx < 0) {
+        nextIdx = e.key === 'ArrowDown' ? 0 : visible.length - 1;
+      } else {
+        nextIdx =
+          e.key === 'ArrowUp' ? Math.max(0, idx - 1) : Math.min(visible.length - 1, idx + 1);
+      }
+      const nextSong = visible[nextIdx];
+      if (!nextSong) return;
+      if (nextSong.id !== selectedSongId) {
+        setSelectedSong(nextSong.id);
+        setFocusedSession(null);
+        setSessionPanelOpen(true);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [visible, selectedSongId, setSelectedSong, setFocusedSession]);
 
   if (!meeting) {
     return (
@@ -134,14 +177,25 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
                 <TabsTrigger value="mine">내 지원</TabsTrigger>
               </TabsList>
             </Tabs>
-            <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 flex items-center rounded-md border md:w-72">
+            <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 flex items-center rounded-md border md:w-60">
               <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
               <input
                 type="search"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                placeholder="곡명 · 아티스트 · 앨범 검색"
+                placeholder="곡명 · 아티스트 · 앨범"
                 aria-label="곡 검색"
+                className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+              />
+            </div>
+            <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 flex items-center rounded-md border md:w-52">
+              <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
+              <input
+                type="search"
+                value={memberQuery}
+                onChange={(e) => setMemberQuery(e.target.value)}
+                placeholder="멤버 이름"
+                aria-label="멤버 검색"
                 className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
               />
             </div>
@@ -153,26 +207,17 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
             songs={visible}
             members={members}
             selectedSongId={selectedSongId}
-            focusedSessionId={focusedSessionId}
             currentUserId={currentUserId}
             isManager={isManager}
+            matchedUserIds={matchedUserIds}
             onSelectSong={(id) => {
-              // 같은 곡을 다시 클릭하면 토글: 패널이 열려있으면 닫고, 닫혀있으면 다시 열기.
+              // 메인 행 클릭은 항상 overview 모드로 진입. 세션 focus 는 우측 패널에서만.
               if (id === selectedSongId) {
                 setSessionPanelOpen((v) => !v);
                 return;
               }
               setSelectedSong(id);
-              setSessionPanelOpen(true);
-            }}
-            onFocusSession={(songId, sessionId) => {
-              // 같은 곡 + 같은 세션 셀 재클릭 시에도 토글.
-              if (songId === selectedSongId && sessionId === focusedSessionId) {
-                setSessionPanelOpen((v) => !v);
-                return;
-              }
-              setSelectedSong(songId);
-              setFocusedSession(sessionId);
+              setFocusedSession(null);
               setSessionPanelOpen(true);
             }}
             onDeleteSong={(id) => deleteSong(id)}

--- a/src/domain/setlist-meeting/components/AddSongModal.client.tsx
+++ b/src/domain/setlist-meeting/components/AddSongModal.client.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus, X } from 'lucide-react';
-import { useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
@@ -18,9 +18,9 @@ import {
   ResponsiveSheetTrigger,
 } from '@/components/ui/responsive-sheet';
 import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/cn';
 import { useToast } from '@/hooks/useToast';
 
-import { DEFAULT_SESSIONS } from '../mock/seed';
 import { useSetlistStore } from '../store/setlistStore';
 import type { SessionDef } from '../types';
 import { addSongSchema, type AddSongSchema } from '../types/schema';
@@ -30,21 +30,25 @@ export interface AddSongModalProps {
   trigger: ReactNode;
 }
 
-function makeSessionId(label: string, existing: SessionDef[]): string {
-  const base = label
-    .replace(/[^A-Za-z0-9가-힣]/g, '')
-    .slice(0, 4)
-    .toUpperCase();
-  let id = base || `S${existing.length + 1}`;
-  let n = 1;
-  while (existing.some((s) => s.id === id)) {
-    id = `${base}${n++}`;
-  }
-  return id;
-}
+/** 표준 프리셋 — 토글 가능한 기본 세션 버튼. id/short/label 1:1. */
+const PRESETS: SessionDef[] = [
+  { id: 'V', label: '보컬', short: 'V', need: 1 },
+  { id: 'G1', label: '기타1', short: 'G1', need: 1 },
+  { id: 'G2', label: '기타2', short: 'G2', need: 1 },
+  { id: 'G3', label: '기타3', short: 'G3', need: 1 },
+  { id: 'B', label: '베이스', short: 'B', need: 1 },
+  { id: 'D', label: '드럼', short: 'D', need: 1 },
+  { id: 'S', label: '신스', short: 'S', need: 1 },
+];
+
+/** 모달 오픈 시 기본 활성화되는 프리셋 id 목록. */
+const DEFAULT_ACTIVE_PRESETS: ReadonlyArray<string> = ['V', 'G1', 'G2', 'B', 'D'];
 
 export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
   const [open, setOpen] = useState(false);
+  // 활성화된 프리셋 id 집합. 토글로 켜고 끔.
+  const [activePresetIds, setActivePresetIds] =
+    useState<ReadonlyArray<string>>(DEFAULT_ACTIVE_PRESETS);
   const [extras, setExtras] = useState<SessionDef[]>([]);
   const [extraDraft, setExtraDraft] = useState('');
   const addSong = useSetlistStore((s) => s.addSong);
@@ -59,30 +63,53 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
 
   const reset = () => {
     form.reset();
+    setActivePresetIds(DEFAULT_ACTIVE_PRESETS);
     setExtras([]);
     setExtraDraft('');
   };
 
+  const togglePreset = (id: string) =>
+    setActivePresetIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+
+  // 활성 프리셋 + 커스텀 결합. 출력 순서는 PRESETS 정의 순서를 따라 안정적으로 유지.
+  const composedSessions = useMemo<SessionDef[]>(() => {
+    const active = PRESETS.filter((p) => activePresetIds.includes(p.id));
+    return [...active, ...extras];
+  }, [activePresetIds, extras]);
+
   const addExtra = () => {
-    const label = extraDraft.trim();
-    if (!label) return;
-    const all = [...DEFAULT_SESSIONS, ...extras];
-    const id = makeSessionId(label, all);
-    const short = label.slice(0, 2);
-    setExtras((prev) => [...prev, { id, label, short, need: 1, custom: true }]);
+    const raw = extraDraft.trim().toUpperCase();
+    if (!raw) return;
+    // 영문 알파벳만 허용. (input onChange 에서도 한 번 거름)
+    const cleaned = raw.replace(/[^A-Z]/g, '');
+    if (!cleaned) return;
+    const id = `X_${cleaned}`;
+    if (composedSessions.some((s) => s.id === id || s.short === cleaned)) {
+      toast.warn('이미 같은 라벨의 세션이 있습니다.');
+      return;
+    }
+    setExtras((prev) => [...prev, { id, label: cleaned, short: cleaned, need: 1, custom: true }]);
     setExtraDraft('');
   };
 
   const removeExtra = (id: string) => setExtras((prev) => prev.filter((s) => s.id !== id));
 
+  const canSubmit = form.formState.isValid && composedSessions.length > 0;
+
   const onSubmit = form.handleSubmit((values) => {
+    if (composedSessions.length === 0) {
+      toast.error('세션을 최소 1개 이상 선택해 주세요.');
+      return;
+    }
     addSong(meetingId, {
       title: values.title,
       artist: values.artist,
       album: values.album,
       note: values.note,
       proposerId: currentUserId,
-      sessions: [...DEFAULT_SESSIONS, ...extras],
+      sessions: composedSessions,
     });
     toast.success('곡이 추가되었습니다.');
     setOpen(false);
@@ -139,21 +166,62 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
                   세션 구성
                 </div>
                 <div className="text-foreground-muted text-micro mb-s-2">
-                  기본 4세션(보컬/기타/베이스/드럼) 외에 필요한 세션을 추가할 수 있습니다.
+                  자주 쓰는 세션을 토글하고, 필요하면 알파벳 라벨로 커스텀 세션을 추가하세요.
                 </div>
-                <div className="gap-s-2 flex">
+
+                {/* 프리셋 토글 버튼들 */}
+                <div className="gap-s-2 flex flex-wrap">
+                  {PRESETS.map((p) => {
+                    const active = activePresetIds.includes(p.id);
+                    return (
+                      <button
+                        key={p.id}
+                        type="button"
+                        onClick={() => togglePreset(p.id)}
+                        aria-pressed={active}
+                        className={cn(
+                          'px-s-3 py-s-1 text-caption rounded-md border font-mono font-bold transition-colors',
+                          active
+                            ? 'bg-accent-dim border-accent/40 text-accent'
+                            : 'bg-card border-border text-foreground-muted hover:border-border-hi',
+                        )}
+                      >
+                        {p.short}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {/* 커스텀 세션 추가 — 영문 알파벳만 허용 */}
+                <div className="gap-s-2 mt-s-3 flex">
                   <Input
                     value={extraDraft}
-                    onChange={(e) => setExtraDraft(e.target.value)}
+                    onChange={(e) =>
+                      setExtraDraft(
+                        e.target.value
+                          .toUpperCase()
+                          .replace(/[^A-Z]/g, '')
+                          .slice(0, 4),
+                      )
+                    }
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
                         e.preventDefault();
                         addExtra();
                       }
                     }}
-                    placeholder="예: 키보드, 퍼커션"
+                    placeholder="커스텀 라벨 (영문 알파벳만, 최대 4자)"
+                    autoCapitalize="characters"
+                    autoComplete="off"
+                    pattern="[A-Za-z]*"
                   />
-                  <Button type="button" variant="secondary" size="sm" onClick={addExtra}>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={addExtra}
+                    disabled={!extraDraft}
+                  >
                     <Plus className="h-4 w-4" /> 추가
                   </Button>
                 </div>
@@ -177,6 +245,10 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
                     ))}
                   </ul>
                 )}
+
+                {composedSessions.length === 0 && (
+                  <p className="text-danger text-micro mt-s-2">최소 1개 세션을 선택하세요.</p>
+                )}
               </div>
             </div>
           </ResponsiveSheetBody>
@@ -186,7 +258,7 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
                 취소
               </Button>
             </ResponsiveSheetClose>
-            <Button type="submit" variant="primary" disabled={!form.formState.isValid}>
+            <Button type="submit" variant="primary" disabled={!canSubmit}>
               곡 추가
             </Button>
           </ResponsiveSheetFooter>

--- a/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
+++ b/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
@@ -21,6 +21,10 @@ export interface MeetingChatBoxProps {
   songId: string;
 }
 
+// 채팅 박스 높이 — 드래그로 위로만 늘어남. 기본/최소 280px, 최대는 viewport-200 (런타임 계산).
+const DEFAULT_HEIGHT = 280;
+const MIN_HEIGHT = DEFAULT_HEIGHT;
+
 export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
   // selector 내부 find 가 매 렌더마다 새 참조 → 무한 루프. 배열 select + useMemo 로 분리.
   const songs = useSetlistStore((s) => s.songs);
@@ -32,9 +36,6 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
   const listRef = useRef<HTMLDivElement | null>(null);
   const [draft, setDraft] = useState('');
 
-  // 채팅 박스 높이 — 드래그로 위로 늘릴 수 있다. 기본 280px, 최소 200px, 최대 viewport-200.
-  const DEFAULT_HEIGHT = 280;
-  const MIN_HEIGHT = 200;
   const [height, setHeight] = useState(DEFAULT_HEIGHT);
   const dragRef = useRef<{ y: number; h: number } | null>(null);
 

--- a/src/domain/setlist-meeting/components/SessionTrack.tsx
+++ b/src/domain/setlist-meeting/components/SessionTrack.tsx
@@ -12,7 +12,10 @@ export interface SessionTrackProps {
   active: boolean;
   /** 현재 사용자가 지원했는지. */
   mine: boolean;
-  onClick: () => void;
+  /** 멤버 검색 매칭 — 빨간 점 표시. */
+  highlighted?: boolean;
+  /** 생략 시 비-인터랙티브 div 로 렌더(메인 행에서는 클릭 동작 없이 시각 표기만). */
+  onClick?: () => void;
 }
 
 const labelTone: Record<'mine' | 'full' | 'partial' | 'empty', string> = {
@@ -35,22 +38,24 @@ export function SessionTrack({
   confirmed,
   active,
   mine,
+  highlighted = false,
   onClick,
 }: SessionTrackProps) {
   const state = sessionState(confirmed, session.need);
   const tone = mine ? 'mine' : state;
   const ratio = Math.min(1, confirmed.length / Math.max(session.need, 1));
 
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={`${session.label} 확정 ${confirmed.length}/${session.need} · 지원 ${applicants.length}명${session.custom ? ' · 커스텀' : ''}${mine ? ' · 내가 지원함' : ''}`}
-      className={cn(
-        'inline-flex min-w-[30px] flex-col items-stretch gap-1 rounded-sm bg-transparent p-0.5 transition-colors',
-        active && 'ring-accent ring-1 ring-offset-2',
+  const title = `${session.label} 확정 ${confirmed.length}/${session.need} · 지원 ${applicants.length}명${session.custom ? ' · 커스텀' : ''}${mine ? ' · 내가 지원함' : ''}`;
+
+  const content = (
+    <>
+      {/* 멤버 검색 매칭 빨간 점 — 우상단 */}
+      {highlighted && (
+        <span
+          aria-label="멤버 검색 매칭"
+          className="bg-danger absolute top-0 right-0 h-1.5 w-1.5 rounded-full"
+        />
       )}
-    >
       <span
         className={cn(
           'text-micro text-center font-mono leading-tight',
@@ -67,6 +72,26 @@ export function SessionTrack({
           style={{ width: `${ratio * 100}%` }}
         />
       </span>
-    </button>
+    </>
+  );
+
+  const baseClass = cn(
+    'relative inline-flex min-w-[30px] flex-col items-stretch gap-1 rounded-sm bg-transparent p-0.5 transition-colors',
+    active && 'ring-accent ring-1 ring-offset-2',
+  );
+
+  if (onClick) {
+    return (
+      <button type="button" onClick={onClick} title={title} className={baseClass}>
+        {content}
+      </button>
+    );
+  }
+
+  // 비-인터랙티브: 메인 행에서는 표기만. 클릭은 row 의 onClick 으로 흘려보냄.
+  return (
+    <span title={title} className={baseClass} aria-hidden="false">
+      {content}
+    </span>
   );
 }

--- a/src/domain/setlist-meeting/components/SongTable.client.tsx
+++ b/src/domain/setlist-meeting/components/SongTable.client.tsx
@@ -13,12 +13,12 @@ export interface SongTableProps {
   songs: Song[];
   members: Member[];
   selectedSongId: string | null;
-  focusedSessionId: string | null;
   currentUserId: string;
   /** true 이면 모든 곡에 삭제 버튼 노출(매니저). false 이면 본인이 제안한 곡만. */
   isManager?: boolean;
+  /** 멤버 검색 매칭 결과 — 해당 userId 가 속한 세션에 빨간 점 표시. */
+  matchedUserIds?: ReadonlySet<string>;
   onSelectSong: (songId: string) => void;
-  onFocusSession: (songId: string, sessionId: string) => void;
   onDeleteSong?: (songId: string) => void;
 }
 
@@ -30,11 +30,10 @@ export function SongTable({
   songs,
   members,
   selectedSongId,
-  focusedSessionId,
   currentUserId,
   isManager = false,
+  matchedUserIds,
   onSelectSong,
-  onFocusSession,
   onDeleteSong,
 }: SongTableProps) {
   if (songs.length === 0) {
@@ -107,17 +106,26 @@ export function SongTable({
                 </td>
                 <td className="px-s-2 py-s-2">
                   <div className="gap-s-3 flex flex-wrap items-end">
-                    {song.sessions.map((s) => (
-                      <SessionTrack
-                        key={s.id}
-                        session={s}
-                        applicants={song.applicants[s.id] ?? []}
-                        confirmed={song.confirmed[s.id] ?? []}
-                        active={selected && focusedSessionId === s.id}
-                        mine={(song.applicants[s.id] ?? []).includes(currentUserId)}
-                        onClick={() => onFocusSession(song.id, s.id)}
-                      />
-                    ))}
+                    {song.sessions.map((s) => {
+                      const apps = song.applicants[s.id] ?? [];
+                      const conf = song.confirmed[s.id] ?? [];
+                      const highlighted =
+                        !!matchedUserIds &&
+                        matchedUserIds.size > 0 &&
+                        (apps.some((u) => matchedUserIds.has(u)) ||
+                          conf.some((u) => matchedUserIds.has(u)));
+                      return (
+                        <SessionTrack
+                          key={s.id}
+                          session={s}
+                          applicants={apps}
+                          confirmed={conf}
+                          active={false}
+                          mine={apps.includes(currentUserId)}
+                          highlighted={highlighted}
+                        />
+                      );
+                    })}
                   </div>
                 </td>
                 <td className="px-s-2 py-s-2 align-middle">


### PR DESCRIPTION
## 변경
1. **채팅 최소 높이**: 280px(기본) 밑으로는 줄어들지 않음
2. **메인 행 토글 단순화**: 세션 셀이 메인 행에서 비-인터랙티브 → 클릭하면 항상 overview 모드. 세션 focus 는 우측 패널에서만
3. **키보드 ↑/↓ 네비게이션**: 입력 필드 포커스 시 무시, visible 범위 내 prev/next 곡으로 이동, focusedSession 자동 해제
4. **멤버 이름 검색**: 곡 검색 옆에 신설, AND 결합. 매칭 멤버가 속한 세션의 SessionTrack 에 빨간 점
5. **AddSongModal 세션 UI**: V/G1/G2/G3/B/D/S 7개 프리셋 토글 (기본 V/G1/G2/B/D 활성). 커스텀 세션은 영문 알파벳만 (replace + pattern, 최대 4자)

## 검증
- pnpm typecheck / lint / test 통과 (61 passed)

Closes #157