### PR TITLE
feat: 곡 추가 모달 - 직접/검색 탭 + 계속 추가 + Enter 이동 + S 약어 + 패널 시퀀싱

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -79,32 +79,39 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
   // 곡 수정 / 삭제 다이얼로그 상태.
   const [editingSong, setEditingSong] = useState<Song | null>(null);
   const [pendingDeleteSong, setPendingDeleteSong] = useState<Song | null>(null);
-  // 채팅 영역 staggered exit — 우측 패널이 먼저 슬라이드 아웃, 채팅은 75ms 늦게.
-  const [chatRendered, setChatRendered] = useState(false);
-  const [chatExiting, setChatExiting] = useState(false);
+  // 우측 패널 / 하단 채팅 순차 애니메이션:
+  //  - 오픈 시: 채팅이 먼저 슬라이드 업(0~200ms) → 끝나면 우측 패널 슬라이드 인(200~400ms)
+  //  - 닫기 시: 우측 패널이 먼저 슬라이드 아웃(0~200ms) → 끝나면 채팅 슬라이드 다운(200~400ms) → 480ms 후 unmount
+  // 결과: 우측 패널은 항상 채팅이 자리잡은 후에만 보이고, 채팅은 우측 패널이 사라진 후에야 사라짐.
+  const [chatMounted, setChatMounted] = useState(false);
+  const [chatSlideIn, setChatSlideIn] = useState(false);
+  const [panelSlideIn, setPanelSlideIn] = useState(false);
 
   useEffect(() => {
     setSelectedMeeting(meetingId);
   }, [meetingId, setSelectedMeeting]);
 
-  // 채팅 mount/unmount 와 transition 클래스 제어.
-  // - 열릴 때: 즉시 렌더 + translate-y-0 으로 등장(스냅)
-  // - 닫힐 때: chatExiting=true → translate-y-full + delay-75 로 우측 패널 보다 늦게 슬라이드 다운 → 그 후 unmount
   useEffect(() => {
     if (sessionPanelOpen && selectedSongId) {
-      setChatExiting(false);
-      setChatRendered(true);
-      return;
+      // 오픈 시퀀스: 채팅 먼저 → 200ms 후 우측 패널.
+      setChatMounted(true);
+      // 다음 프레임에 translate 클래스 변경(이전 mount 직후 transition 발동).
+      const enter = requestAnimationFrame(() => setChatSlideIn(true));
+      const panelTimer = setTimeout(() => setPanelSlideIn(true), 200);
+      return () => {
+        cancelAnimationFrame(enter);
+        clearTimeout(panelTimer);
+      };
     }
-    if (chatRendered) {
-      setChatExiting(true);
-      const t = setTimeout(() => {
-        setChatRendered(false);
-        setChatExiting(false);
-      }, 280);
-      return () => clearTimeout(t);
-    }
-  }, [sessionPanelOpen, selectedSongId, chatRendered]);
+    // 클로즈 시퀀스: 우측 패널 먼저 → 200ms 후 채팅 슬라이드 다운 → 480ms 후 unmount.
+    setPanelSlideIn(false);
+    const chatOut = setTimeout(() => setChatSlideIn(false), 200);
+    const unmount = setTimeout(() => setChatMounted(false), 480);
+    return () => {
+      clearTimeout(chatOut);
+      clearTimeout(unmount);
+    };
+  }, [sessionPanelOpen, selectedSongId]);
 
   const stats = useMemo(() => {
     const total = allSongs.length;
@@ -295,12 +302,12 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
             }}
           />
         </div>
-        {/* 메인 컬럼 하단 채팅. 닫힐 때는 staggered exit (우측 패널 먼저, 채팅은 75ms 후). */}
-        {chatRendered && selectedSongId && (
+        {/* 메인 컬럼 하단 채팅 — 시퀀싱: 오픈 시 먼저 들어오고, 닫을 때는 우측 패널 후에 나감. */}
+        {chatMounted && selectedSongId && (
           <div
             className={cn(
               'relative z-30 transition-transform duration-200 ease-out',
-              chatExiting ? 'pointer-events-none translate-y-full delay-75' : 'translate-y-0',
+              chatSlideIn ? 'translate-y-0' : 'pointer-events-none translate-y-full',
             )}
           >
             <MeetingChatBox songId={selectedSongId} />
@@ -308,15 +315,13 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
         )}
       </div>
 
-      {/* 우측 오버레이 SessionPanel — 메인 차트 위로 absolute. */}
+      {/* 우측 오버레이 SessionPanel — panelSlideIn 상태로 슬라이드. 채팅이 자리잡은 후에만 보이고 채팅이 사라지기 전에 먼저 빠짐. */}
       {selectedSongId && (
         <aside
-          aria-hidden={!sessionPanelOpen}
-          // 하단 채팅(h-280)과 동시에 열리므로 우측 패널은 채팅 영역을 침범하지 않도록 bottom-[280px].
-          // 패널 body 는 자체 overflow-y-auto 라 작은 뷰포트에서도 자연 스크롤.
+          aria-hidden={!panelSlideIn}
           className={cn(
             'absolute top-0 right-0 bottom-[280px] z-20 hidden shadow-lg transition-transform duration-200 ease-out lg:flex',
-            sessionPanelOpen ? 'translate-x-0' : 'pointer-events-none translate-x-full',
+            panelSlideIn ? 'translate-x-0' : 'pointer-events-none translate-x-full',
           )}
           style={{ width: 380 }}
         >

--- a/src/domain/setlist-meeting/components/AddSongModal.client.tsx
+++ b/src/domain/setlist-meeting/components/AddSongModal.client.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Plus, X } from 'lucide-react';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { Plus, Search, X } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
@@ -29,7 +29,6 @@ export interface AddSongModalProps {
   meetingId: string;
   /** 제공 시 수정 모드. 기존 곡 데이터로 폼이 사전 채움된다. */
   song?: Song;
-  /** 외부에서 open 상태를 제어하고 싶을 때(수정 모드 사용 시 권장). */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   trigger?: ReactNode;
@@ -54,10 +53,6 @@ const PRESET_ROWS: ReadonlyArray<ReadonlyArray<string>> = [
   ['V2', 'G3', 'D2', 'S1', 'S2'],
 ];
 
-/**
- * 곡 표/패널 노출 시 항상 따라야 하는 표준 순서. V → V2 → G → G2 → G3 → B → D → D2 → S1 → S2.
- * 사용자가 토글하는 순서와 무관하게 안정적으로 표시되도록.
- */
 const CANONICAL_ORDER: ReadonlyArray<string> = [
   'V',
   'V2',
@@ -71,10 +66,8 @@ const CANONICAL_ORDER: ReadonlyArray<string> = [
   'S2',
 ];
 
-/** 모달 오픈 시 기본 활성화되는 프리셋. */
 const DEFAULT_ACTIVE_PRESETS: ReadonlyArray<string> = ['V', 'G', 'B', 'D'];
 
-/** 0~99 범위의 숫자 두자리로 정규화. 빈 문자열은 그대로 두고, 화면에 표시할 때 padStart. */
 function clampNumeric(raw: string, max: number): string {
   const digits = raw.replace(/[^0-9]/g, '').slice(0, 2);
   if (digits === '') return '';
@@ -88,7 +81,6 @@ function formatDuration(mm: string, ss: string): string {
   return `${m}:${s}`;
 }
 
-/** 'mm:ss' → {mm,ss} 분리. 미지정/포맷 오류 시 빈 문자열. */
 function parseDuration(d?: string): { mm: string; ss: string } {
   if (!d) return { mm: '', ss: '' };
   const m = d.match(/^(\d{1,2}):(\d{2})$/);
@@ -96,7 +88,6 @@ function parseDuration(d?: string): { mm: string; ss: string } {
   return { mm: String(parseInt(m[1]!, 10)), ss: String(parseInt(m[2]!, 10)) };
 }
 
-/** 곡의 세션 배열에서 PRESETS 에 속한 활성 id 와 커스텀 extras 분리. */
 function splitSessions(sessions: SessionDef[]): {
   activeIds: ReadonlyArray<string>;
   extras: SessionDef[];
@@ -109,6 +100,8 @@ function splitSessions(sessions: SessionDef[]): {
   }
   return { activeIds, extras };
 }
+
+type Mode = 'manual' | 'search';
 
 export function AddSongModal({
   meetingId,
@@ -125,7 +118,6 @@ export function AddSongModal({
     else setInternalOpen(v);
   };
 
-  // 초기 상태 계산 — 수정 모드면 song 으로부터, 아니면 디폴트.
   const initial = useMemo(() => {
     if (song) {
       const split = splitSessions(song.sessions);
@@ -152,11 +144,19 @@ export function AddSongModal({
     };
   }, [song]);
 
+  const [mode, setMode] = useState<Mode>('manual');
+  const [searchQuery, setSearchQuery] = useState('');
+  // '계속해서 추가하기' 토글. 새로 추가 시에만 의미 있음(수정 모드에서는 비활성).
+  const [keepOpen, setKeepOpen] = useState(false);
   const [activePresetIds, setActivePresetIds] = useState<ReadonlyArray<string>>(initial.activeIds);
   const [extras, setExtras] = useState<SessionDef[]>(initial.extras);
   const [extraDraft, setExtraDraft] = useState('');
   const [durationMm, setDurationMm] = useState(initial.durationMm);
   const [durationSs, setDurationSs] = useState(initial.durationSs);
+  const ssInputRef = useRef<HTMLInputElement | null>(null);
+  const titleRef = useRef<HTMLInputElement | null>(null);
+
+  const allSongs = useSetlistStore((s) => s.songs);
   const addSong = useSetlistStore((s) => s.addSong);
   const updateSong = useSetlistStore((s) => s.updateSong);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
@@ -171,6 +171,9 @@ export function AddSongModal({
   // 모달이 열릴 때, 또는 song 이 변경될 때(다른 곡 수정으로 전환) 폼/세션 상태를 initial 로 동기화.
   useEffect(() => {
     if (!open) return;
+    setMode('manual');
+    setSearchQuery('');
+    setKeepOpen(false);
     setActivePresetIds(initial.activeIds);
     setExtras(initial.extras);
     setExtraDraft('');
@@ -180,13 +183,13 @@ export function AddSongModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- initial 은 song 변경 시에만 갱신됨
   }, [open, initial]);
 
-  const reset = () => {
-    form.reset(initial.formValues);
-    setActivePresetIds(initial.activeIds);
-    setExtras(initial.extras);
-    setExtraDraft('');
-    setDurationMm(initial.durationMm);
-    setDurationSs(initial.durationSs);
+  /** 다음 곡 입력을 위해 폼/duration 만 비움. 세션/extras/keepOpen 은 유지. */
+  const resetForNext = () => {
+    form.reset({ title: '', artist: '', album: '', note: '' });
+    setDurationMm('');
+    setDurationSs('');
+    // 다음 입력에 즉시 포커스.
+    setTimeout(() => titleRef.current?.focus(), 0);
   };
 
   const togglePreset = (id: string) =>
@@ -194,7 +197,6 @@ export function AddSongModal({
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
     );
 
-  // 활성 프리셋 + 커스텀 결합. 표시 순서는 CANONICAL_ORDER 를 따라 토글 순서와 무관하게 안정.
   const composedSessions = useMemo<SessionDef[]>(() => {
     const ordered: SessionDef[] = [];
     for (const id of CANONICAL_ORDER) {
@@ -215,11 +217,7 @@ export function AddSongModal({
       toast.warn('이미 같은 라벨의 세션이 있습니다.');
       return;
     }
-    setExtras((prev) => [
-      ...prev,
-      // label: 사용자가 입력한 풀텍스트(대문자), short: 표시용 앞 2자.
-      { id, label: cleaned, short, need: 1, custom: true },
-    ]);
+    setExtras((prev) => [...prev, { id, label: cleaned, short, need: 1, custom: true }]);
     setExtraDraft('');
   };
 
@@ -244,20 +242,98 @@ export function AddSongModal({
     if (song) {
       updateSong(song.id, payload);
       toast.success('곡 정보가 수정되었습니다.');
-    } else {
-      addSong(meetingId, { ...payload, proposerId: currentUserId });
-      toast.success('곡이 추가되었습니다.');
+      setOpen(false);
+      return;
     }
-    setOpen(false);
-    reset();
+    addSong(meetingId, { ...payload, proposerId: currentUserId });
+    toast.success('곡이 추가되었습니다.');
+    if (keepOpen) {
+      resetForNext();
+    } else {
+      setOpen(false);
+    }
   });
+
+  // Enter 로 다음 입력 필드 포커스 이동. 마지막 ss 까지 가면 더 이상 이동하지 않고 유지(submit 은 버튼).
+  const advanceTo = (target: 'artist' | 'album' | 'mmInput' | 'ssInput' | 'note') => {
+    if (target === 'mmInput') {
+      // mm input ref 는 별도로 관리하지 않음 — 그냥 album 다음은 ss 또는 note 로.
+      return;
+    }
+    if (target === 'ssInput') {
+      ssInputRef.current?.focus();
+      return;
+    }
+    form.setFocus(target);
+  };
+
+  const onEnterAdvance =
+    (next: 'artist' | 'album' | 'ssInput' | 'note') => (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== 'Enter') return;
+      if (e.nativeEvent.isComposing) return;
+      e.preventDefault();
+      advanceTo(next);
+    };
+
+  const onMmKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter') return;
+    if (e.nativeEvent.isComposing) return;
+    e.preventDefault();
+    ssInputRef.current?.focus();
+  };
+
+  const onSsKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter') return;
+    if (e.nativeEvent.isComposing) return;
+    e.preventDefault();
+    form.setFocus('note');
+  };
+
+  // 검색 결과 — 전체 곡 풀(현재 모든 회의)에서 부분 매칭. BE 도입 시 별도 API 로 교체 예정.
+  const searchResults = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return [];
+    return allSongs
+      .filter(
+        (s) =>
+          s.title.toLowerCase().includes(q) ||
+          s.artist.toLowerCase().includes(q) ||
+          (s.album ?? '').toLowerCase().includes(q) ||
+          (s.duration ?? '').toLowerCase().includes(q),
+      )
+      .slice(0, 12);
+  }, [allSongs, searchQuery]);
+
+  const pickSearchResult = (s: Song) => {
+    form.setValue('title', s.title);
+    form.setValue('artist', s.artist);
+    form.setValue('album', s.album ?? '');
+    form.setValue('note', s.note ?? '');
+    const dur = parseDuration(s.duration);
+    setDurationMm(dur.mm);
+    setDurationSs(dur.ss);
+    setMode('manual');
+    setSearchQuery('');
+    toast.info('검색한 곡 정보를 불러왔습니다. 세션 구성을 확인하고 추가하세요.');
+  };
 
   return (
     <ResponsiveSheet
       open={open}
       onOpenChange={(v) => {
         setOpen(v);
-        if (!v) reset();
+        if (!v) {
+          // Close 시 다음 오픈을 위해 상태 리셋.
+          form.reset(initial.formValues);
+          setActivePresetIds(initial.activeIds);
+          setExtras(initial.extras);
+          setExtraDraft('');
+          setDurationMm(initial.durationMm);
+          setDurationSs(initial.durationSs);
+          setMode('manual');
+          setSearchQuery('');
+          setKeepOpen(false);
+        }
       }}
     >
       {trigger && <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>}
@@ -267,60 +343,162 @@ export function AddSongModal({
         </ResponsiveSheetHeader>
         <form onSubmit={onSubmit}>
           <ResponsiveSheetBody>
+            {/* 모드 탭 — 수정 모드에서는 검색 비활성(편집은 직접만). */}
+            {!isEdit && (
+              <div className="bg-card border-border mb-s-4 inline-flex items-center rounded-md border p-1">
+                <button
+                  type="button"
+                  onClick={() => setMode('manual')}
+                  className={cn(
+                    'px-s-3 py-s-1 text-caption rounded-sm font-semibold transition-colors',
+                    mode === 'manual'
+                      ? 'bg-accent text-foreground'
+                      : 'text-foreground-muted hover:text-foreground',
+                  )}
+                >
+                  직접 추가
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMode('search')}
+                  className={cn(
+                    'px-s-3 py-s-1 text-caption rounded-sm font-semibold transition-colors',
+                    mode === 'search'
+                      ? 'bg-accent text-foreground'
+                      : 'text-foreground-muted hover:text-foreground',
+                  )}
+                >
+                  검색
+                </button>
+              </div>
+            )}
+
             <div className="gap-s-3 flex flex-col">
-              <Input
-                label="곡명"
-                required
-                error={form.formState.errors.title?.message}
-                placeholder="예: Vicarious"
-                autoFocus
-                {...form.register('title')}
-              />
-              <Input
-                label="아티스트"
-                required
-                error={form.formState.errors.artist?.message}
-                placeholder="예: Tool"
-                {...form.register('artist')}
-              />
-              <div className="gap-s-3 flex">
-                <div className="flex-1">
+              {mode === 'manual' || isEdit ? (
+                <>
                   <Input
-                    label="앨범"
-                    error={form.formState.errors.album?.message}
-                    placeholder="선택"
-                    {...form.register('album')}
+                    label="곡명"
+                    required
+                    error={form.formState.errors.title?.message}
+                    placeholder="예: Vicarious"
+                    autoFocus
+                    {...form.register('title')}
+                    ref={(el) => {
+                      form.register('title').ref(el);
+                      titleRef.current = el;
+                    }}
+                    onKeyDown={onEnterAdvance('artist')}
                   />
-                </div>
+                  <Input
+                    label="아티스트"
+                    required
+                    error={form.formState.errors.artist?.message}
+                    placeholder="예: Tool"
+                    {...form.register('artist')}
+                    onKeyDown={onEnterAdvance('album')}
+                  />
+                  <div className="gap-s-3 flex">
+                    <div className="flex-1">
+                      <Input
+                        label="앨범"
+                        error={form.formState.errors.album?.message}
+                        placeholder="선택"
+                        {...form.register('album')}
+                        onKeyDown={onEnterAdvance('ssInput')}
+                      />
+                    </div>
+                    <div>
+                      <label className="text-foreground text-sm font-medium">재생 시간</label>
+                      <div className="bg-surface border-border focus-within:ring-accent focus-within:ring-offset-bg gap-s-1 px-s-3 mt-1.5 flex h-10 items-center rounded-md border focus-within:ring-2 focus-within:ring-offset-2">
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          maxLength={2}
+                          value={durationMm}
+                          onChange={(e) => {
+                            const next = clampNumeric(e.target.value, 99);
+                            setDurationMm(next);
+                            // 두 자리 입력되면 자동으로 초 필드로 이동.
+                            if (next.length === 2) ssInputRef.current?.focus();
+                          }}
+                          onKeyDown={onMmKeyDown}
+                          placeholder="00"
+                          aria-label="재생 시간 분"
+                          className="placeholder:text-foreground-muted w-7 bg-transparent text-center font-mono text-sm tabular-nums outline-none"
+                        />
+                        <span className="text-foreground-muted font-mono text-sm">:</span>
+                        <input
+                          ref={ssInputRef}
+                          type="text"
+                          inputMode="numeric"
+                          maxLength={2}
+                          value={durationSs}
+                          onChange={(e) => setDurationSs(clampNumeric(e.target.value, 59))}
+                          onKeyDown={onSsKeyDown}
+                          placeholder="00"
+                          aria-label="재생 시간 초"
+                          className="placeholder:text-foreground-muted w-7 bg-transparent text-center font-mono text-sm tabular-nums outline-none"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </>
+              ) : (
                 <div>
-                  <label className="text-foreground text-sm font-medium">재생 시간</label>
-                  <div className="bg-surface border-border focus-within:ring-accent focus-within:ring-offset-bg gap-s-1 px-s-3 mt-1.5 flex h-10 items-center rounded-md border focus-within:ring-2 focus-within:ring-offset-2">
+                  <label className="text-foreground text-sm font-medium">곡 검색</label>
+                  <div className="bg-surface border-border gap-s-2 px-s-3 focus-within:ring-accent focus-within:ring-offset-bg mt-1.5 flex h-10 items-center rounded-md border focus-within:ring-2 focus-within:ring-offset-2">
+                    <Search className="text-foreground-muted h-4 w-4 shrink-0" />
                     <input
-                      type="text"
-                      inputMode="numeric"
-                      maxLength={2}
-                      value={durationMm}
-                      onChange={(e) => setDurationMm(clampNumeric(e.target.value, 99))}
-                      placeholder="00"
-                      aria-label="재생 시간 분"
-                      className="placeholder:text-foreground-muted w-7 bg-transparent text-center font-mono text-sm tabular-nums outline-none"
-                    />
-                    <span className="text-foreground-muted font-mono text-sm">:</span>
-                    <input
-                      type="text"
-                      inputMode="numeric"
-                      maxLength={2}
-                      value={durationSs}
-                      onChange={(e) => setDurationSs(clampNumeric(e.target.value, 59))}
-                      placeholder="00"
-                      aria-label="재생 시간 초"
-                      className="placeholder:text-foreground-muted w-7 bg-transparent text-center font-mono text-sm tabular-nums outline-none"
+                      type="search"
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      placeholder="곡명 · 아티스트 · 앨범 · 재생 시간"
+                      autoFocus
+                      className="placeholder:text-foreground-muted w-full bg-transparent text-sm outline-none"
                     />
                   </div>
+                  <div className="text-foreground-muted text-micro mt-s-2">
+                    합주곡 풀에서 검색합니다. 결과 클릭 시 폼이 채워지고 직접 추가 탭으로
+                    전환됩니다.
+                  </div>
+                  {searchQuery && (
+                    <div className="border-border mt-s-3 max-h-72 overflow-y-auto rounded-md border">
+                      {searchResults.length === 0 ? (
+                        <div className="text-foreground-muted px-s-4 py-s-6 text-caption text-center">
+                          일치하는 곡이 없습니다.
+                        </div>
+                      ) : (
+                        <ul>
+                          {searchResults.map((s) => (
+                            <li key={s.id}>
+                              <button
+                                type="button"
+                                onClick={() => pickSearchResult(s)}
+                                className="hover:bg-card border-border px-s-3 py-s-2 flex w-full items-center justify-between border-b text-left last:border-b-0"
+                              >
+                                <div className="min-w-0">
+                                  <div className="text-caption truncate font-bold">{s.title}</div>
+                                  <div className="text-foreground-muted text-micro mt-0.5 truncate">
+                                    {s.artist}
+                                    {s.album ? ` · ${s.album}` : ''}
+                                  </div>
+                                </div>
+                                {s.duration && (
+                                  <span className="text-foreground-muted text-micro shrink-0 font-mono tabular-nums">
+                                    {s.duration}
+                                  </span>
+                                )}
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  )}
                 </div>
-              </div>
+              )}
 
-              {/* 세션 구성 — 추천자 의견 위로 이동 */}
+              {/* 세션 구성 — 두 모드 공통 */}
               <div>
                 <div className="text-foreground-sub text-caption mb-s-2 font-semibold">
                   세션 구성
@@ -329,7 +507,6 @@ export function AddSongModal({
                   자주 쓰는 세션을 토글하고, 필요하면 알파벳 라벨로 커스텀 세션을 추가하세요.
                 </div>
 
-                {/* 1행: 기본 4세션 / 2행: 보조 5세션 */}
                 <div className="gap-s-2 flex flex-col">
                   {PRESET_ROWS.map((row, rowIdx) => (
                     <div key={rowIdx} className="gap-s-2 flex flex-wrap">
@@ -357,13 +534,11 @@ export function AddSongModal({
                   ))}
                 </div>
 
-                {/* 커스텀 세션 추가 — 영문 알파벳만 허용 */}
                 <div className="gap-s-2 mt-s-3 flex items-end">
                   <div className="flex-1">
                     <Input
                       value={extraDraft}
                       onChange={(e) =>
-                        // 대/소문자 자유 입력 → toUpperCase 로 저장. A-Z 외 문자는 차단. 최대 10자.
                         setExtraDraft(
                           e.target.value
                             .toUpperCase()
@@ -428,13 +603,25 @@ export function AddSongModal({
             </div>
           </ResponsiveSheetBody>
           <ResponsiveSheetFooter>
+            {/* 새로 추가 모드일 때만 '계속 추가' 토글 노출. */}
+            {!isEdit && (
+              <label className="text-foreground-sub gap-s-2 text-caption mr-auto inline-flex cursor-pointer items-center">
+                <input
+                  type="checkbox"
+                  checked={keepOpen}
+                  onChange={(e) => setKeepOpen(e.target.checked)}
+                  className="accent-accent h-4 w-4"
+                />
+                계속해서 추가하기
+              </label>
+            )}
             <ResponsiveSheetClose asChild>
               <Button type="button" variant="ghost">
                 취소
               </Button>
             </ResponsiveSheetClose>
             <Button type="submit" variant="primary" disabled={!canSubmit}>
-              {isEdit ? '저장' : '곡 추가'}
+              {isEdit ? '저장' : keepOpen ? '다음 곡 추가' : '곡 추가'}
             </Button>
           </ResponsiveSheetFooter>
         </form>

--- a/src/domain/setlist-meeting/utils.ts
+++ b/src/domain/setlist-meeting/utils.ts
@@ -28,8 +28,9 @@ export function findSession(song: Song, sessionId: string): SessionDef | undefin
 }
 
 /**
- * 곡 내에서 보여줄 세션 약어. 같은 패밀리(V↔V2, G↔G2, D↔D2)가 함께 있으면
- * 기본 세션을 'V1' / 'G1' / 'D1' 로 표기해 시각적 짝을 맞춘다. 단일이면 'V'/'G'/'D' 유지.
+ * 곡 내에서 보여줄 세션 약어.
+ * - V↔V2, G↔G2, D↔D2 가 함께 있으면 기본을 V1/G1/D1 로 표기.
+ * - S1/S2 는 기본 'S' 가 별도로 없으므로 둘 중 하나만 있으면 'S' 로, 둘 다 있으면 S1/S2 그대로.
  */
 export function displaySessionShort(session: SessionDef, all: SessionDef[]): string {
   const pairs: Array<[string, string]> = [
@@ -40,5 +41,12 @@ export function displaySessionShort(session: SessionDef, all: SessionDef[]): str
   for (const [base, sibling] of pairs) {
     if (session.id === base && all.some((s) => s.id === sibling)) return `${base}1`;
   }
+
+  const synthIds = ['S1', 'S2'];
+  if (synthIds.includes(session.id)) {
+    const synthsPresent = all.filter((s) => synthIds.includes(s.id));
+    if (synthsPresent.length === 1) return 'S';
+  }
+
   return session.short;
 }


### PR DESCRIPTION
## 변경
1. **S1/S2 → S 약어**: `displaySessionShort` 가 S1/S2 중 하나만 있으면 'S' 로 표기.
2. **모달 상단 탭 (직접 추가 / 검색)**:
   - 직접: 기존 폼
   - 검색: 곡명·아티스트·앨범·재생시간 영역을 단일 검색 input 으로 대체. 결과 클릭 시 폼 사전 채움 + 직접 추가 탭 자동 전환. 세션 구성/추천자 의견/footer 버튼은 두 탭 공통.
3. **'계속해서 추가하기' 체크박스**: footer 좌측. 활성 시 버튼 라벨 '다음 곡 추가', 제출 후 모달 유지 + 폼만 리셋.
4. **Enter 다음 필드 이동**: title→artist→album→ss→note. IME 조합 중에는 무시.
5. **재생 시간 auto-advance**: mm 입력 2자리 → 자동으로 ss 필드 포커스.
6. **우측 패널 ↔ 하단 채팅 풀 시퀀싱**:
   - 오픈: 채팅 슬라이드 업(0~200ms) → 우측 패널 슬라이드 인(200~400ms)
   - 닫기: 우측 패널 슬라이드 아웃(0~200ms) → 채팅 슬라이드 다운(200~400ms) → 480ms 후 unmount
   - 우측 패널이 항상 채팅 위에 자리잡은 후에만 보이고, 채팅은 우측 패널 사라진 뒤에야 빠짐 → 잘려보이는 문제 해소.

## 검증
- pnpm typecheck / lint / test 통과 (61 passed)

Closes #170