### PR TITLE
feat: 곡 추가 모달 - 재생시간 분리 입력 + 프리셋 재배치

### DIFF
--- a/src/domain/setlist-meeting/components/AddSongModal.client.tsx
+++ b/src/domain/setlist-meeting/components/AddSongModal.client.tsx
@@ -30,19 +30,40 @@ export interface AddSongModalProps {
   trigger: ReactNode;
 }
 
-/** 표준 프리셋 — 토글 가능한 기본 세션 버튼. id/short/label 1:1. */
-const PRESETS: SessionDef[] = [
-  { id: 'V', label: '보컬', short: 'V', need: 1 },
-  { id: 'G1', label: '기타1', short: 'G1', need: 1 },
-  { id: 'G2', label: '기타2', short: 'G2', need: 1 },
-  { id: 'G3', label: '기타3', short: 'G3', need: 1 },
-  { id: 'B', label: '베이스', short: 'B', need: 1 },
-  { id: 'D', label: '드럼', short: 'D', need: 1 },
-  { id: 'S', label: '신스', short: 'S', need: 1 },
+/** 표준 프리셋. 1행: 기본 4세션, 2행: 보조/멀티 세션. */
+const PRESETS: Record<string, SessionDef> = {
+  V: { id: 'V', label: '보컬', short: 'V', need: 1 },
+  G: { id: 'G', label: '기타', short: 'G', need: 1 },
+  B: { id: 'B', label: '베이스', short: 'B', need: 1 },
+  D: { id: 'D', label: '드럼', short: 'D', need: 1 },
+  V2: { id: 'V2', label: '보컬2', short: 'V2', need: 1 },
+  G2: { id: 'G2', label: '기타2', short: 'G2', need: 1 },
+  D2: { id: 'D2', label: '드럼2', short: 'D2', need: 1 },
+  S1: { id: 'S1', label: '신스1', short: 'S1', need: 1 },
+  S2: { id: 'S2', label: '신스2', short: 'S2', need: 1 },
+};
+
+const PRESET_ROWS: ReadonlyArray<ReadonlyArray<string>> = [
+  ['V', 'G', 'B', 'D'],
+  ['V2', 'G2', 'D2', 'S1', 'S2'],
 ];
 
-/** 모달 오픈 시 기본 활성화되는 프리셋 id 목록. */
-const DEFAULT_ACTIVE_PRESETS: ReadonlyArray<string> = ['V', 'G1', 'G2', 'B', 'D'];
+/** 모달 오픈 시 기본 활성화되는 프리셋 — 1행 전체. */
+const DEFAULT_ACTIVE_PRESETS: ReadonlyArray<string> = ['V', 'G', 'B', 'D'];
+
+/** 0~99 범위의 숫자 두자리로 정규화. 빈 문자열은 그대로 두고, 화면에 표시할 때 padStart. */
+function clampNumeric(raw: string, max: number): string {
+  const digits = raw.replace(/[^0-9]/g, '').slice(0, 2);
+  if (digits === '') return '';
+  const n = Math.min(parseInt(digits, 10), max);
+  return String(n);
+}
+
+function formatDuration(mm: string, ss: string): string {
+  const m = mm === '' ? '00' : mm.padStart(2, '0');
+  const s = ss === '' ? '00' : ss.padStart(2, '0');
+  return `${m}:${s}`;
+}
 
 export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
   const [open, setOpen] = useState(false);
@@ -51,13 +72,16 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
     useState<ReadonlyArray<string>>(DEFAULT_ACTIVE_PRESETS);
   const [extras, setExtras] = useState<SessionDef[]>([]);
   const [extraDraft, setExtraDraft] = useState('');
+  // 재생 시간 — 분/초 분리 입력. 기본 '00:00'.
+  const [durationMm, setDurationMm] = useState('');
+  const [durationSs, setDurationSs] = useState('');
   const addSong = useSetlistStore((s) => s.addSong);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
   const toast = useToast();
 
   const form = useForm<AddSongSchema>({
     resolver: zodResolver(addSongSchema),
-    defaultValues: { title: '', artist: '', album: '', duration: '', note: '' },
+    defaultValues: { title: '', artist: '', album: '', note: '' },
     mode: 'onTouched',
   });
 
@@ -66,6 +90,8 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
     setActivePresetIds(DEFAULT_ACTIVE_PRESETS);
     setExtras([]);
     setExtraDraft('');
+    setDurationMm('');
+    setDurationSs('');
   };
 
   const togglePreset = (id: string) =>
@@ -73,16 +99,20 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
     );
 
-  // 활성 프리셋 + 커스텀 결합. 출력 순서는 PRESETS 정의 순서를 따라 안정적으로 유지.
+  // 활성 프리셋 + 커스텀 결합. 출력 순서는 PRESET_ROWS 정의 순서를 따라 안정적으로 유지.
   const composedSessions = useMemo<SessionDef[]>(() => {
-    const active = PRESETS.filter((p) => activePresetIds.includes(p.id));
-    return [...active, ...extras];
+    const ordered: SessionDef[] = [];
+    for (const row of PRESET_ROWS) {
+      for (const id of row) {
+        if (activePresetIds.includes(id)) ordered.push(PRESETS[id]!);
+      }
+    }
+    return [...ordered, ...extras];
   }, [activePresetIds, extras]);
 
   const addExtra = () => {
     const raw = extraDraft.trim().toUpperCase();
     if (!raw) return;
-    // 영문 알파벳만 허용. (input onChange 에서도 한 번 거름)
     const cleaned = raw.replace(/[^A-Z]/g, '');
     if (!cleaned) return;
     const id = `X_${cleaned}`;
@@ -103,11 +133,12 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
       toast.error('세션을 최소 1개 이상 선택해 주세요.');
       return;
     }
+    const duration = formatDuration(durationMm, durationSs);
     addSong(meetingId, {
       title: values.title,
       artist: values.artist,
       album: values.album,
-      duration: values.duration,
+      duration: duration === '00:00' ? undefined : duration,
       note: values.note,
       proposerId: currentUserId,
       sessions: composedSessions,
@@ -157,24 +188,35 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
                     {...form.register('album')}
                   />
                 </div>
-                <div className="w-28">
-                  <Input
-                    label="재생 시간"
-                    error={form.formState.errors.duration?.message}
-                    placeholder="mm:ss"
-                    inputMode="numeric"
-                    {...form.register('duration')}
-                  />
+                <div>
+                  <label className="text-foreground text-sm font-medium">재생 시간</label>
+                  <div className="bg-surface border-border focus-within:ring-accent focus-within:ring-offset-bg gap-s-1 px-s-3 mt-1.5 flex h-10 items-center rounded-md border focus-within:ring-2 focus-within:ring-offset-2">
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      maxLength={2}
+                      value={durationMm}
+                      onChange={(e) => setDurationMm(clampNumeric(e.target.value, 99))}
+                      placeholder="00"
+                      aria-label="재생 시간 분"
+                      className="placeholder:text-foreground-muted w-7 bg-transparent text-center font-mono text-sm tabular-nums outline-none"
+                    />
+                    <span className="text-foreground-muted font-mono text-sm">:</span>
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      maxLength={2}
+                      value={durationSs}
+                      onChange={(e) => setDurationSs(clampNumeric(e.target.value, 59))}
+                      placeholder="00"
+                      aria-label="재생 시간 초"
+                      className="placeholder:text-foreground-muted w-7 bg-transparent text-center font-mono text-sm tabular-nums outline-none"
+                    />
+                  </div>
                 </div>
               </div>
-              <Textarea
-                label="추천자 의견"
-                error={form.formState.errors.note?.message}
-                rows={3}
-                placeholder="이 곡을 추천하는 이유, 합주 시 유의사항 등"
-                {...form.register('note')}
-              />
 
+              {/* 세션 구성 — 추천자 의견 위로 이동 */}
               <div>
                 <div className="text-foreground-sub text-caption mb-s-2 font-semibold">
                   세션 구성
@@ -183,27 +225,32 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
                   자주 쓰는 세션을 토글하고, 필요하면 알파벳 라벨로 커스텀 세션을 추가하세요.
                 </div>
 
-                {/* 프리셋 토글 버튼들 */}
-                <div className="gap-s-2 flex flex-wrap">
-                  {PRESETS.map((p) => {
-                    const active = activePresetIds.includes(p.id);
-                    return (
-                      <button
-                        key={p.id}
-                        type="button"
-                        onClick={() => togglePreset(p.id)}
-                        aria-pressed={active}
-                        className={cn(
-                          'px-s-3 py-s-1 text-caption rounded-md border font-mono font-bold transition-colors',
-                          active
-                            ? 'bg-accent-dim border-accent/40 text-accent'
-                            : 'bg-card border-border text-foreground-muted hover:border-border-hi',
-                        )}
-                      >
-                        {p.short}
-                      </button>
-                    );
-                  })}
+                {/* 1행: 기본 4세션 / 2행: 보조 5세션 */}
+                <div className="gap-s-2 flex flex-col">
+                  {PRESET_ROWS.map((row, rowIdx) => (
+                    <div key={rowIdx} className="gap-s-2 flex flex-wrap">
+                      {row.map((id) => {
+                        const p = PRESETS[id]!;
+                        const active = activePresetIds.includes(id);
+                        return (
+                          <button
+                            key={id}
+                            type="button"
+                            onClick={() => togglePreset(id)}
+                            aria-pressed={active}
+                            className={cn(
+                              'px-s-3 py-s-1 text-caption rounded-md border font-mono font-bold transition-colors',
+                              active
+                                ? 'bg-accent-dim border-accent/40 text-accent'
+                                : 'bg-card border-border text-foreground-muted hover:border-border-hi',
+                            )}
+                          >
+                            {p.short}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  ))}
                 </div>
 
                 {/* 커스텀 세션 추가 — 영문 알파벳만 허용 */}
@@ -264,6 +311,14 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
                   <p className="text-danger text-micro mt-s-2">최소 1개 세션을 선택하세요.</p>
                 )}
               </div>
+
+              <Textarea
+                label="추천자 의견"
+                error={form.formState.errors.note?.message}
+                rows={3}
+                placeholder="이 곡을 추천하는 이유, 합주 시 유의사항 등"
+                {...form.register('note')}
+              />
             </div>
           </ResponsiveSheetBody>
           <ResponsiveSheetFooter>

--- a/src/domain/setlist-meeting/types/schema.ts
+++ b/src/domain/setlist-meeting/types/schema.ts
@@ -8,11 +8,6 @@ export const addSongSchema = z.object({
     .max(100)
     .optional()
     .or(z.literal('').transform(() => undefined)),
-  duration: z
-    .string()
-    .regex(/^([0-9]{1,2}):[0-5][0-9]$/, '재생 시간은 mm:ss 형식 (예: 4:32) 으로 입력하세요.')
-    .optional()
-    .or(z.literal('').transform(() => undefined)),
   note: z
     .string()
     .max(500)


### PR DESCRIPTION
## 변경
1. **재생 시간 분리 입력**: `mm:ss` 단일 input → `[mm] : [ss]` 분리. 숫자만 입력 가능 (`replace /[^0-9]/`). 분 최대 99, 초 최대 59 자동 클램프. 기본값 `00:00`. zod schema 에서 duration 제거.
2. **세션 프리셋 2행 배치**:
   - 1행: V / G / B / D (기본 모두 활성)
   - 2행: V2 / G2 / D2 / S1 / S2 (기본 비활성)
3. **세션 구성 위치**: 추천자 의견 위로 이동.

## 검증
- pnpm typecheck / lint / test 통과 (61 passed)

Closes #162