### PR TITLE
feat: 선곡 확정 + 모달 탭 언더라인 + 검색 3곡 + duration 0패딩

### DIFF
--- a/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/setlist-meetings/[meetingId]/MeetingDetail.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PanelRightOpen, Plus, Search } from 'lucide-react';
+import { CheckCircle2, Lock, PanelRightOpen, Plus, RotateCcw, Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -15,6 +15,7 @@ import {
   type SongSortKey,
 } from '@/domain/setlist-meeting/components/SongTable.client';
 import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
+import { useToast } from '@/hooks/useToast';
 import type { Song } from '@/domain/setlist-meeting/types';
 import { confirmedCount, isReady, totalNeed } from '@/domain/setlist-meeting/utils';
 import { cn } from '@/lib/cn';
@@ -65,8 +66,13 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
   const setSelectedSong = useSetlistStore((s) => s.setSelectedSong);
   const setFocusedSession = useSetlistStore((s) => s.setFocusedSession);
   const deleteSong = useSetlistStore((s) => s.deleteSong);
+  const lockMeeting = useSetlistStore((s) => s.lockMeeting);
+  const unlockMeeting = useSetlistStore((s) => s.unlockMeeting);
 
   const isManager = meeting ? meeting.managerId === currentUserId : false;
+  const isLocked = !!meeting?.lockedAt;
+  const [pendingLockAction, setPendingLockAction] = useState<'lock' | 'unlock' | null>(null);
+  const toast = useToast();
 
   const [filter, setFilter] = useState<Filter>('all');
   const [query, setQuery] = useState('');
@@ -256,8 +262,8 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
                 className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
               />
             </div>
-            {isManager && (
-              <div className="md:ml-auto">
+            <div className="gap-s-2 flex items-center md:ml-auto">
+              {isManager && !isLocked && (
                 <AddSongModal
                   meetingId={meetingId}
                   trigger={
@@ -266,9 +272,41 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
                     </Button>
                   }
                 />
-              </div>
-            )}
+              )}
+              {isManager && !isLocked && (
+                <Button
+                  size="sm"
+                  variant="primary"
+                  onClick={() => setPendingLockAction('lock')}
+                  aria-label="선곡 확정"
+                  className="bg-success hover:bg-success/90 text-white"
+                >
+                  <CheckCircle2 className="h-4 w-4" /> 선곡 확정
+                </Button>
+              )}
+              {isManager && isLocked && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => setPendingLockAction('unlock')}
+                  aria-label="회의 재개"
+                >
+                  <RotateCcw className="h-4 w-4" /> 회의 재개
+                </Button>
+              )}
+            </div>
           </div>
+
+          {/* 잠금 안내 배너 — 모든 멤버에게 노출. */}
+          {isLocked && (
+            <div className="bg-success-dim border-success/30 mt-s-3 px-s-3 py-s-2 gap-s-2 text-caption text-success flex items-center rounded-md border">
+              <Lock className="h-4 w-4 shrink-0" />
+              <span className="font-semibold">선곡이 확정된 회의입니다.</span>
+              <span className="text-foreground-sub">
+                곡 추가/수정/삭제는 매니저가 회의를 재개할 때까지 잠겨 있습니다.
+              </span>
+            </div>
+          )}
         </header>
 
         <div className="flex-1 overflow-y-auto">
@@ -278,6 +316,7 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
             selectedSongId={selectedSongId}
             currentUserId={currentUserId}
             isManager={isManager}
+            isLocked={isLocked}
             matchedUserIds={matchedUserIds}
             sortKey={sortKey}
             sortDir={sortDir}
@@ -372,6 +411,30 @@ export function MeetingDetail({ meetingId }: { meetingId: string }) {
         tone="danger"
         onConfirm={() => {
           if (pendingDeleteSong) deleteSong(pendingDeleteSong.id);
+        }}
+      />
+
+      {/* 선곡 확정 / 회의 재개 확인 다이얼로그 — 매니저 전용 액션. */}
+      <ConfirmDialog
+        open={pendingLockAction !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingLockAction(null);
+        }}
+        title={pendingLockAction === 'lock' ? '선곡 확정' : '회의 재개'}
+        description={
+          pendingLockAction === 'lock'
+            ? '선곡을 확정하면 모든 멤버의 곡 추가·수정·삭제가 잠깁니다. 진행하시겠습니까?'
+            : '회의를 재개하면 다시 곡 추가·수정·삭제가 가능해집니다. 진행하시겠습니까?'
+        }
+        confirmLabel={pendingLockAction === 'lock' ? '확정' : '재개'}
+        onConfirm={() => {
+          if (pendingLockAction === 'lock') {
+            lockMeeting(meetingId);
+            toast.success('선곡이 확정되었습니다.');
+          } else if (pendingLockAction === 'unlock') {
+            unlockMeeting(meetingId);
+            toast.info('회의가 재개되었습니다.');
+          }
         }}
       />
     </div>

--- a/src/domain/setlist-meeting/components/AddSongModal.client.tsx
+++ b/src/domain/setlist-meeting/components/AddSongModal.client.tsx
@@ -86,7 +86,8 @@ function parseDuration(d?: string): { mm: string; ss: string } {
   if (!d) return { mm: '', ss: '' };
   const m = d.match(/^(\d{1,2}):(\d{2})$/);
   if (!m) return { mm: '', ss: '' };
-  return { mm: String(parseInt(m[1]!, 10)), ss: String(parseInt(m[2]!, 10)) };
+  // 입력 필드는 0 패딩된 형식을 그대로 보여줌. 단일 자리 입력 후 onBlur 가 패딩을 보장.
+  return { mm: m[1]!.padStart(2, '0'), ss: m[2]! };
 }
 
 function splitSessions(sessions: SessionDef[]): {
@@ -331,40 +332,37 @@ export function AddSongModal({
         </ResponsiveSheetHeader>
         <form onSubmit={onSubmit}>
           <ResponsiveSheetBody>
-            {/* 모드 탭 — 수정 모드에서는 검색 비활성(편집은 직접만). */}
+            {/* 모드 탭 — 밴드 정보/멤버 탭과 동일한 underline 스타일. 수정 모드에서는 검색 비활성. */}
             {!isEdit && (
-              <div className="bg-card border-border mb-s-4 inline-flex items-center rounded-md border p-1">
-                <button
-                  type="button"
-                  onClick={() => setMode('manual')}
-                  className={cn(
-                    'px-s-3 py-s-1 text-caption rounded-sm font-semibold transition-colors',
-                    mode === 'manual'
-                      ? 'bg-accent text-foreground'
-                      : 'text-foreground-muted hover:text-foreground',
-                  )}
-                >
-                  직접 추가
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setMode('search')}
-                  className={cn(
-                    'px-s-3 py-s-1 text-caption rounded-sm font-semibold transition-colors',
-                    mode === 'search'
-                      ? 'bg-accent text-foreground'
-                      : 'text-foreground-muted hover:text-foreground',
-                  )}
-                >
-                  검색
-                </button>
+              <div className="border-border mb-s-4 gap-s-6 -mx-s-1 flex border-b">
+                {[
+                  { id: 'manual' as const, label: '직접 추가' },
+                  { id: 'search' as const, label: '검색' },
+                ].map((tab) => {
+                  const active = mode === tab.id;
+                  return (
+                    <button
+                      key={tab.id}
+                      type="button"
+                      onClick={() => setMode(tab.id)}
+                      aria-pressed={active}
+                      className={cn(
+                        'px-s-1 -mb-px h-10 border-b-2 text-sm font-semibold transition-colors',
+                        active
+                          ? 'border-accent text-accent'
+                          : 'text-foreground-sub hover:text-foreground border-transparent',
+                      )}
+                    >
+                      {tab.label}
+                    </button>
+                  );
+                })}
               </div>
             )}
 
             <div className="gap-s-3 flex flex-col">
-              {/* 상단 입력 영역 — 직접 추가 / 검색 두 모드의 모달 높이를 일치시키기 위해 동일 min-h. */}
               {mode === 'manual' || isEdit ? (
-                <div className="gap-s-3 flex min-h-[400px] flex-col">
+                <div className="gap-s-3 flex flex-col">
                   <Input
                     label="곡명"
                     required
@@ -440,7 +438,7 @@ export function AddSongModal({
                   </div>
                 </div>
               ) : (
-                <div className="min-h-[400px]">
+                <div>
                   <label className="text-foreground text-sm font-medium">곡 검색</label>
                   <div className="bg-surface border-border gap-s-2 px-s-3 focus-within:ring-accent focus-within:ring-offset-bg mt-1.5 flex h-10 items-center rounded-md border focus-within:ring-2 focus-within:ring-offset-2">
                     <Search className="text-foreground-muted h-4 w-4 shrink-0" />
@@ -457,8 +455,8 @@ export function AddSongModal({
                     외부 곡 DB 에서 검색합니다 (현재 mock — 추후 SONG 검색 API 로 교체). 결과 클릭
                     시 폼이 채워지고 직접 추가 탭으로 전환됩니다.
                   </div>
-                  {/* 결과 영역 — 고정 높이 + 스크롤. ~3곡 이상 노출되도록 320px. 직접 추가 탭과 모달 높이 일치. */}
-                  <div className="border-border mt-s-3 h-[320px] overflow-y-auto rounded-md border">
+                  {/* 결과 영역 — 카드 ~64px × 3곡 + 약간 = 200px. 그 이상은 스크롤. */}
+                  <div className="border-border mt-s-3 h-[200px] overflow-y-auto rounded-md border">
                     {!searchQuery ? (
                       <div className="text-foreground-muted gap-s-2 px-s-4 py-s-12 text-caption flex flex-col items-center justify-center text-center">
                         <Search className="h-6 w-6 opacity-50" />

--- a/src/domain/setlist-meeting/components/SongTable.client.tsx
+++ b/src/domain/setlist-meeting/components/SongTable.client.tsx
@@ -19,6 +19,8 @@ export interface SongTableProps {
   currentUserId: string;
   /** true 이면 모든 곡에 삭제/수정 버튼 노출(매니저). false 이면 본인이 제안한 곡만. */
   isManager?: boolean;
+  /** 회의가 매니저에 의해 선곡 확정됨 — 모든 멤버의 수정/삭제 비활성. */
+  isLocked?: boolean;
   /** 멤버 검색 매칭 결과 — 해당 userId 가 속한 세션에 빨간 점 표시. */
   matchedUserIds?: ReadonlySet<string>;
   /** 정렬 상태(부모에서 관리). null 이면 원본 순서. */
@@ -49,6 +51,7 @@ export function SongTable({
   selectedSongId,
   currentUserId,
   isManager = false,
+  isLocked = false,
   matchedUserIds,
   sortKey = null,
   sortDir = 'asc',
@@ -219,6 +222,8 @@ export function SongTable({
                 </td>
                 <td className="px-s-3 py-s-2 align-middle">
                   {(() => {
+                    // 잠긴 회의는 모든 멤버에 대해 수정/삭제 비활성.
+                    if (isLocked) return null;
                     const canMutate = isManager || song.proposerId === currentUserId;
                     if (!canMutate) return null;
                     // 확정된 곡(모든 세션이 정원만큼 확정)은 수정 비활성 — 확정자 데이터 보호.

--- a/src/domain/setlist-meeting/store/setlistStore.ts
+++ b/src/domain/setlist-meeting/store/setlistStore.ts
@@ -51,6 +51,10 @@ type Actions = {
   ) => void;
   addCustomSession: (songId: string, session: SessionDef) => void;
   addMeeting: (meeting: Omit<Meeting, 'id' | 'createdAt' | 'updatedAt'>) => string;
+  /** 매니저가 선곡 확정 — 곡 추가/수정/삭제 잠금. */
+  lockMeeting: (meetingId: string) => void;
+  /** 매니저가 회의 재개 — 잠금 해제. */
+  unlockMeeting: (meetingId: string) => void;
   /** 테스트/디버그용. seed 로 되돌림. */
   reset: () => void;
 };
@@ -222,6 +226,18 @@ export const useSetlistStore = create<SetlistStore>()(
         set((state) => ({ meetings: [...state.meetings, next], selectedMeetingId: id }));
         return id;
       },
+
+      lockMeeting: (meetingId) =>
+        set((state) => ({
+          meetings: state.meetings.map((m) =>
+            m.id === meetingId ? { ...m, lockedAt: new Date().toISOString() } : m,
+          ),
+        })),
+
+      unlockMeeting: (meetingId) =>
+        set((state) => ({
+          meetings: state.meetings.map((m) => (m.id === meetingId ? { ...m, lockedAt: null } : m)),
+        })),
 
       reset: () => set({ ...initial }),
     }),

--- a/src/domain/setlist-meeting/types.ts
+++ b/src/domain/setlist-meeting/types.ts
@@ -60,6 +60,8 @@ export type Meeting = {
   managerId: string;
   createdAt: string;
   updatedAt: string;
+  /** 매니저가 선곡을 확정한 시각(ISO). null/undefined 면 진행 중. */
+  lockedAt?: string | null;
 };
 
 export type SessionState = 'full' | 'partial' | 'empty';


### PR DESCRIPTION
## 변경
### 0. 모달 폴리시
- 직접/검색 토글: 버튼 → underline 탭(밴드 정보/멤버 스타일)
- 직접 추가 모드 `min-h-[400px]` 제거 → 곡 정보와 세션 사이 빈 공간 해소
- 검색 결과 영역 `h-[320px]` → `h-[200px]` (~3곡 + 스크롤)
- `parseDuration` 이 mm 0 패딩 유지 → 검색으로 곡 선택 시 자동 패딩

### 1. 선곡 확정 / 회의 재개
- `Meeting.lockedAt` 필드 + store `lockMeeting` / `unlockMeeting` 액션
- 매니저 전용 success 톤 '선곡 확정' 버튼 (곡 추가 옆)
- 잠금 상태: 매니저는 secondary '회의 재개' 버튼, 모든 멤버에게 잠금 안내 배너
- 잠금 시 곡 추가 버튼 숨김, SongTable 의 수정/삭제 버튼 모두 비활성
- ConfirmDialog 로 잠금/재개 확인 + toast 피드백

## 검증
- pnpm typecheck / lint / test 통과 (61 passed)

Closes #176