### PR TITLE
feat: 곡 검색 외부 DB mock + 결과 영역 확대 + 모달 높이 일관

### DIFF
--- a/src/domain/setlist-meeting/components/AddSongModal.client.tsx
+++ b/src/domain/setlist-meeting/components/AddSongModal.client.tsx
@@ -21,6 +21,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/cn';
 import { useToast } from '@/hooks/useToast';
 
+import { searchMockSongs, type SongSearchResult } from '../mock/songSearchMock';
 import { useSetlistStore } from '../store/setlistStore';
 import type { SessionDef, Song } from '../types';
 import { addSongSchema, type AddSongSchema } from '../types/schema';
@@ -156,7 +157,6 @@ export function AddSongModal({
   const ssInputRef = useRef<HTMLInputElement | null>(null);
   const titleRef = useRef<HTMLInputElement | null>(null);
 
-  const allSongs = useSetlistStore((s) => s.songs);
   const addSong = useSetlistStore((s) => s.addSong);
   const updateSong = useSetlistStore((s) => s.updateSong);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
@@ -289,26 +289,14 @@ export function AddSongModal({
     form.setFocus('note');
   };
 
-  // 검색 결과 — 전체 곡 풀(현재 모든 회의)에서 부분 매칭. BE 도입 시 별도 API 로 교체 예정.
-  const searchResults = useMemo(() => {
-    const q = searchQuery.trim().toLowerCase();
-    if (!q) return [];
-    return allSongs
-      .filter(
-        (s) =>
-          s.title.toLowerCase().includes(q) ||
-          s.artist.toLowerCase().includes(q) ||
-          (s.album ?? '').toLowerCase().includes(q) ||
-          (s.duration ?? '').toLowerCase().includes(q),
-      )
-      .slice(0, 12);
-  }, [allSongs, searchQuery]);
+  // 외부 곡 DB mock 검색. 향후 SONG 검색 API 도입 시 fetcher 만 교체.
+  const searchResults = useMemo(() => searchMockSongs(searchQuery, 30), [searchQuery]);
 
-  const pickSearchResult = (s: Song) => {
+  const pickSearchResult = (s: SongSearchResult) => {
     form.setValue('title', s.title);
     form.setValue('artist', s.artist);
     form.setValue('album', s.album ?? '');
-    form.setValue('note', s.note ?? '');
+    form.setValue('note', '');
     const dur = parseDuration(s.duration);
     setDurationMm(dur.mm);
     setDurationSs(dur.ss);
@@ -374,8 +362,9 @@ export function AddSongModal({
             )}
 
             <div className="gap-s-3 flex flex-col">
+              {/* 상단 입력 영역 — 직접 추가 / 검색 두 모드의 모달 높이를 일치시키기 위해 동일 min-h. */}
               {mode === 'manual' || isEdit ? (
-                <>
+                <div className="gap-s-3 flex min-h-[400px] flex-col">
                   <Input
                     label="곡명"
                     required
@@ -449,9 +438,9 @@ export function AddSongModal({
                       </div>
                     </div>
                   </div>
-                </>
+                </div>
               ) : (
-                <div>
+                <div className="min-h-[400px]">
                   <label className="text-foreground text-sm font-medium">곡 검색</label>
                   <div className="bg-surface border-border gap-s-2 px-s-3 focus-within:ring-accent focus-within:ring-offset-bg mt-1.5 flex h-10 items-center rounded-md border focus-within:ring-2 focus-within:ring-offset-2">
                     <Search className="text-foreground-muted h-4 w-4 shrink-0" />
@@ -465,11 +454,11 @@ export function AddSongModal({
                     />
                   </div>
                   <div className="text-foreground-muted text-micro mt-s-2">
-                    합주곡 풀에서 검색합니다. 결과 클릭 시 폼이 채워지고 직접 추가 탭으로
-                    전환됩니다.
+                    외부 곡 DB 에서 검색합니다 (현재 mock — 추후 SONG 검색 API 로 교체). 결과 클릭
+                    시 폼이 채워지고 직접 추가 탭으로 전환됩니다.
                   </div>
-                  {/* 결과 영역 — 직접 추가 탭과 모달 높이를 맞추기 위해 항상 고정 높이(min-h). */}
-                  <div className="border-border mt-s-3 min-h-[280px] overflow-y-auto rounded-md border">
+                  {/* 결과 영역 — 고정 높이 + 스크롤. ~3곡 이상 노출되도록 320px. 직접 추가 탭과 모달 높이 일치. */}
+                  <div className="border-border mt-s-3 h-[320px] overflow-y-auto rounded-md border">
                     {!searchQuery ? (
                       <div className="text-foreground-muted gap-s-2 px-s-4 py-s-12 text-caption flex flex-col items-center justify-center text-center">
                         <Search className="h-6 w-6 opacity-50" />
@@ -482,7 +471,7 @@ export function AddSongModal({
                     ) : (
                       <ul>
                         {searchResults.map((s) => (
-                          <li key={s.id}>
+                          <li key={s.externalId}>
                             <button
                               type="button"
                               onClick={() => pickSearchResult(s)}

--- a/src/domain/setlist-meeting/mock/songSearchMock.ts
+++ b/src/domain/setlist-meeting/mock/songSearchMock.ts
@@ -1,0 +1,239 @@
+/**
+ * 곡 검색 API mock — 외부 음원 DB 를 흉내낸 정적 목록.
+ * 추후 SONG 검색 API 가 도입되면 useSongSearch 같은 훅의 fetcher 만 교체하면 된다.
+ */
+export interface SongSearchResult {
+  /** 외부 DB 의 트랙 식별자(예: ISRC, MusicBrainz id 등). 현재는 mock 슬러그. */
+  externalId: string;
+  title: string;
+  artist: string;
+  album?: string;
+  /** 'mm:ss'. */
+  duration?: string;
+}
+
+export const MOCK_SONG_DB: SongSearchResult[] = [
+  {
+    externalId: 'queen-bohemian',
+    title: 'Bohemian Rhapsody',
+    artist: 'Queen',
+    album: 'A Night at the Opera',
+    duration: '5:55',
+  },
+  {
+    externalId: 'queen-wewillrock',
+    title: 'We Will Rock You',
+    artist: 'Queen',
+    album: 'News of the World',
+    duration: '2:01',
+  },
+  {
+    externalId: 'queen-wearethechampions',
+    title: 'We Are the Champions',
+    artist: 'Queen',
+    album: 'News of the World',
+    duration: '3:00',
+  },
+  {
+    externalId: 'led-zeppelin-stairway',
+    title: 'Stairway to Heaven',
+    artist: 'Led Zeppelin',
+    album: 'Led Zeppelin IV',
+    duration: '8:02',
+  },
+  {
+    externalId: 'beatles-hey-jude',
+    title: 'Hey Jude',
+    artist: 'The Beatles',
+    album: 'Hey Jude',
+    duration: '7:11',
+  },
+  {
+    externalId: 'beatles-let-it-be',
+    title: 'Let It Be',
+    artist: 'The Beatles',
+    album: 'Let It Be',
+    duration: '4:03',
+  },
+  {
+    externalId: 'beatles-here-comes',
+    title: 'Here Comes the Sun',
+    artist: 'The Beatles',
+    album: 'Abbey Road',
+    duration: '3:05',
+  },
+  {
+    externalId: 'oasis-wonderwall',
+    title: 'Wonderwall',
+    artist: 'Oasis',
+    album: "(What's the Story) Morning Glory?",
+    duration: '4:18',
+  },
+  {
+    externalId: 'oasis-dont-look',
+    title: "Don't Look Back in Anger",
+    artist: 'Oasis',
+    album: "(What's the Story) Morning Glory?",
+    duration: '4:48',
+  },
+  {
+    externalId: 'nirvana-smells',
+    title: 'Smells Like Teen Spirit',
+    artist: 'Nirvana',
+    album: 'Nevermind',
+    duration: '5:01',
+  },
+  {
+    externalId: 'nirvana-come-as',
+    title: 'Come as You Are',
+    artist: 'Nirvana',
+    album: 'Nevermind',
+    duration: '3:39',
+  },
+  {
+    externalId: 'rhcp-californication',
+    title: 'Californication',
+    artist: 'Red Hot Chili Peppers',
+    album: 'Californication',
+    duration: '5:21',
+  },
+  {
+    externalId: 'rhcp-otherside',
+    title: 'Otherside',
+    artist: 'Red Hot Chili Peppers',
+    album: 'Californication',
+    duration: '4:15',
+  },
+  {
+    externalId: 'radiohead-creep',
+    title: 'Creep',
+    artist: 'Radiohead',
+    album: 'Pablo Honey',
+    duration: '3:58',
+  },
+  {
+    externalId: 'radiohead-karma',
+    title: 'Karma Police',
+    artist: 'Radiohead',
+    album: 'OK Computer',
+    duration: '4:21',
+  },
+  {
+    externalId: 'metallica-master',
+    title: 'Master of Puppets',
+    artist: 'Metallica',
+    album: 'Master of Puppets',
+    duration: '8:35',
+  },
+  {
+    externalId: 'metallica-enter',
+    title: 'Enter Sandman',
+    artist: 'Metallica',
+    album: 'Metallica',
+    duration: '5:32',
+  },
+  {
+    externalId: 'tool-vicarious',
+    title: 'Vicarious',
+    artist: 'Tool',
+    album: '10,000 Days',
+    duration: '7:06',
+  },
+  {
+    externalId: 'tool-jambi',
+    title: 'Jambi',
+    artist: 'Tool',
+    album: '10,000 Days',
+    duration: '7:28',
+  },
+  {
+    externalId: 'tool-the-pot',
+    title: 'The Pot',
+    artist: 'Tool',
+    album: '10,000 Days',
+    duration: '6:21',
+  },
+  {
+    externalId: 'pink-floyd-wish',
+    title: 'Wish You Were Here',
+    artist: 'Pink Floyd',
+    album: 'Wish You Were Here',
+    duration: '5:34',
+  },
+  {
+    externalId: 'pink-floyd-comfortably',
+    title: 'Comfortably Numb',
+    artist: 'Pink Floyd',
+    album: 'The Wall',
+    duration: '6:23',
+  },
+  {
+    externalId: 'eagles-hotel',
+    title: 'Hotel California',
+    artist: 'Eagles',
+    album: 'Hotel California',
+    duration: '6:30',
+  },
+  {
+    externalId: 'guns-sweet',
+    title: "Sweet Child o' Mine",
+    artist: "Guns N' Roses",
+    album: 'Appetite for Destruction',
+    duration: '5:56',
+  },
+  {
+    externalId: 'acdc-back',
+    title: 'Back in Black',
+    artist: 'AC/DC',
+    album: 'Back in Black',
+    duration: '4:15',
+  },
+  {
+    externalId: 'iu-night',
+    title: '밤편지',
+    artist: '아이유 (IU)',
+    album: 'Palette',
+    duration: '4:13',
+  },
+  {
+    externalId: 'iu-good-day',
+    title: '좋은 날',
+    artist: '아이유 (IU)',
+    album: 'Real',
+    duration: '3:50',
+  },
+  {
+    externalId: 'jaurim-hahaha',
+    title: '하하하쏭',
+    artist: '자우림',
+    album: '음모론',
+    duration: '3:48',
+  },
+  {
+    externalId: 'jaurim-kkochbal',
+    title: '꽃',
+    artist: '자우림',
+    album: 'Ashes to Ashes',
+    duration: '4:47',
+  },
+  {
+    externalId: 'cherryfilter-flying',
+    title: '낭만고양이',
+    artist: '체리필터',
+    album: 'Made in Korea',
+    duration: '4:09',
+  },
+];
+
+/** 부분 매칭 검색. 추후 외부 API fetcher 로 교체. */
+export function searchMockSongs(query: string, limit = 30): SongSearchResult[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  return MOCK_SONG_DB.filter(
+    (s) =>
+      s.title.toLowerCase().includes(q) ||
+      s.artist.toLowerCase().includes(q) ||
+      (s.album ?? '').toLowerCase().includes(q) ||
+      (s.duration ?? '').includes(q),
+  ).slice(0, limit);
+}


### PR DESCRIPTION
## 변경
1. **검색 소스 분리**: 회의 곡 풀 → 외부 곡 DB mock (`mock/songSearchMock.ts`, 30곡). 추후 SONG 검색 API 도입 시 `searchMockSongs` 만 교체.
2. **결과 영역 확대**: `h-[320px]` + overflow-y-auto. ~4-5곡 노출 + 스크롤.
3. **모달 높이 일관**: 직접 추가 / 검색 상단 입력 영역에 `min-h-[400px]` 동일 적용 → 탭 전환해도 모달 높이 변동 없음.
4. 검색 결과 클릭 시: 외부 트랙 정보(title/artist/album/duration)로 폼 채움. note 는 비움.

## 검증
- pnpm typecheck / lint / test 통과 (61 passed)

Closes #174