### PR TITLE
feat: 곡 수정 + 커스텀 삭제 다이얼로그 + 컬럼 정렬 + 채팅 staggered exit

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -4,14 +4,19 @@ import { PanelRightOpen, Plus, Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AddSongModal } from '@/domain/setlist-meeting/components/AddSongModal.client';
 import { MeetingChatBox } from '@/domain/setlist-meeting/components/MeetingChatBox.client';
 import { SessionPanel } from '@/domain/setlist-meeting/components/SessionPanel.client';
-import { SongTable } from '@/domain/setlist-meeting/components/SongTable.client';
+import {
+  SongTable,
+  type SongSortDir,
+  type SongSortKey,
+} from '@/domain/setlist-meeting/components/SongTable.client';
 import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
 import type { Song } from '@/domain/setlist-meeting/types';
-import { isReady } from '@/domain/setlist-meeting/utils';
+import { confirmedCount, isReady, totalNeed } from '@/domain/setlist-meeting/utils';
 import { cn } from '@/lib/cn';
 
 type Filter = 'all' | 'ready' | 'pending' | 'mine';
@@ -68,10 +73,38 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
   const [memberQuery, setMemberQuery] = useState('');
   // 우측 세션 패널 토글. 곡을 새로 선택하면 자동 열림.
   const [sessionPanelOpen, setSessionPanelOpen] = useState(false);
+  // 컬럼 정렬 — 재생시간 / 세션 모집 현황. 동일 컬럼 재클릭 시 asc↔desc 토글.
+  const [sortKey, setSortKey] = useState<SongSortKey | null>(null);
+  const [sortDir, setSortDir] = useState<SongSortDir>('asc');
+  // 곡 수정 / 삭제 다이얼로그 상태.
+  const [editingSong, setEditingSong] = useState<Song | null>(null);
+  const [pendingDeleteSong, setPendingDeleteSong] = useState<Song | null>(null);
+  // 채팅 영역 staggered exit — 우측 패널이 먼저 슬라이드 아웃, 채팅은 75ms 늦게.
+  const [chatRendered, setChatRendered] = useState(false);
+  const [chatExiting, setChatExiting] = useState(false);
 
   useEffect(() => {
     setSelectedMeeting(meetingId);
   }, [meetingId, setSelectedMeeting]);
+
+  // 채팅 mount/unmount 와 transition 클래스 제어.
+  // - 열릴 때: 즉시 렌더 + translate-y-0 으로 등장(스냅)
+  // - 닫힐 때: chatExiting=true → translate-y-full + delay-75 로 우측 패널 보다 늦게 슬라이드 다운 → 그 후 unmount
+  useEffect(() => {
+    if (sessionPanelOpen && selectedSongId) {
+      setChatExiting(false);
+      setChatRendered(true);
+      return;
+    }
+    if (chatRendered) {
+      setChatExiting(true);
+      const t = setTimeout(() => {
+        setChatRendered(false);
+        setChatExiting(false);
+      }, 280);
+      return () => clearTimeout(t);
+    }
+  }, [sessionPanelOpen, selectedSongId, chatRendered]);
 
   const stats = useMemo(() => {
     const total = allSongs.length;
@@ -86,7 +119,7 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
     return new Set(members.filter((m) => m.name.toLowerCase().includes(t)).map((m) => m.id));
   }, [members, memberQuery]);
 
-  const visible = useMemo(() => {
+  const filtered = useMemo(() => {
     let result = applySearch(applyFilter(allSongs, filter, currentUserId), query);
     if (matchedUserIds.size > 0) {
       // 곡 필터 + 멤버 필터 AND: 매칭 유저가 어떤 세션이든 들어있는 곡만.
@@ -98,6 +131,35 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
     }
     return result;
   }, [allSongs, filter, currentUserId, query, matchedUserIds]);
+
+  // 컬럼 정렬 적용. progress = confirmed/totalNeed 비율, duration = mm*60+ss 초.
+  const visible = useMemo(() => {
+    if (!sortKey) return filtered;
+    const score = (s: Song): number => {
+      if (sortKey === 'duration') {
+        if (!s.duration) return Number.NEGATIVE_INFINITY;
+        const m = s.duration.match(/^(\d{1,2}):(\d{2})$/);
+        if (!m) return Number.NEGATIVE_INFINITY;
+        return parseInt(m[1]!, 10) * 60 + parseInt(m[2]!, 10);
+      }
+      const total = totalNeed(s);
+      return total === 0 ? 0 : confirmedCount(s) / total;
+    };
+    return [...filtered].sort((a, b) => {
+      const av = score(a);
+      const bv = score(b);
+      return sortDir === 'asc' ? av - bv : bv - av;
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  const handleToggleSort = (key: SongSortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
 
   // ↑/↓ 키보드 네비게이션 — 입력 필드 포커스 시에는 무시. 이동 시 focusedSession 정리(overview 모드).
   useEffect(() => {
@@ -210,6 +272,9 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
             currentUserId={currentUserId}
             isManager={isManager}
             matchedUserIds={matchedUserIds}
+            sortKey={sortKey}
+            sortDir={sortDir}
+            onToggleSort={handleToggleSort}
             onSelectSong={(id) => {
               // 메인 행 클릭은 항상 overview 모드로 진입. 세션 focus 는 우측 패널에서만.
               if (id === selectedSongId) {
@@ -220,13 +285,24 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
               setFocusedSession(null);
               setSessionPanelOpen(true);
             }}
-            onDeleteSong={(id) => deleteSong(id)}
+            onEditSong={(id) => {
+              const s = visible.find((x) => x.id === id);
+              if (s) setEditingSong(s);
+            }}
+            onDeleteSong={(id) => {
+              const s = visible.find((x) => x.id === id);
+              if (s) setPendingDeleteSong(s);
+            }}
           />
         </div>
-        {/* 메인 컬럼 하단 채팅 — 우측 패널과 sessionPanelOpen 으로 동기 토글.
-            우측 absolute 패널(z-20)보다 위에 보이도록 relative z-30. */}
-        {selectedSongId && sessionPanelOpen && (
-          <div className="relative z-30">
+        {/* 메인 컬럼 하단 채팅. 닫힐 때는 staggered exit (우측 패널 먼저, 채팅은 75ms 후). */}
+        {chatRendered && selectedSongId && (
+          <div
+            className={cn(
+              'relative z-30 transition-transform duration-200 ease-out',
+              chatExiting ? 'pointer-events-none translate-y-full delay-75' : 'translate-y-0',
+            )}
+          >
             <MeetingChatBox songId={selectedSongId} />
           </div>
         )}
@@ -259,6 +335,40 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
           <PanelRightOpen className="h-4 w-4" />
         </button>
       )}
+
+      {/* 곡 수정 모달 — 외부에서 open 제어. song 이 있으면 수정 모드로 동작. */}
+      {editingSong && (
+        <AddSongModal
+          meetingId={meetingId}
+          song={editingSong}
+          open={true}
+          onOpenChange={(o) => {
+            if (!o) setEditingSong(null);
+          }}
+        />
+      )}
+
+      {/* 삭제 확인 다이얼로그 — 브라우저 기본 confirm 대신 디자인 토큰 적용. */}
+      <ConfirmDialog
+        open={pendingDeleteSong !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingDeleteSong(null);
+        }}
+        title="곡 삭제"
+        description={
+          pendingDeleteSong ? (
+            <>
+              <strong className="text-foreground">{pendingDeleteSong.title}</strong> 곡을 정말
+              삭제하시겠습니까? 지원/확정 정보도 함께 사라집니다.
+            </>
+          ) : null
+        }
+        confirmLabel="삭제"
+        tone="danger"
+        onConfirm={() => {
+          if (pendingDeleteSong) deleteSong(pendingDeleteSong.id);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { type ReactNode } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { Button } from './button';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './dialog';
+
+export type ConfirmDialogTone = 'primary' | 'danger';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: ReactNode;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  tone?: ConfirmDialogTone;
+  /** 비동기 처리도 가능. 반환값 무관하게 다이얼로그는 닫힘. */
+  onConfirm: () => void | Promise<void>;
+}
+
+/**
+ * 브라우저 기본 confirm 대신 사용하는 디자인 토큰 적용 확인 다이얼로그.
+ * tone='danger' 일 때 confirm 버튼이 위험 색(danger) 으로 강조됨.
+ */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = '확인',
+  cancelLabel = '취소',
+  tone = 'primary',
+  onConfirm,
+}: ConfirmDialogProps) {
+  const handleConfirm = async () => {
+    await onConfirm();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent srOnlyTitle={typeof title === 'string' ? title : '확인'}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {description && (
+          <DialogBody>
+            <p className="text-foreground-sub text-caption leading-relaxed">{description}</p>
+          </DialogBody>
+        )}
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            onClick={handleConfirm}
+            className={cn(tone === 'danger' && 'bg-danger hover:bg-danger/90 text-white')}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/domain/setlist-meeting/components/AddSongModal.client.tsx
+++ b/src/domain/setlist-meeting/components/AddSongModal.client.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus, X } from 'lucide-react';
-import { useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
@@ -22,12 +22,17 @@ import { cn } from '@/lib/cn';
 import { useToast } from '@/hooks/useToast';
 
 import { useSetlistStore } from '../store/setlistStore';
-import type { SessionDef } from '../types';
+import type { SessionDef, Song } from '../types';
 import { addSongSchema, type AddSongSchema } from '../types/schema';
 
 export interface AddSongModalProps {
   meetingId: string;
-  trigger: ReactNode;
+  /** 제공 시 수정 모드. 기존 곡 데이터로 폼이 사전 채움된다. */
+  song?: Song;
+  /** 외부에서 open 상태를 제어하고 싶을 때(수정 모드 사용 시 권장). */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  trigger?: ReactNode;
 }
 
 /** 표준 프리셋. 1행: 기본 + G2, 2행: 보조/멀티 세션. */
@@ -83,33 +88,105 @@ function formatDuration(mm: string, ss: string): string {
   return `${m}:${s}`;
 }
 
-export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
-  const [open, setOpen] = useState(false);
-  // 활성화된 프리셋 id 집합. 토글로 켜고 끔.
-  const [activePresetIds, setActivePresetIds] =
-    useState<ReadonlyArray<string>>(DEFAULT_ACTIVE_PRESETS);
-  const [extras, setExtras] = useState<SessionDef[]>([]);
+/** 'mm:ss' → {mm,ss} 분리. 미지정/포맷 오류 시 빈 문자열. */
+function parseDuration(d?: string): { mm: string; ss: string } {
+  if (!d) return { mm: '', ss: '' };
+  const m = d.match(/^(\d{1,2}):(\d{2})$/);
+  if (!m) return { mm: '', ss: '' };
+  return { mm: String(parseInt(m[1]!, 10)), ss: String(parseInt(m[2]!, 10)) };
+}
+
+/** 곡의 세션 배열에서 PRESETS 에 속한 활성 id 와 커스텀 extras 분리. */
+function splitSessions(sessions: SessionDef[]): {
+  activeIds: ReadonlyArray<string>;
+  extras: SessionDef[];
+} {
+  const activeIds: string[] = [];
+  const extras: SessionDef[] = [];
+  for (const s of sessions) {
+    if (s.id in PRESETS) activeIds.push(s.id);
+    else extras.push(s);
+  }
+  return { activeIds, extras };
+}
+
+export function AddSongModal({
+  meetingId,
+  song,
+  open: controlledOpen,
+  onOpenChange,
+  trigger,
+}: AddSongModalProps) {
+  const isEdit = !!song;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (v: boolean) => {
+    if (onOpenChange) onOpenChange(v);
+    else setInternalOpen(v);
+  };
+
+  // 초기 상태 계산 — 수정 모드면 song 으로부터, 아니면 디폴트.
+  const initial = useMemo(() => {
+    if (song) {
+      const split = splitSessions(song.sessions);
+      const dur = parseDuration(song.duration);
+      return {
+        activeIds: split.activeIds,
+        extras: split.extras,
+        durationMm: dur.mm,
+        durationSs: dur.ss,
+        formValues: {
+          title: song.title,
+          artist: song.artist,
+          album: song.album ?? '',
+          note: song.note ?? '',
+        },
+      };
+    }
+    return {
+      activeIds: DEFAULT_ACTIVE_PRESETS,
+      extras: [] as SessionDef[],
+      durationMm: '',
+      durationSs: '',
+      formValues: { title: '', artist: '', album: '', note: '' } as AddSongSchema,
+    };
+  }, [song]);
+
+  const [activePresetIds, setActivePresetIds] = useState<ReadonlyArray<string>>(initial.activeIds);
+  const [extras, setExtras] = useState<SessionDef[]>(initial.extras);
   const [extraDraft, setExtraDraft] = useState('');
-  // 재생 시간 — 분/초 분리 입력. 기본 '00:00'.
-  const [durationMm, setDurationMm] = useState('');
-  const [durationSs, setDurationSs] = useState('');
+  const [durationMm, setDurationMm] = useState(initial.durationMm);
+  const [durationSs, setDurationSs] = useState(initial.durationSs);
   const addSong = useSetlistStore((s) => s.addSong);
+  const updateSong = useSetlistStore((s) => s.updateSong);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
   const toast = useToast();
 
   const form = useForm<AddSongSchema>({
     resolver: zodResolver(addSongSchema),
-    defaultValues: { title: '', artist: '', album: '', note: '' },
+    defaultValues: initial.formValues,
     mode: 'onTouched',
   });
 
-  const reset = () => {
-    form.reset();
-    setActivePresetIds(DEFAULT_ACTIVE_PRESETS);
-    setExtras([]);
+  // 모달이 열릴 때, 또는 song 이 변경될 때(다른 곡 수정으로 전환) 폼/세션 상태를 initial 로 동기화.
+  useEffect(() => {
+    if (!open) return;
+    setActivePresetIds(initial.activeIds);
+    setExtras(initial.extras);
     setExtraDraft('');
-    setDurationMm('');
-    setDurationSs('');
+    setDurationMm(initial.durationMm);
+    setDurationSs(initial.durationSs);
+    form.reset(initial.formValues);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- initial 은 song 변경 시에만 갱신됨
+  }, [open, initial]);
+
+  const reset = () => {
+    form.reset(initial.formValues);
+    setActivePresetIds(initial.activeIds);
+    setExtras(initial.extras);
+    setExtraDraft('');
+    setDurationMm(initial.durationMm);
+    setDurationSs(initial.durationSs);
   };
 
   const togglePreset = (id: string) =>
@@ -156,16 +233,21 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
       return;
     }
     const duration = formatDuration(durationMm, durationSs);
-    addSong(meetingId, {
+    const payload = {
       title: values.title,
       artist: values.artist,
       album: values.album,
       duration: duration === '00:00' ? undefined : duration,
       note: values.note,
-      proposerId: currentUserId,
       sessions: composedSessions,
-    });
-    toast.success('곡이 추가되었습니다.');
+    };
+    if (song) {
+      updateSong(song.id, payload);
+      toast.success('곡 정보가 수정되었습니다.');
+    } else {
+      addSong(meetingId, { ...payload, proposerId: currentUserId });
+      toast.success('곡이 추가되었습니다.');
+    }
     setOpen(false);
     reset();
   });
@@ -178,10 +260,10 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
         if (!v) reset();
       }}
     >
-      <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>
+      {trigger && <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>}
       <ResponsiveSheetContent>
         <ResponsiveSheetHeader>
-          <ResponsiveSheetTitle>곡 추가</ResponsiveSheetTitle>
+          <ResponsiveSheetTitle>{isEdit ? '곡 수정' : '곡 추가'}</ResponsiveSheetTitle>
         </ResponsiveSheetHeader>
         <form onSubmit={onSubmit}>
           <ResponsiveSheetBody>
@@ -352,7 +434,7 @@ export function AddSongModal({ meetingId, trigger }: AddSongModalProps) {
               </Button>
             </ResponsiveSheetClose>
             <Button type="submit" variant="primary" disabled={!canSubmit}>
-              곡 추가
+              {isEdit ? '저장' : '곡 추가'}
             </Button>
           </ResponsiveSheetFooter>
         </form>

--- a/src/domain/setlist-meeting/components/SongTable.client.tsx
+++ b/src/domain/setlist-meeting/components/SongTable.client.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { Check, Trash2 } from 'lucide-react';
+import { ArrowDown, ArrowUp, ArrowUpDown, Check, Pencil, Trash2 } from 'lucide-react';
 
 import { cn } from '@/lib/cn';
 
 import type { Member, Song } from '../types';
 import { confirmedCount, displaySessionShort, isReady, totalNeed } from '../utils';
+
+export type SongSortKey = 'progress' | 'duration';
+export type SongSortDir = 'asc' | 'desc';
 
 import { SessionTrack } from './SessionTrack';
 
@@ -14,16 +17,30 @@ export interface SongTableProps {
   members: Member[];
   selectedSongId: string | null;
   currentUserId: string;
-  /** true 이면 모든 곡에 삭제 버튼 노출(매니저). false 이면 본인이 제안한 곡만. */
+  /** true 이면 모든 곡에 삭제/수정 버튼 노출(매니저). false 이면 본인이 제안한 곡만. */
   isManager?: boolean;
   /** 멤버 검색 매칭 결과 — 해당 userId 가 속한 세션에 빨간 점 표시. */
   matchedUserIds?: ReadonlySet<string>;
+  /** 정렬 상태(부모에서 관리). null 이면 원본 순서. */
+  sortKey?: SongSortKey | null;
+  sortDir?: SongSortDir;
+  onToggleSort?: (key: SongSortKey) => void;
   onSelectSong: (songId: string) => void;
+  onEditSong?: (songId: string) => void;
   onDeleteSong?: (songId: string) => void;
 }
 
 function memberName(members: Member[], id: string): string {
   return members.find((m) => m.id === id)?.name ?? '?';
+}
+
+function SortIcon({ active, dir }: { active: boolean; dir: SongSortDir }) {
+  if (!active) return <ArrowUpDown className="text-foreground-muted ml-s-1 inline h-3 w-3" />;
+  return dir === 'asc' ? (
+    <ArrowUp className="text-accent ml-s-1 inline h-3 w-3" />
+  ) : (
+    <ArrowDown className="text-accent ml-s-1 inline h-3 w-3" />
+  );
 }
 
 export function SongTable({
@@ -33,7 +50,11 @@ export function SongTable({
   currentUserId,
   isManager = false,
   matchedUserIds,
+  sortKey = null,
+  sortDir = 'asc',
+  onToggleSort,
   onSelectSong,
+  onEditSong,
   onDeleteSong,
 }: SongTableProps) {
   if (songs.length === 0) {
@@ -57,17 +78,43 @@ export function SongTable({
             <th className="px-s-3 py-s-2 hidden font-semibold tracking-wider lg:table-cell">
               앨범
             </th>
-            <th className="px-s-3 py-s-2 pr-s-5 hidden w-20 text-right font-semibold tracking-wider md:table-cell">
-              재생 시간
+            <th className="px-s-3 py-s-2 pr-s-5 hidden w-24 text-right font-semibold tracking-wider md:table-cell">
+              {onToggleSort ? (
+                <button
+                  type="button"
+                  onClick={() => onToggleSort('duration')}
+                  className="hover:text-foreground inline-flex items-center font-semibold tracking-wider uppercase"
+                  aria-label="재생 시간 정렬"
+                >
+                  재생 시간
+                  <SortIcon active={sortKey === 'duration'} dir={sortDir} />
+                </button>
+              ) : (
+                <>재생 시간</>
+              )}
             </th>
             <th className="px-s-3 py-s-2 pl-s-4 min-w-[160px] font-semibold tracking-wider">
               세션
             </th>
-            <th className="px-s-3 py-s-2 w-28 text-right font-semibold tracking-wider">진행도</th>
+            <th className="px-s-3 py-s-2 w-36 text-right font-semibold tracking-wider">
+              {onToggleSort ? (
+                <button
+                  type="button"
+                  onClick={() => onToggleSort('progress')}
+                  className="hover:text-foreground inline-flex items-center font-semibold tracking-wider uppercase"
+                  aria-label="세션 모집 현황 정렬"
+                >
+                  세션 모집 현황
+                  <SortIcon active={sortKey === 'progress'} dir={sortDir} />
+                </button>
+              ) : (
+                <>세션 모집 현황</>
+              )}
+            </th>
             <th className="px-s-3 py-s-2 hidden font-semibold tracking-wider lg:table-cell">
               추천자 의견
             </th>
-            <th className="px-s-3 py-s-2 w-10" aria-label="삭제" />
+            <th className="px-s-3 py-s-2 w-20" aria-label="작업" />
           </tr>
         </thead>
         <tbody>
@@ -142,7 +189,7 @@ export function SongTable({
                 <td className="px-s-3 py-s-2 align-middle">
                   <div className="gap-s-2 flex items-center justify-end">
                     <div
-                      className="bg-card border-border h-1.5 w-12 overflow-hidden rounded-full border"
+                      className="bg-card border-border h-1.5 w-20 overflow-hidden rounded-full border"
                       role="progressbar"
                       aria-valuenow={pct}
                       aria-valuemin={0}
@@ -170,22 +217,54 @@ export function SongTable({
                     <span className="text-foreground-muted">-</span>
                   )}
                 </td>
-                <td className="px-s-3 py-s-2 text-right align-middle">
-                  {(isManager || song.proposerId === currentUserId) && onDeleteSong && (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (window.confirm(`'${song.title}' 을 삭제하시겠습니까?`)) {
-                          onDeleteSong(song.id);
-                        }
-                      }}
-                      aria-label={`${song.title} 삭제`}
-                      className="text-foreground-muted hover:bg-danger-dim hover:text-danger inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
-                  )}
+                <td className="px-s-3 py-s-2 align-middle">
+                  {(() => {
+                    const canMutate = isManager || song.proposerId === currentUserId;
+                    if (!canMutate) return null;
+                    // 확정된 곡(모든 세션이 정원만큼 확정)은 수정 비활성 — 확정자 데이터 보호.
+                    const editLocked = ready;
+                    return (
+                      <div className="gap-s-1 flex items-center justify-end">
+                        {onEditSong && (
+                          <button
+                            type="button"
+                            disabled={editLocked}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onEditSong(song.id);
+                            }}
+                            aria-label={
+                              editLocked
+                                ? `${song.title} 수정 불가 (확정 완료)`
+                                : `${song.title} 수정`
+                            }
+                            title={editLocked ? '확정된 곡은 수정할 수 없습니다.' : '곡 수정'}
+                            className={cn(
+                              'inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors',
+                              editLocked
+                                ? 'text-foreground-muted/40 cursor-not-allowed'
+                                : 'text-foreground-muted hover:bg-accent-dim hover:text-accent',
+                            )}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                        {onDeleteSong && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onDeleteSong(song.id);
+                            }}
+                            aria-label={`${song.title} 삭제`}
+                            className="text-foreground-muted hover:bg-danger-dim hover:text-danger inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })()}
                 </td>
               </tr>
             );

--- a/src/domain/setlist-meeting/store/setlistStore.ts
+++ b/src/domain/setlist-meeting/store/setlistStore.ts
@@ -43,6 +43,12 @@ type Actions = {
     },
   ) => string;
   deleteSong: (songId: string) => void;
+  updateSong: (
+    songId: string,
+    patch: Partial<Pick<Song, 'title' | 'artist' | 'album' | 'duration' | 'note'>> & {
+      sessions?: SessionDef[];
+    },
+  ) => void;
   addCustomSession: (songId: string, session: SessionDef) => void;
   addMeeting: (meeting: Omit<Meeting, 'id' | 'createdAt' | 'updatedAt'>) => string;
   /** 테스트/디버그용. seed 로 되돌림. */
@@ -171,6 +177,28 @@ export const useSetlistStore = create<SetlistStore>()(
           // 삭제 곡이 현재 선택 상태였다면 선택 해제.
           selectedSongId: state.selectedSongId === songId ? null : state.selectedSongId,
           focusedSessionId: state.selectedSongId === songId ? null : state.focusedSessionId,
+        })),
+
+      updateSong: (songId, patch) =>
+        set((state) => ({
+          songs: state.songs.map((s) => {
+            if (s.id !== songId) return s;
+            const next: Song = { ...s, ...patch };
+            // 세션 목록이 변경된 경우 applicants/confirmed 버킷을 새 세션 기준으로 재정렬:
+            // - 새로 추가된 세션은 빈 배열로 초기화
+            // - 제거된 세션은 데이터도 함께 정리 (확정자 데이터 유실 — 호출 측에서 사전 검증)
+            if (patch.sessions) {
+              const applicants: Record<string, string[]> = {};
+              const confirmed: Record<string, string[]> = {};
+              for (const sess of patch.sessions) {
+                applicants[sess.id] = s.applicants[sess.id] ?? [];
+                confirmed[sess.id] = s.confirmed[sess.id] ?? [];
+              }
+              next.applicants = applicants;
+              next.confirmed = confirmed;
+            }
+            return next;
+          }),
         })),
 
       addCustomSession: (songId, session) =>


### PR DESCRIPTION
## 변경
### 1. 곡 수정 (제안자/매니저)
- AddSongModal 에 `song?: Song` / `open` / `onOpenChange` prop 추가 → 수정 모드 동작
- 진입 시 폼/세션/duration 사전 채움. 제목과 제출 라벨 분기 (곡 추가 / 곡 수정·저장)
- store.updateSong 액션 추가 (세션 변경 시 applicants/confirmed 버킷 재정렬)
- **확정된 곡(isReady)** 은 수정 버튼 비활성 + 툴팁 안내

### 2. 커스텀 삭제 다이얼로그
- `@/components/ui/confirm-dialog.tsx` 신규 — 디자인 토큰 적용, tone='danger' 지원
- SongTable 의 window.confirm 제거. MeetingDetail 의 `pendingDeleteSong` 으로 다이얼로그 트리거

### 3. 컬럼 정렬
- '진행도' → '세션 모집 현황' 으로 라벨 변경
- '재생 시간' / '세션 모집 현황' 헤더 클릭 시 asc/desc 토글, ▲▼ 아이콘
- progress = confirmed/totalNeed, duration = mm*60+ss

### 4. 채팅 Staggered Exit
- 우측 패널이 먼저 슬라이드 아웃, 채팅은 75ms 후 translate-y-full → 280ms 후 unmount
- chatRendered/chatExiting state 로 mount/unmount + transition 분리 제어

## 검증
- pnpm typecheck / lint / test 통과 (61 passed)

Closes #168