### PR TITLE
feat: 세션 프리셋 재배치 + G/G1 동적 표시 + 커스텀 10자 + 곡 추가 버튼 이동

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -139,36 +139,24 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
     <div className="relative flex h-full">
       <div className="flex min-w-0 flex-1 flex-col">
         <header className="border-border px-s-5 py-s-4 border-b">
-          <div className="gap-s-3 flex items-start justify-between">
-            <div className="min-w-0">
-              <div className="text-accent text-caption font-semibold">{meeting.bandName}</div>
-              <h1 className="text-title-lg mt-s-1 font-bold">{meeting.title}</h1>
-              <div className="text-foreground-muted text-caption gap-s-3 mt-s-2 flex flex-wrap items-center">
-                <span>
-                  전체 <strong className="text-foreground">{stats.total}</strong>곡
-                </span>
-                <span className="text-success">
-                  합주 가능 <strong>{stats.ready}</strong>
-                </span>
-                <span className="text-warn">
-                  모집 중 <strong>{stats.pending}</strong>
-                </span>
-              </div>
+          <div className="min-w-0">
+            <div className="text-accent text-caption font-semibold">{meeting.bandName}</div>
+            <h1 className="text-title-lg mt-s-1 font-bold">{meeting.title}</h1>
+            <div className="text-foreground-muted text-caption gap-s-3 mt-s-2 flex flex-wrap items-center">
+              <span>
+                전체 <strong className="text-foreground">{stats.total}</strong>곡
+              </span>
+              <span className="text-success">
+                합주 가능 <strong>{stats.ready}</strong>
+              </span>
+              <span className="text-warn">
+                모집 중 <strong>{stats.pending}</strong>
+              </span>
             </div>
-            {isManager && (
-              <AddSongModal
-                meetingId={meetingId}
-                trigger={
-                  <Button size="sm" variant="accent-outline" aria-label="새 곡 추가">
-                    <Plus className="h-4 w-4" /> 곡 추가
-                  </Button>
-                }
-              />
-            )}
           </div>
 
-          {/* 필터 탭 + 검색을 같은 라인 좌측에 인라인 배치 — 우측 380px 오버레이가 검색을 가리지 않도록. */}
-          <div className="gap-s-3 mt-s-4 flex flex-col items-stretch md:flex-row md:items-center">
+          {/* 필터 탭 + 검색 + '곡 추가'(매니저) 를 같은 라인에 — 사용자가 표 바로 위에서 즉시 곡을 추가할 수 있도록. */}
+          <div className="gap-s-3 mt-s-4 flex flex-col items-stretch md:flex-row md:flex-wrap md:items-center">
             <Tabs value={filter} onValueChange={(v) => setFilter(v as Filter)}>
               <TabsList>
                 <TabsTrigger value="all">전체</TabsTrigger>
@@ -199,6 +187,18 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
                 className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
               />
             </div>
+            {isManager && (
+              <div className="md:ml-auto">
+                <AddSongModal
+                  meetingId={meetingId}
+                  trigger={
+                    <Button size="sm" variant="primary" aria-label="새 곡 추가">
+                      <Plus className="h-4 w-4" /> 곡 추가
+                    </Button>
+                  }
+                />
+              </div>
+            )}
           </div>
         </header>
 

--- a/src/domain/setlist-meeting/components/AddSongModal.client.tsx
+++ b/src/domain/setlist-meeting/components/AddSongModal.client.tsx
@@ -30,7 +30,7 @@ export interface AddSongModalProps {
   trigger: ReactNode;
 }
 
-/** 표준 프리셋. 1행: 기본 4세션, 2행: 보조/멀티 세션. */
+/** 표준 프리셋. 1행: 기본 + G2, 2행: 보조/멀티 세션. */
 const PRESETS: Record<string, SessionDef> = {
   V: { id: 'V', label: '보컬', short: 'V', need: 1 },
   G: { id: 'G', label: '기타', short: 'G', need: 1 },
@@ -38,17 +38,35 @@ const PRESETS: Record<string, SessionDef> = {
   D: { id: 'D', label: '드럼', short: 'D', need: 1 },
   V2: { id: 'V2', label: '보컬2', short: 'V2', need: 1 },
   G2: { id: 'G2', label: '기타2', short: 'G2', need: 1 },
+  G3: { id: 'G3', label: '기타3', short: 'G3', need: 1 },
   D2: { id: 'D2', label: '드럼2', short: 'D2', need: 1 },
   S1: { id: 'S1', label: '신스1', short: 'S1', need: 1 },
   S2: { id: 'S2', label: '신스2', short: 'S2', need: 1 },
 };
 
 const PRESET_ROWS: ReadonlyArray<ReadonlyArray<string>> = [
-  ['V', 'G', 'B', 'D'],
-  ['V2', 'G2', 'D2', 'S1', 'S2'],
+  ['V', 'G', 'G2', 'B', 'D'],
+  ['V2', 'G3', 'D2', 'S1', 'S2'],
 ];
 
-/** 모달 오픈 시 기본 활성화되는 프리셋 — 1행 전체. */
+/**
+ * 곡 표/패널 노출 시 항상 따라야 하는 표준 순서. V → V2 → G → G2 → G3 → B → D → D2 → S1 → S2.
+ * 사용자가 토글하는 순서와 무관하게 안정적으로 표시되도록.
+ */
+const CANONICAL_ORDER: ReadonlyArray<string> = [
+  'V',
+  'V2',
+  'G',
+  'G2',
+  'G3',
+  'B',
+  'D',
+  'D2',
+  'S1',
+  'S2',
+];
+
+/** 모달 오픈 시 기본 활성화되는 프리셋. */
 const DEFAULT_ACTIVE_PRESETS: ReadonlyArray<string> = ['V', 'G', 'B', 'D'];
 
 /** 0~99 범위의 숫자 두자리로 정규화. 빈 문자열은 그대로 두고, 화면에 표시할 때 padStart. */
@@ -99,28 +117,32 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
     );
 
-  // 활성 프리셋 + 커스텀 결합. 출력 순서는 PRESET_ROWS 정의 순서를 따라 안정적으로 유지.
+  // 활성 프리셋 + 커스텀 결합. 표시 순서는 CANONICAL_ORDER 를 따라 토글 순서와 무관하게 안정.
   const composedSessions = useMemo<SessionDef[]>(() => {
     const ordered: SessionDef[] = [];
-    for (const row of PRESET_ROWS) {
-      for (const id of row) {
-        if (activePresetIds.includes(id)) ordered.push(PRESETS[id]!);
-      }
+    for (const id of CANONICAL_ORDER) {
+      if (activePresetIds.includes(id)) ordered.push(PRESETS[id]!);
     }
     return [...ordered, ...extras];
   }, [activePresetIds, extras]);
 
   const addExtra = () => {
-    const raw = extraDraft.trim().toUpperCase();
-    if (!raw) return;
-    const cleaned = raw.replace(/[^A-Z]/g, '');
+    const cleaned = extraDraft
+      .trim()
+      .toUpperCase()
+      .replace(/[^A-Z]/g, '');
     if (!cleaned) return;
     const id = `X_${cleaned}`;
-    if (composedSessions.some((s) => s.id === id || s.short === cleaned)) {
+    const short = cleaned.slice(0, 2);
+    if (composedSessions.some((s) => s.id === id || s.short === short || s.label === cleaned)) {
       toast.warn('이미 같은 라벨의 세션이 있습니다.');
       return;
     }
-    setExtras((prev) => [...prev, { id, label: cleaned, short: cleaned, need: 1, custom: true }]);
+    setExtras((prev) => [
+      ...prev,
+      // label: 사용자가 입력한 풀텍스트(대문자), short: 표시용 앞 2자.
+      { id, label: cleaned, short, need: 1, custom: true },
+    ]);
     setExtraDraft('');
   };
 
@@ -254,28 +276,30 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
                 </div>
 
                 {/* 커스텀 세션 추가 — 영문 알파벳만 허용 */}
-                <div className="gap-s-2 mt-s-3 flex">
-                  <Input
-                    value={extraDraft}
-                    onChange={(e) =>
-                      setExtraDraft(
-                        e.target.value
-                          .toUpperCase()
-                          .replace(/[^A-Z]/g, '')
-                          .slice(0, 4),
-                      )
-                    }
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault();
-                        addExtra();
+                <div className="gap-s-2 mt-s-3 flex items-end">
+                  <div className="flex-1">
+                    <Input
+                      value={extraDraft}
+                      onChange={(e) =>
+                        // 대/소문자 자유 입력 → toUpperCase 로 저장. A-Z 외 문자는 차단. 최대 10자.
+                        setExtraDraft(
+                          e.target.value
+                            .toUpperCase()
+                            .replace(/[^A-Z]/g, '')
+                            .slice(0, 10),
+                        )
                       }
-                    }}
-                    placeholder="커스텀 라벨 (영문 알파벳만, 최대 4자)"
-                    autoCapitalize="characters"
-                    autoComplete="off"
-                    pattern="[A-Za-z]*"
-                  />
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          addExtra();
+                        }
+                      }}
+                      placeholder="커스텀 세션 라벨 (영문 최대 10자, 표시는 앞 2자)"
+                      autoComplete="off"
+                      maxLength={10}
+                    />
+                  </div>
                   <Button
                     type="button"
                     variant="secondary"

--- a/src/domain/setlist-meeting/components/SessionPanel.client.tsx
+++ b/src/domain/setlist-meeting/components/SessionPanel.client.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/cn';
 
 import { useSetlistStore } from '../store/setlistStore';
 import type { Member, SessionDef, Song } from '../types';
-import { findSession, missingCount, sessionState } from '../utils';
+import { displaySessionShort, findSession, missingCount, sessionState } from '../utils';
 import { useToast } from '@/hooks/useToast';
 
 import { MemberAvatar } from './MemberAvatar';
@@ -186,7 +186,7 @@ function OverviewSessionView({
                         : 'border-border text-foreground-muted',
                   )}
                 >
-                  {s.short}
+                  {displaySessionShort(s, song.sessions)}
                 </span>
                 <div className="min-w-0 flex-1 text-left">
                   {/* 1행: 라벨 + 우측 경쟁률 칩 */}

--- a/src/domain/setlist-meeting/components/SessionTrack.tsx
+++ b/src/domain/setlist-meeting/components/SessionTrack.tsx
@@ -14,6 +14,8 @@ export interface SessionTrackProps {
   mine: boolean;
   /** 멤버 검색 매칭 — 빨간 점 표시. */
   highlighted?: boolean;
+  /** 표시용 약어. 생략 시 session.short 그대로. (예: G/G2 동시 존재 시 'G1' 로 변환된 값을 부모가 전달) */
+  displayShort?: string;
   /** 생략 시 비-인터랙티브 div 로 렌더(메인 행에서는 클릭 동작 없이 시각 표기만). */
   onClick?: () => void;
 }
@@ -39,6 +41,7 @@ export function SessionTrack({
   active,
   mine,
   highlighted = false,
+  displayShort,
   onClick,
 }: SessionTrackProps) {
   const state = sessionState(confirmed, session.need);
@@ -63,7 +66,7 @@ export function SessionTrack({
           labelTone[tone],
         )}
       >
-        {session.short}
+        {displayShort ?? session.short}
       </span>
       <span className="bg-border relative block h-0.5 overflow-hidden rounded-[1px]">
         <span

--- a/src/domain/setlist-meeting/components/SongTable.client.tsx
+++ b/src/domain/setlist-meeting/components/SongTable.client.tsx
@@ -5,7 +5,7 @@ import { Check, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/cn';
 
 import type { Member, Song } from '../types';
-import { confirmedCount, isReady, totalNeed } from '../utils';
+import { confirmedCount, displaySessionShort, isReady, totalNeed } from '../utils';
 
 import { SessionTrack } from './SessionTrack';
 
@@ -131,6 +131,7 @@ export function SongTable({
                           active={false}
                           mine={apps.includes(currentUserId)}
                           highlighted={highlighted}
+                          displayShort={displaySessionShort(s, song.sessions)}
                         />
                       );
                     })}

--- a/src/domain/setlist-meeting/utils.ts
+++ b/src/domain/setlist-meeting/utils.ts
@@ -26,3 +26,19 @@ export function isReady(song: Song): boolean {
 export function findSession(song: Song, sessionId: string): SessionDef | undefined {
   return song.sessions.find((s) => s.id === sessionId);
 }
+
+/**
+ * 곡 내에서 보여줄 세션 약어. 같은 패밀리(V↔V2, G↔G2, D↔D2)가 함께 있으면
+ * 기본 세션을 'V1' / 'G1' / 'D1' 로 표기해 시각적 짝을 맞춘다. 단일이면 'V'/'G'/'D' 유지.
+ */
+export function displaySessionShort(session: SessionDef, all: SessionDef[]): string {
+  const pairs: Array<[string, string]> = [
+    ['V', 'V2'],
+    ['G', 'G2'],
+    ['D', 'D2'],
+  ];
+  for (const [base, sibling] of pairs) {
+    if (session.id === base && all.some((s) => s.id === sibling)) return `${base}1`;
+  }
+  return session.short;
+}


### PR DESCRIPTION
## 변경
1. **프리셋 행 재배치 + G3 신설**:
   - 1행: V / G / G2 / B / D
   - 2행: V2 / G3 / D2 / S1 / S2
2. **표시 순서 안정화**: `CANONICAL_ORDER` (V/V2/G/G2/G3/B/D/D2/S1/S2) 로 결합 → 토글 순서와 무관.
3. **G/V/D 동적 약어**: 곡에 V+V2 / G+G2 / D+D2 둘 다 있으면 기본을 V1/G1/D1 로 표기, 단일이면 V/G/D 그대로. `displaySessionShort` 헬퍼 신설, SongTable / SessionPanel 적용.
4. **커스텀 라벨**: 입력은 영문 대/소문자 자유, 저장은 toUpperCase, 최대 10자. 표시용 short 는 앞 2자.
5. **곡 추가 버튼 이동**: 헤더 우상단 → 필터/검색 라인 우측으로 (사용자가 표 위에서 즉시 추가 가능).

## 검증
- pnpm typecheck / lint / test 통과 (61 passed)

Closes #164