### PR TITLE
feat: 합주 일정 조율 + 마법사 합주 기간 + 중복 공연 차단

### DIFF
--- a/.taskmaster/docs/schedule_coordination_prd.txt
+++ b/.taskmaster/docs/schedule_coordination_prd.txt
@@ -1,0 +1,159 @@
+# 합주 일정 조율 PRD
+
+작성일: 2026-04-26
+영향 도메인: 신규 `domain/schedule-coordination`, 기존 `domain/setlist-meeting`
+선행 라운드: setlist-phase2 (회의 만들기 마법사)
+
+## 0. 배경 / 목적
+선곡 확정 후, 참여 멤버들의 가용 일정을 모아 최적 합주 시간을 잡는 기능이 부재. 본 라운드는 멤버 스케줄 수집 → 종합 → 매니저 확정의 풀 플로우를 도입한다. when2meet 패턴을 Bandage 디자인 토큰으로 재구성.
+
+## 1. 범위 요약
+0. **마법사 Step 3 확장**: 회의 정보 단계에 '합주 기간' 입력 추가. 공연 모드는 오늘~공연 일자 자동, 사용자 수정 가능. 일반 모드는 사용자 직접 입력.
+1. **신규 서브탭 '합주 일정 조율'**: `/scheduling`
+   - 사이드바 sub: 합주 일정 조율
+   - 마스터 사이드바(오버레이) — 선곡 회의 목록 (기존 패널 재사용 / 동일 동작)
+   - 회의 선택 → 사이드바 자동 닫힘 + 메인 화면 진입
+   - 메인: 좌/우 절반 — 좌측 멤버 리스트, 우측 확정 곡 리스트
+   - 언더라인 탭: 내 합주곡만 / 전체 보기
+   - '나의 스케줄 입력' 버튼 → 5-Step 모달 (캐싱)
+   - 멤버 행 클릭 → 우측 패널 열림(개인 일정 시각화)
+   - 곡 행 클릭 → 우측 패널 열림(이 곡 가능한 시간/멤버 매트릭스)
+   - 매니저: '합주 일정 확정' 액션 + 최적 시간표 추천
+
+## 2. 사용자 시나리오
+
+### 2-1. 마법사 Step 3 합주 기간 입력
+- 공연 모드 진입 시 합주 기간 자동 = 오늘 ~ 공연 startAt 일자.
+- 일반 모드 진입 시 빈 값 → 사용자가 'YYYY-MM-DD ~ YYYY-MM-DD' 두 input 으로 직접 입력.
+- 두 모드 모두 사용자 수정 가능. 검증: from <= to.
+- store.addMeeting 시 `practiceWindow: { from, to }` 로 저장.
+
+### 2-2. 합주 일정 조율 진입
+- 사이드바 '선곡 회의 > 합주 일정 조율' 클릭 → `/setlist-meetings/scheduling`
+- 좌측 마스터 패널 자동 펼침(오버레이) — 회의 목록.
+- 회의 클릭 → `/setlist-meetings/scheduling/{meetingId}` + 패널 자동 닫힘.
+
+### 2-3. 메인 화면
+- 상단 헤더: 회의 제목, 합주 기간, 매니저, '나의 스케줄 입력' 버튼.
+- 두 패널 (md 이상 좌우 분할, 모바일 세로):
+  - **좌측: 멤버 리스트** — 참여 멤버 N명, 각자의 입력 진행 상태(미입력 / 부분 / 완료) 배지. 클릭 → 우측 상세.
+  - **우측: 곡 리스트** — 확정된 곡(`isReady=true` 또는 잠금된 회의의 모든 곡). 곡 클릭 → '이 곡 합주 가능한 시간' 매트릭스 표시.
+- 언더라인 탭: '내 합주곡만 / 전체 보기' — 곡 리스트 필터.
+- 매니저면 헤더에 success 톤 '합주 일정 확정' 버튼.
+
+### 2-4. 나의 스케줄 입력 모달 (5-step)
+- 모든 step 의 입력은 `localStorage` 에 즉시 영속화 — 실수 종료 후 재진입해도 복원.
+- Key: `bandage-schedule-{meetingId}-{userId}`.
+- Step 0: 입력 방식 선택 (언더라인 탭) — 'AI 입력 (준비 중)' / '스케줄 입력'. AI 탭은 '곧 제공됩니다' placeholder.
+- Step 1: 가능한 날짜
+  - 합주 기간(meeting.practiceWindow) 모든 일자를 달력 그리드로 노출.
+  - 필터: 평일만 / 주말만 / 전체 / 공휴일 제외(mock 공휴일 목록 + 토스트로 적용).
+  - 일자 클릭 → 가능 ↔ 불가능 토글.
+- Step 2: 시간 블록 선택 (when2meet 스타일)
+  - 선택된 일자만 노출 (가용 day 위주). 1주 단위 — 좌우 화살표로 주차 이동.
+  - 30분 단위, 9:00~22:00 기본 활성, 외 시간은 비활성 토글 가능.
+  - 드래그 X(선택 셀 클릭으로 토글). 셀 색: 활성=accent-dim / 비활성=card.
+- Step 3: 특이사항 텍스트 (Textarea, 200자)
+- Step 4: 요약 + 제출
+
+### 2-5. 멤버 클릭 시 우측 패널 (AI/Agent UX)
+- 우측 패널(380px, 기존 SessionPanel 패턴 재사용 — overlay)
+- 표시 정보 (UI 제안):
+  - 이름·이메일·아바타
+  - 입력 상태: 미입력 / 부분 / 완료
+  - **가용 캘린더 미니뷰**: 합주 기간 N주를 작은 격자로 압축, 각 셀은 '가능 시간 비율'(예: 0%=빈칸, 1-50%=warn, 51-99%=accent, 100%=success)
+  - 시간대 히트맵: 30분 슬롯을 가로축 시간(9-22), 세로축 요일로 깔고 짙기로 가능도 표현
+  - 특이사항 메모
+
+### 2-6. 곡 클릭 시 우측 패널
+- 곡 정보 + '합주 가능 멤버 매트릭스':
+  - 이 곡 세션 정원 = `totalNeed`
+  - 곡의 확정자(또는 곡에 참여 가능한 멤버) ∩ 회의 참여 멤버 = 후보
+  - 후보들의 스케줄을 종합해 '최소 N명 동시 가능' 슬롯 강조
+  - 매트릭스: 가로 시간, 세로 일자 — 각 셀에 동시 가능 멤버 수 표시(success/warn/empty)
+
+### 2-7. 매니저 확정
+- '합주 일정 확정' 버튼 → 최적 슬롯 후보 자동 계산(가장 많은 멤버 동시 가능) → 확인 다이얼로그
+- 확정 시: meeting 에 `confirmedSlot: { date, start, end }` 저장 + 모든 멤버에 toast(향후 BE 알림)
+- BE 도입 시: POST /api/v1/setlist-meetings/{id}/practice-schedule
+
+## 3. 라우트
+- `/setlist-meetings/scheduling` — 빈 상태(첫 회의로 redirect)
+- `/setlist-meetings/scheduling/{meetingId}` — 메인 화면
+- 사이드바 sub 추가: '합주 일정 조율' → `/setlist-meetings/scheduling`
+
+## 4. 도메인 / 데이터 모델
+
+### 4-1. types
+```ts
+// setlist-meeting/types.ts
+export type Meeting = {
+  // ...
+  /** 합주 가능 기간. mvp: 'YYYY-MM-DD'. */
+  practiceWindow?: { from: string; to: string };
+  /** 매니저가 확정한 합주 슬롯. */
+  confirmedSlot?: { date: string; startMin: number; endMin: number } | null;
+};
+```
+
+### 4-2. 신규 도메인 schedule-coordination
+```
+domain/schedule-coordination/
+├── types.ts              # MemberSchedule, DayAvailability, TimeBlock
+├── store/scheduleStore.ts # localStorage persist
+├── components/           # CalendarMonthGrid, TimeBlockMatrix, MemberSchedulePanel, SongSchedulePanel
+└── utils.ts              # 필터/교집합/최적 슬롯 계산
+```
+
+### 4-3. 캐싱
+- localStorage key: `bandage-schedule-{meetingId}-{userId}`.
+- payload: `{ availableDates: string[], unavailableDates: string[], blocks: { [date: string]: BitMask48 }, note: string, completed: boolean }`
+- BitMask48 = 30분 × 48슬롯/일.
+
+## 5. UI 가이드라인
+- when2meet 스타일 시간 블록: row=요일, col=30분 슬롯. 셀 토글 click. 드래그는 v2.
+- 캘린더 그리드: 7열 × N행, 일자 셀 click 토글. 비활성 일자는 회색.
+- 우측 패널: 기존 SessionPanel 의 absolute 오버레이 패턴 재사용.
+
+## 6. 백엔드 요청 (API_REQUIRED 추가)
+
+### FE-API-040 회의 합주 기간 저장
+- POST/PATCH 회의 시 `practiceWindow: { from, to }` 포함.
+- v1 은 mock(localStorage) 만.
+
+### FE-API-041 멤버 스케줄 제출
+```
+POST /api/v1/setlist-meetings/{id}/schedule
+Body: { availableDates: [...], unavailableDates: [...], blocks: {...}, note }
+```
+
+### FE-API-042 회의 스케줄 종합 조회
+```
+GET /api/v1/setlist-meetings/{id}/schedule
+Response: { perMember: [...], aggregate: {...} }
+```
+
+### FE-API-043 합주 일정 확정 (매니저)
+```
+POST /api/v1/setlist-meetings/{id}/practice-schedule
+Body: { date, startMin, endMin }
+```
+
+## 7. 작업 분할
+1. types + Meeting.practiceWindow + Step 3 합주 기간 입력
+2. 라우트 + 사이드바 sub + master pane 재사용
+3. 도메인 schedule-coordination (types/store/utils)
+4. 메인 화면 — 좌/우 패널(멤버 리스트 + 곡 리스트) + 언더라인 필터
+5. 나의 스케줄 입력 모달 (5-step) + localStorage 영속화
+6. 멤버 클릭 → 우측 패널(개인 일정 시각화) + 곡 클릭 → 우측 패널(매트릭스)
+7. 매니저 확정 — 최적 슬롯 계산 + 확정 다이얼로그
+8. API_REQUIRED.md FE-API-040~043 등록
+
+## 8. 비범위
+- AI 자동 입력 (placeholder 만)
+- 푸시 알림
+- 드래그 선택 — 클릭 토글로 시작
+
+## 9. 활성화 절차 (BE 도입 시)
+- types/store 의 mock fetcher 를 실제 fetch 로 교체
+- localStorage 캐시는 옵티미스틱 업데이트 자리로 활용

--- a/.taskmaster/state.json
+++ b/.taskmaster/state.json
@@ -1,6 +1,6 @@
 {
-  "currentTag": "setlist-phase2",
-  "lastSwitched": "2026-04-26T12:37:18.134Z",
+  "currentTag": "schedule-coordination",
+  "lastSwitched": "2026-04-26T13:07:43.530Z",
   "branchTagMapping": {},
   "migrationNoticeShown": true
 }

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -4204,8 +4204,9 @@
         "testStrategy": "1. '/setlist-meetings/new' 접속 시 마법사 페이지 렌더 확인\n2. 사이드바에서 '선곡 회의' 클릭 시 서브탭 펼침 확인\n3. '나의 선곡 회의' 클릭 시 '/setlist-meetings?listOpen=1'로 이동하고 마스터 패널 자동 펼침 확인\n4. '회의 만들기' 클릭 시 '/setlist-meetings/new'로 이동 확인",
         "priority": "high",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-26T12:50:32.211Z"
       },
       {
         "id": 2,
@@ -4215,10 +4216,11 @@
         "testStrategy": "1. StepIndicator가 4단계 모두 표시되는지 확인\n2. '다음' 버튼 클릭 시 단계 전환 확인\n3. '이전' 버튼 클릭 시 이전 단계로 이동 확인\n4. Navigation Guard 동작 확인 (입력 후 페이지 이탈 시 경고)",
         "priority": "high",
         "dependencies": [
-          1
+          "1"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-26T12:50:35.916Z"
       },
       {
         "id": 3,
@@ -4228,10 +4230,11 @@
         "testStrategy": "1. 언더라인 탭으로 목적 전환 시 UI 변경 확인\n2. 공연 모드에서 검색어 입력 시 결과 표시 확인\n3. 공연 선택 시 선택 상태 표시(체크마크, 테두리 강조) 확인\n4. '공연 즉시 생성' 클릭 시 '/performances/new'로 리다이렉트 확인\n5. 공연 미선택 시 '다음' 버튼 비활성화 확인",
         "priority": "high",
         "dependencies": [
-          2
+          "2"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-26T12:50:39.655Z"
       },
       {
         "id": 4,
@@ -4241,10 +4244,11 @@
         "testStrategy": "1. 공연 모드에서 멤버 풀이 자동으로 체크되어 표시되는지 확인\n2. 체크박스 토글로 멤버 제외/포함 동작 확인\n3. 일반 모드에서 밴드 검색 시 결과 표시 및 선택 확인\n4. 일반 모드에서 멤버 검색 시 결과 표시 및 개별 추가 확인\n5. 참여 인원 0명일 때 '다음' 버튼 비활성화 확인",
         "priority": "high",
         "dependencies": [
-          2
+          "2"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-26T12:50:43.779Z"
       },
       {
         "id": 5,
@@ -4254,10 +4258,11 @@
         "testStrategy": "1. 회의 제목 입력 필드 동작 확인\n2. Step 2에서 선택한 참여 인원만 매니저 후보로 표시되는지 확인\n3. 라디오 버튼으로 매니저 단일 선택 동작 확인\n4. 제목 미입력 또는 매니저 미선택 시 '다음' 버튼 비활성화 확인",
         "priority": "medium",
         "dependencies": [
-          4
+          "4"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-26T12:50:47.876Z"
       },
       {
         "id": 6,
@@ -4267,10 +4272,11 @@
         "testStrategy": "1. 확인 단계에서 모든 입력 정보가 올바르게 요약 표시되는지 확인\n2. '수정' 버튼 클릭 시 해당 단계로 이동 확인\n3. '회의 만들기' 클릭 시 store에 회의 추가 확인\n4. 회의 생성 후 디테일 페이지로 리다이렉트 확인\n5. 토스트 메시지 표시 확인",
         "priority": "medium",
         "dependencies": [
-          5
+          "5"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-26T12:50:51.787Z"
       },
       {
         "id": 7,
@@ -4280,8 +4286,9 @@
         "testStrategy": "1. 타입 정의가 올바르게 확장되었는지 TypeScript 컴파일 확인\n2. SEED_MEMBERS에 email, profileImg 필드가 추가되었는지 확인\n3. memberSearchMock 함수가 검색어에 따라 올바른 결과 반환 확인\n4. performanceSearchMock 함수가 검색어에 따라 올바른 결과 반환 확인\n5. 기존 기능(회의 목록, 디테일)이 정상 동작하는지 회귀 테스트",
         "priority": "high",
         "dependencies": [],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-26T12:50:55.527Z"
       },
       {
         "id": 8,
@@ -4291,10 +4298,11 @@
         "testStrategy": "1. 선곡 확정 시 lockSnapshots에 곡 목록 저장 확인\n2. 회의 재개 → 곡 추가/삭제 → 재확정 시 diff가 올바르게 계산되는지 확인\n3. practiceSongMap에 새로 매핑된 항목 추가 확인\n4. 기존 lockMeeting/unlockMeeting 동작 회귀 테스트",
         "priority": "medium",
         "dependencies": [
-          7
+          "7"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-26T12:50:59.247Z"
       },
       {
         "id": 9,
@@ -4304,23 +4312,38 @@
         "testStrategy": "1. API_REQUIRED 문서에 모든 엔드포인트가 정확하게 기록되었는지 확인\n2. lint, typecheck, format 모두 통과 확인\n3. 전체 플로우 E2E 수동 테스트:\n   - 사이드바 > 회의 만들기 클릭\n   - 목적 선택 (공연/일반)\n   - 참여 인원 선택\n   - 회의 정보 입력\n   - 확인 및 생성\n   - 디테일 페이지에서 선곡 확정/재개",
         "priority": "low",
         "dependencies": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8"
         ],
-        "status": "pending",
-        "subtasks": []
+        "status": "done",
+        "subtasks": [],
+        "updatedAt": "2026-04-26T12:51:03.203Z"
       }
     ],
     "metadata": {
-      "created": "2026-04-26T12:37:04.749Z",
-      "updated": "2026-04-26T12:40:48.963Z",
+      "version": "1.0.0",
+      "lastModified": "2026-04-26T12:51:03.204Z",
+      "taskCount": 9,
+      "completedCount": 9,
+      "tags": [
+        "setlist-phase2"
+      ],
+      "created": "2026-04-26T13:07:38.631Z",
       "description": "Tasks for setlist-phase2 context"
+    }
+  },
+  "schedule-coordination": {
+    "tasks": [],
+    "metadata": {
+      "created": "2026-04-26T13:07:38.635Z",
+      "updated": "2026-04-26T13:07:38.635Z",
+      "description": "합주 일정 조율"
     }
   }
 }

--- a/API_REQUIRED.md
+++ b/API_REQUIRED.md
@@ -330,6 +330,39 @@ POST /api/v1/setlist-meetings/{meetingId}/unlock
 
 - 단순 잠금 해제. 매핑은 유지(다음 확정에서 diff 계산 기준).
 
+### FE-API-040 회의 합주 기간
+
+- 회의 생성/수정 시 `practiceWindow: { from, to }` 포함.
+- v1 mock 은 store/Wizard 의 from/to input 으로 저장.
+
+### FE-API-041 멤버 스케줄 제출
+
+```
+POST /api/v1/setlist-meetings/{meetingId}/schedule
+Body: { availableDates: string[], unavailableDates: string[], blocks: Record<date, boolean[48]>, note: string }
+```
+
+- 본인만 제출 가능. 부분 입력 저장 시 멱등 PATCH 가능.
+- v1 mock 은 `domain/schedule-coordination/store/scheduleStore` 의 localStorage persist 로 우회.
+
+### FE-API-042 회의 스케줄 종합 조회
+
+```
+GET /api/v1/setlist-meetings/{meetingId}/schedule
+Response: { perMember: MemberSchedule[], aggregate: Record<date, number[48]> }
+```
+
+- 회의 참여 멤버 + 매니저만 조회 가능.
+
+### FE-API-043 합주 일정 확정 (매니저)
+
+```
+POST /api/v1/setlist-meetings/{meetingId}/practice-schedule
+Body: { date, startMin, endMin }
+```
+
+- 매니저만. 응답: 확정된 슬롯 + 영향 받는 합주곡 매핑.
+
 ### FE-API-036 회의 곡 벌크 수정 (재확정 시 변경분 동기)
 
 ```

--- a/src/app/(main)/setlist-meetings/layout.tsx
+++ b/src/app/(main)/setlist-meetings/layout.tsx
@@ -16,7 +16,9 @@ export default function SetlistMeetingsLayout({ children }: { children: ReactNod
   const pathname = usePathname() ?? '';
   const fullPage =
     pathname === ROUTES.SETLIST_MEETING_NEW ||
-    pathname.startsWith(`${ROUTES.SETLIST_MEETING_NEW}/`);
+    pathname.startsWith(`${ROUTES.SETLIST_MEETING_NEW}/`) ||
+    pathname === ROUTES.SETLIST_SCHEDULING ||
+    pathname.startsWith(`${ROUTES.SETLIST_SCHEDULING}/`);
 
   if (fullPage) {
     return <div className="h-full overflow-y-auto">{children}</div>;

--- a/src/app/(main)/setlist-meetings/new/MeetingCreateWizard.client.tsx
+++ b/src/app/(main)/setlist-meetings/new/MeetingCreateWizard.client.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowRight, CalendarDays, Music, Search, Users, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -40,6 +40,15 @@ export function MeetingCreateWizard() {
   const toast = useToast();
   const addMeeting = useSetlistStore((s) => s.addMeeting);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
+  const existingMeetings = useSetlistStore((s) => s.meetings);
+  // 이미 회의가 생성된 공연 id 집합 — Step 1 에서 블러 + 비활성화.
+  const usedPerformanceIds = useMemo(
+    () =>
+      new Set(
+        existingMeetings.filter((m) => m.performanceId).map((m) => m.performanceId as string),
+      ),
+    [existingMeetings],
+  );
 
   const [step, setStep] = useState<Step>(0);
 
@@ -59,17 +68,31 @@ export function MeetingCreateWizard() {
   // Step 3
   const [title, setTitle] = useState('');
   const [managerId, setManagerId] = useState<string | null>(null);
+  /** 합주 기간 'YYYY-MM-DD'. 공연 모드 진입 시 자동 채움(아래 effect). */
+  const [practiceFrom, setPracticeFrom] = useState('');
+  const [practiceTo, setPracticeTo] = useState('');
 
   // 공연 풀 멤버 vs 일반 모드 풀 멤버.
   const performancePool = useMemo<Member[]>(
     () => (performance ? flattenPerformanceMembers(performance) : []),
     [performance],
   );
-  // 공연 모드: 공연 선택 시 자동으로 풀 전체 활성화.
+  // 공연 모드: 공연 선택 시 자동으로 풀 전체 활성화 + 합주 기간 자동 채움(오늘~공연일).
   const onPickPerformance = (p: PerformanceMock) => {
     setPerformance(p);
     setParticipantIds(flattenPerformanceMembers(p).map((m) => m.id));
+    const today = new Date().toISOString().slice(0, 10);
+    const perfDate = p.startAt.slice(0, 10);
+    setPracticeFrom(today);
+    setPracticeTo(perfDate >= today ? perfDate : today);
   };
+
+  // purpose 가 'general' 로 전환되면 공연 기반 자동 채움을 비움.
+  useEffect(() => {
+    if (purpose === 'general') {
+      setPerformance(null);
+    }
+  }, [purpose]);
 
   // 멤버 검색 결과 — 검색창 아래 자체 패널에 노출. 클릭 시 참여 풀에 추가.
   const memberSearchResults = useMemo<Member[]>(() => {
@@ -112,10 +135,13 @@ export function MeetingCreateWizard() {
       .filter((m): m is Member => Boolean(m));
   }, [participantIds]);
 
+  const practiceWindowValid =
+    practiceFrom !== '' && practiceTo !== '' && practiceFrom <= practiceTo;
+
   const canNext = (() => {
     if (step === 0) return purpose === 'general' || !!performance;
     if (step === 1) return participantIds.length > 0;
-    if (step === 2) return title.trim().length > 0 && !!managerId;
+    if (step === 2) return title.trim().length > 0 && !!managerId && practiceWindowValid;
     return true;
   })();
 
@@ -123,7 +149,11 @@ export function MeetingCreateWizard() {
     if (!canNext) {
       if (step === 0) toast.error('공연을 선택하거나 일반 회의로 진행하세요.');
       else if (step === 1) toast.error('최소 1명 이상의 참여 멤버를 선택하세요.');
-      else if (step === 2) toast.error('회의 제목과 매니저를 지정하세요.');
+      else if (step === 2) {
+        if (!title.trim()) toast.error('회의 제목을 입력하세요.');
+        else if (!managerId) toast.error('매니저를 지정하세요.');
+        else toast.error('합주 가능 기간을 올바르게 입력하세요(시작 ≤ 종료).');
+      }
       return;
     }
     if (step < 3) setStep((step + 1) as Step);
@@ -149,6 +179,7 @@ export function MeetingCreateWizard() {
       purpose,
       performanceId: performance?.performanceId ?? null,
       participantUserIds: participantIds,
+      practiceWindow: { from: practiceFrom, to: practiceTo },
     });
     toast.success('선곡 회의가 만들어졌습니다.');
     router.replace(ROUTES.SETLIST_MEETING_DETAIL(id));
@@ -181,6 +212,7 @@ export function MeetingCreateWizard() {
           perfQuery={perfQuery}
           setPerfQuery={setPerfQuery}
           onCreatePerformance={() => router.push(ROUTES.PERFORMANCE_NEW)}
+          usedPerformanceIds={usedPerformanceIds}
         />
       )}
       {step === 1 && (
@@ -209,6 +241,11 @@ export function MeetingCreateWizard() {
           setManagerId={setManagerId}
           participantMembers={participantMembers}
           currentUserId={currentUserId}
+          practiceFrom={practiceFrom}
+          setPracticeFrom={setPracticeFrom}
+          practiceTo={practiceTo}
+          setPracticeTo={setPracticeTo}
+          isPerformanceMode={purpose === 'performance' && !!performance}
         />
       )}
       {step === 3 && (
@@ -219,6 +256,8 @@ export function MeetingCreateWizard() {
           participantMembers={participantMembers}
           title={title}
           managerId={managerId}
+          practiceFrom={practiceFrom}
+          practiceTo={practiceTo}
         />
       )}
 
@@ -249,6 +288,7 @@ function Step1Purpose({
   perfQuery,
   setPerfQuery,
   onCreatePerformance,
+  usedPerformanceIds,
 }: {
   purpose: MeetingPurpose;
   setPurpose: (p: MeetingPurpose) => void;
@@ -257,6 +297,7 @@ function Step1Purpose({
   perfQuery: string;
   setPerfQuery: (q: string) => void;
   onCreatePerformance: () => void;
+  usedPerformanceIds: ReadonlySet<string>;
 }) {
   const results = useMemo(() => searchMockPerformances(perfQuery), [perfQuery]);
   return (
@@ -296,19 +337,30 @@ function Step1Purpose({
             ) : (
               results.map((p) => {
                 const active = performance?.performanceId === p.performanceId;
+                const used = usedPerformanceIds.has(p.performanceId);
                 return (
                   <li key={p.performanceId}>
                     <button
                       type="button"
-                      onClick={() => onPickPerformance(p)}
+                      onClick={() => !used && onPickPerformance(p)}
+                      disabled={used}
+                      title={used ? '이미 회의가 생성된 공연입니다.' : undefined}
                       className={cn(
-                        'gap-s-3 px-s-3 py-s-2 hover:bg-card flex w-full items-center rounded-md text-left transition-colors',
-                        active && 'bg-accent-dim border-accent/30 border',
+                        'gap-s-3 px-s-3 py-s-2 flex w-full items-center rounded-md text-left transition-colors',
+                        used ? 'cursor-not-allowed opacity-40 blur-[0.5px]' : 'hover:bg-card',
+                        active && !used && 'bg-accent-dim border-accent/30 border',
                       )}
                     >
                       <CalendarDays className="text-foreground-muted h-4 w-4 shrink-0" />
                       <div className="min-w-0 flex-1">
-                        <div className="text-caption truncate font-bold">{p.title}</div>
+                        <div className="text-caption gap-s-2 flex items-center font-bold">
+                          <span className="truncate">{p.title}</span>
+                          {used && (
+                            <span className="bg-foreground-muted/15 text-foreground-muted text-micro shrink-0 rounded px-1.5 py-0.5 font-bold">
+                              회의 생성됨
+                            </span>
+                          )}
+                        </div>
                         <div className="text-foreground-muted text-micro mt-0.5 truncate">
                           {p.venue} · {p.startAt.slice(0, 16).replace('T', ' ')} ·{' '}
                           {p.bands.map((b) => b.bandName).join(', ')}
@@ -565,6 +617,11 @@ function Step3Info({
   setManagerId,
   participantMembers,
   currentUserId,
+  practiceFrom,
+  setPracticeFrom,
+  practiceTo,
+  setPracticeTo,
+  isPerformanceMode,
 }: {
   title: string;
   setTitle: (t: string) => void;
@@ -572,7 +629,13 @@ function Step3Info({
   setManagerId: (id: string) => void;
   participantMembers: Member[];
   currentUserId: string;
+  practiceFrom: string;
+  setPracticeFrom: (v: string) => void;
+  practiceTo: string;
+  setPracticeTo: (v: string) => void;
+  isPerformanceMode: boolean;
 }) {
+  const today = new Date().toISOString().slice(0, 10);
   return (
     <section className="gap-s-4 flex flex-col">
       <Input
@@ -582,6 +645,40 @@ function Step3Info({
         onChange={(e) => setTitle(e.target.value)}
         placeholder="예: 여름 페스티벌 셋리스트 회의"
       />
+
+      <div>
+        <div className="text-foreground mb-s-2 text-sm font-medium">
+          합주 가능 기간 <span className="text-danger">*</span>
+        </div>
+        <div className="text-foreground-muted text-micro mb-s-2">
+          {isPerformanceMode
+            ? '공연 모드는 오늘 ~ 공연 일자로 자동 입력됩니다. 필요 시 수정 가능.'
+            : '회의에서 다룰 합주가 가능한 기간을 입력하세요. 멤버 스케줄 조율의 기준이 됩니다.'}
+        </div>
+        <div className="gap-s-3 flex items-center">
+          <input
+            type="date"
+            value={practiceFrom}
+            min={today}
+            onChange={(e) => setPracticeFrom(e.target.value)}
+            aria-label="합주 시작일"
+            className="bg-surface border-border px-s-3 focus:ring-accent h-10 rounded-md border text-sm outline-none focus:ring-2"
+          />
+          <span className="text-foreground-muted">~</span>
+          <input
+            type="date"
+            value={practiceTo}
+            min={practiceFrom || today}
+            onChange={(e) => setPracticeTo(e.target.value)}
+            aria-label="합주 종료일"
+            className="bg-surface border-border px-s-3 focus:ring-accent h-10 rounded-md border text-sm outline-none focus:ring-2"
+          />
+        </div>
+        {practiceFrom && practiceTo && practiceFrom > practiceTo && (
+          <p className="text-danger text-micro mt-s-2">시작일은 종료일보다 빨라야 합니다.</p>
+        )}
+      </div>
+
       <div>
         <div className="text-foreground mb-s-2 text-sm font-medium">
           매니저 지정 <span className="text-danger">*</span>
@@ -637,6 +734,8 @@ function Step4Review({
   participantMembers,
   title,
   managerId,
+  practiceFrom,
+  practiceTo,
 }: {
   purpose: MeetingPurpose;
   performance: PerformanceMock | null;
@@ -644,6 +743,8 @@ function Step4Review({
   participantMembers: Member[];
   title: string;
   managerId: string | null;
+  practiceFrom: string;
+  practiceTo: string;
 }) {
   const manager = participantMembers.find((m) => m.id === managerId);
   return (
@@ -686,6 +787,11 @@ function Step4Review({
       </SummaryRow>
       <SummaryRow label="제목">
         <span className="text-caption font-bold">{title || '(미입력)'}</span>
+      </SummaryRow>
+      <SummaryRow icon={<CalendarDays className="h-4 w-4" />} label="합주 가능 기간">
+        <span className="text-caption font-mono">
+          {practiceFrom || '-'} ~ {practiceTo || '-'}
+        </span>
       </SummaryRow>
       <SummaryRow label="매니저">
         {manager ? (

--- a/src/app/(main)/setlist-meetings/scheduling/[meetingId]/ScheduleInputModal.client.tsx
+++ b/src/app/(main)/setlist-meetings/scheduling/[meetingId]/ScheduleInputModal.client.tsx
@@ -1,0 +1,520 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetContent,
+  ResponsiveSheetFooter,
+  ResponsiveSheetHeader,
+  ResponsiveSheetTitle,
+} from '@/components/ui/responsive-sheet';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  DEFAULT_DAY_MASK,
+  useScheduleStore,
+} from '@/domain/schedule-coordination/store/scheduleStore';
+import type { SlotMask } from '@/domain/schedule-coordination/types';
+import {
+  addDays,
+  dayOfWeek,
+  isHoliday,
+  isWeekend,
+  slotToTime,
+  startOfWeek,
+} from '@/domain/schedule-coordination/utils';
+import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/cn';
+
+const STEPS = ['입력 방식', '가능 일자', '시간 블록', '특이사항', '확인'] as const;
+type Step = 0 | 1 | 2 | 3 | 4;
+
+type DateFilter = 'all' | 'weekday' | 'weekend' | 'no-holidays';
+
+export function ScheduleInputModal({
+  meetingId,
+  userId,
+  allDays,
+  open,
+  onOpenChange,
+}: {
+  meetingId: string;
+  userId: string;
+  allDays: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const existing = useScheduleStore((s) => s.schedules[`${meetingId}__${userId}`]);
+  const upsert = useScheduleStore((s) => s.upsertSchedule);
+  const setCompleted = useScheduleStore((s) => s.setCompleted);
+  const toast = useToast();
+
+  const [step, setStep] = useState<Step>(0);
+  const [inputMode, setInputMode] = useState<'ai' | 'manual'>('manual');
+  const [availableDates, setAvailableDates] = useState<string[]>(existing?.availableDates ?? []);
+  const [blocks, setBlocks] = useState<Record<string, SlotMask>>(existing?.blocks ?? {});
+  const [note, setNote] = useState(existing?.note ?? '');
+
+  // 모달 열릴 때 기존 입력으로 hydrate (localStorage 영속화 + 이미 store 에 있음).
+  useEffect(() => {
+    if (!open) return;
+    setStep(0);
+    setInputMode('manual');
+    setAvailableDates(existing?.availableDates ?? []);
+    setBlocks(existing?.blocks ?? {});
+    setNote(existing?.note ?? '');
+  }, [open, existing]);
+
+  // 입력 변동 시 즉시 store 에 저장 → localStorage 영속화 (실수 종료해도 유지).
+  useEffect(() => {
+    if (!open) return;
+    upsert({
+      meetingId,
+      userId,
+      availableDates,
+      unavailableDates: [],
+      blocks,
+      note,
+      completed: existing?.completed ?? false,
+      updatedAt: new Date().toISOString(),
+    });
+  }, [open, meetingId, userId, availableDates, blocks, note, existing?.completed, upsert]);
+
+  const next = () => setStep((s) => (s < 4 ? ((s + 1) as Step) : s));
+  const back = () => setStep((s) => (s > 0 ? ((s - 1) as Step) : s));
+
+  const submit = () => {
+    setCompleted(meetingId, userId, true);
+    toast.success('나의 스케줄이 저장되었습니다.');
+    onOpenChange(false);
+  };
+
+  return (
+    <ResponsiveSheet open={open} onOpenChange={onOpenChange}>
+      <ResponsiveSheetContent className="sm:max-w-2xl">
+        <ResponsiveSheetHeader>
+          <ResponsiveSheetTitle>나의 스케줄 입력</ResponsiveSheetTitle>
+        </ResponsiveSheetHeader>
+        <ResponsiveSheetBody>
+          <ProgressBar step={step} />
+          <div className="mt-s-4">
+            {step === 0 && <Step0InputMode value={inputMode} onChange={setInputMode} />}
+            {step === 1 && (
+              <Step1Dates
+                allDays={allDays}
+                availableDates={availableDates}
+                setAvailableDates={setAvailableDates}
+              />
+            )}
+            {step === 2 && (
+              <Step2Blocks
+                allDays={allDays}
+                availableDates={availableDates}
+                blocks={blocks}
+                setBlocks={setBlocks}
+              />
+            )}
+            {step === 3 && <Step3Note note={note} setNote={setNote} />}
+            {step === 4 && (
+              <Step4Review
+                inputMode={inputMode}
+                availableDates={availableDates}
+                blocks={blocks}
+                note={note}
+              />
+            )}
+          </div>
+        </ResponsiveSheetBody>
+        <ResponsiveSheetFooter>
+          <Button type="button" variant="ghost" onClick={back} disabled={step === 0}>
+            이전
+          </Button>
+          {step < 4 ? (
+            <Button
+              type="button"
+              variant="primary"
+              onClick={next}
+              disabled={step === 0 && inputMode === 'ai'}
+            >
+              다음
+            </Button>
+          ) : (
+            <Button type="button" variant="primary" onClick={submit}>
+              저장
+            </Button>
+          )}
+        </ResponsiveSheetFooter>
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}
+
+function ProgressBar({ step }: { step: Step }) {
+  return (
+    <div className="border-border gap-s-1 pb-s-3 flex items-center border-b">
+      {STEPS.map((label, i) => (
+        <div key={label} className="flex-1 text-center">
+          <div
+            className={cn(
+              'text-micro mb-1 font-bold',
+              i === step ? 'text-accent' : i < step ? 'text-success' : 'text-foreground-muted',
+            )}
+          >
+            {i + 1}. {label}
+          </div>
+          <div
+            className={cn(
+              'h-1 rounded-full',
+              i === step ? 'bg-accent' : i < step ? 'bg-success' : 'bg-card',
+            )}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Step 0
+function Step0InputMode({
+  value,
+  onChange,
+}: {
+  value: 'ai' | 'manual';
+  onChange: (v: 'ai' | 'manual') => void;
+}) {
+  return (
+    <section className="gap-s-3 flex flex-col">
+      <UnderlineTabs
+        value={value}
+        onChange={(v) => onChange(v as 'ai' | 'manual')}
+        items={[
+          { id: 'manual', label: '스케줄 입력' },
+          { id: 'ai', label: 'AI 입력' },
+        ]}
+      />
+      {value === 'ai' ? (
+        <div className="bg-card border-border px-s-4 py-s-8 text-foreground-muted text-caption rounded-lg border border-dashed text-center">
+          AI 자동 입력은 준비 중입니다. 곧 제공됩니다.
+        </div>
+      ) : (
+        <p className="text-foreground-muted text-caption">
+          이어지는 단계에서 합주 가능 일자와 시간 블록, 특이사항을 입력합니다.
+        </p>
+      )}
+    </section>
+  );
+}
+
+// Step 1: 가능 일자
+function Step1Dates({
+  allDays,
+  availableDates,
+  setAvailableDates,
+}: {
+  allDays: string[];
+  availableDates: string[];
+  setAvailableDates: (next: string[]) => void;
+}) {
+  const [filter, setFilter] = useState<DateFilter>('all');
+
+  const passesFilter = (d: string) => {
+    if (filter === 'weekday') return !isWeekend(d);
+    if (filter === 'weekend') return isWeekend(d);
+    if (filter === 'no-holidays') return !isHoliday(d);
+    return true;
+  };
+
+  const toggle = (d: string) => {
+    if (availableDates.includes(d)) {
+      setAvailableDates(availableDates.filter((x) => x !== d));
+    } else {
+      setAvailableDates([...availableDates, d]);
+    }
+  };
+
+  const applyFilter = () => {
+    setAvailableDates(allDays.filter(passesFilter));
+  };
+
+  return (
+    <section className="gap-s-3 flex flex-col">
+      <p className="text-foreground-muted text-caption">
+        합주 가능한 일자를 선택하세요. 필터를 적용하면 일괄 선택됩니다.
+      </p>
+      <div className="gap-s-2 flex flex-wrap">
+        {(['all', 'weekday', 'weekend', 'no-holidays'] as const).map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => setFilter(f)}
+            className={cn(
+              'px-s-3 py-s-1 text-micro rounded-full border font-semibold',
+              filter === f
+                ? 'bg-accent-dim border-accent/40 text-accent'
+                : 'bg-card border-border text-foreground-muted hover:border-border-hi',
+            )}
+          >
+            {f === 'all'
+              ? '전체'
+              : f === 'weekday'
+                ? '평일'
+                : f === 'weekend'
+                  ? '주말'
+                  : '공휴일 제외'}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={applyFilter}
+          className="text-accent text-micro ml-auto font-semibold hover:underline"
+        >
+          필터로 일괄 선택
+        </button>
+      </div>
+      <div className="grid grid-cols-7 gap-1">
+        {['일', '월', '화', '수', '목', '금', '토'].map((d) => (
+          <div key={d} className="text-foreground-muted text-micro text-center font-bold">
+            {d}
+          </div>
+        ))}
+        {allDays.length > 0 &&
+          // 첫 일자의 요일만큼 빈 칸 채워 정렬.
+          Array.from({ length: dayOfWeek(allDays[0]!) }).map((_, i) => <div key={`pad-${i}`} />)}
+        {allDays.map((d) => {
+          const selected = availableDates.includes(d);
+          const dim = !passesFilter(d);
+          const holiday = isHoliday(d);
+          return (
+            <button
+              key={d}
+              type="button"
+              onClick={() => toggle(d)}
+              className={cn(
+                'text-caption rounded-md px-1 py-2 text-center font-mono font-bold',
+                selected
+                  ? 'bg-accent text-foreground'
+                  : 'bg-card text-foreground-muted hover:bg-card-hover',
+                holiday && !selected && 'text-danger',
+                dim && !selected && 'opacity-40',
+              )}
+            >
+              {d.slice(8)}
+            </button>
+          );
+        })}
+      </div>
+      <div className="text-foreground-sub text-caption">
+        선택 <strong className="text-foreground">{availableDates.length}</strong>일
+      </div>
+    </section>
+  );
+}
+
+// Step 2: 시간 블록 (when2meet 스타일, 1주 단위)
+function Step2Blocks({
+  allDays,
+  availableDates,
+  blocks,
+  setBlocks,
+}: {
+  allDays: string[];
+  availableDates: string[];
+  blocks: Record<string, SlotMask>;
+  setBlocks: (next: Record<string, SlotMask>) => void;
+}) {
+  const sortedAvail = useMemo(() => [...availableDates].sort(), [availableDates]);
+  const firstWeekStart = useMemo(
+    () => (sortedAvail[0] ? startOfWeek(sortedAvail[0]) : startOfWeek(allDays[0] ?? '')),
+    [sortedAvail, allDays],
+  );
+  const [weekStart, setWeekStart] = useState(firstWeekStart);
+  const weekDates = useMemo(
+    () => Array.from({ length: 7 }, (_, i) => addDays(weekStart, i)),
+    [weekStart],
+  );
+  const weekAvailDates = weekDates.filter((d) => availableDates.includes(d));
+
+  // 기본 9:00~22:00 활성. 사용자가 selected 한 cell 만 boolean.
+  const ensureMask = (date: string): SlotMask => blocks[date] ?? [...DEFAULT_DAY_MASK];
+
+  const toggleSlot = (date: string, slot: number) => {
+    const mask = ensureMask(date);
+    const next = mask.slice();
+    next[slot] = !next[slot];
+    setBlocks({ ...blocks, [date]: next });
+  };
+
+  if (sortedAvail.length === 0) {
+    return (
+      <p className="text-foreground-muted text-caption py-s-6 text-center">
+        먼저 이전 단계에서 가능한 일자를 선택하세요.
+      </p>
+    );
+  }
+
+  return (
+    <section className="gap-s-3 flex flex-col">
+      <div className="gap-s-2 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => setWeekStart(addDays(weekStart, -7))}
+          className="text-foreground-muted hover:text-foreground p-1"
+          aria-label="이전 주"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <span className="text-caption font-mono font-bold">
+          {weekStart} ~ {addDays(weekStart, 6)}
+        </span>
+        <button
+          type="button"
+          onClick={() => setWeekStart(addDays(weekStart, 7))}
+          className="text-foreground-muted hover:text-foreground p-1"
+          aria-label="다음 주"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+      <p className="text-foreground-muted text-micro">
+        30분 단위. 셀 클릭으로 가능/불가 토글. 기본 09:00~22:00 가능.
+      </p>
+      {weekAvailDates.length === 0 ? (
+        <p className="text-foreground-muted text-caption py-s-4 text-center">
+          이 주에 선택된 일자가 없습니다.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="text-micro w-full">
+            <thead>
+              <tr>
+                <th className="px-1 py-1"></th>
+                {[18, 22, 26, 30, 34, 38, 42].map((s) => (
+                  <th key={s} className="text-foreground-muted px-1 py-1 text-center">
+                    {slotToTime(s)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {weekAvailDates.map((d) => {
+                const mask = ensureMask(d);
+                return (
+                  <tr key={d}>
+                    <td className="px-1 py-1 font-mono">{d.slice(5)}</td>
+                    {Array.from({ length: 26 }, (_, i) => 18 + i).map((s) => (
+                      <td key={s} className="p-0">
+                        <button
+                          type="button"
+                          onClick={() => toggleSlot(d, s)}
+                          aria-label={`${d} ${slotToTime(s)}`}
+                          className={cn(
+                            'h-6 w-full border-r border-b transition-colors',
+                            mask[s]
+                              ? 'bg-accent border-accent-hi'
+                              : 'bg-card border-border hover:bg-card-hover',
+                          )}
+                        />
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Step3Note({ note, setNote }: { note: string; setNote: (n: string) => void }) {
+  return (
+    <section className="gap-s-3 flex flex-col">
+      <Textarea
+        label="특이사항"
+        rows={5}
+        maxLength={200}
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        placeholder="합주 일정 결정 시 참고할 특이사항을 적어주세요. (예: 매주 금요일은 오후 8시 이후만 가능)"
+      />
+      <div className="text-foreground-muted text-micro text-right">{note.length}/200</div>
+    </section>
+  );
+}
+
+function Step4Review({
+  inputMode,
+  availableDates,
+  blocks,
+  note,
+}: {
+  inputMode: 'ai' | 'manual';
+  availableDates: string[];
+  blocks: Record<string, SlotMask>;
+  note: string;
+}) {
+  const totalSlots = Object.values(blocks).reduce(
+    (acc, mask) => acc + mask.filter(Boolean).length,
+    0,
+  );
+  return (
+    <section className="gap-s-3 flex flex-col">
+      <SummaryRow label="입력 방식">
+        {inputMode === 'manual' ? '스케줄 입력' : 'AI 입력 (준비 중)'}
+      </SummaryRow>
+      <SummaryRow label="가능 일자">{availableDates.length}일</SummaryRow>
+      <SummaryRow label="총 가능 시간">{Math.round((totalSlots * 30) / 60)}시간</SummaryRow>
+      <SummaryRow label="특이사항">
+        {note || <span className="text-foreground-muted">(없음)</span>}
+      </SummaryRow>
+    </section>
+  );
+}
+
+function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-card border-border px-s-4 py-s-3 gap-s-3 flex items-center rounded-lg border">
+      <div className="text-foreground-muted text-micro w-24 shrink-0 font-bold uppercase">
+        {label}
+      </div>
+      <div className="text-foreground text-caption flex-1">{children}</div>
+    </div>
+  );
+}
+
+function UnderlineTabs<T extends string>({
+  value,
+  onChange,
+  items,
+}: {
+  value: T;
+  onChange: (v: T) => void;
+  items: ReadonlyArray<{ id: T; label: string }>;
+}) {
+  return (
+    <div className="border-border gap-s-6 flex border-b">
+      {items.map((it) => {
+        const active = value === it.id;
+        return (
+          <button
+            key={it.id}
+            type="button"
+            onClick={() => onChange(it.id)}
+            className={cn(
+              'px-s-1 -mb-px h-10 border-b-2 text-sm font-semibold transition-colors',
+              active
+                ? 'border-accent text-accent'
+                : 'text-foreground-sub hover:text-foreground border-transparent',
+            )}
+          >
+            {it.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(main)/setlist-meetings/scheduling/[meetingId]/SchedulingMain.client.tsx
+++ b/src/app/(main)/setlist-meetings/scheduling/[meetingId]/SchedulingMain.client.tsx
@@ -1,0 +1,485 @@
+'use client';
+
+import { CalendarDays, CheckCircle2, Clock3, Crown, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { GLOBAL_MEMBER_POOL } from '@/domain/setlist-meeting/mock/memberSearchMock';
+import { MemberAvatar } from '@/domain/setlist-meeting/components/MemberAvatar';
+import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
+import type { Member, Song } from '@/domain/setlist-meeting/types';
+import { isReady } from '@/domain/setlist-meeting/utils';
+import { useScheduleStore } from '@/domain/schedule-coordination/store/scheduleStore';
+import {
+  aggregateAvailability,
+  enumerateDays,
+  slotToTime,
+} from '@/domain/schedule-coordination/utils';
+import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/cn';
+
+import { ScheduleInputModal } from './ScheduleInputModal.client';
+
+type SongFilter = 'mine' | 'all';
+type RightPanel = { kind: 'member'; member: Member } | { kind: 'song'; song: Song } | null;
+
+export function SchedulingMain({ meetingId }: { meetingId: string }) {
+  const meetings = useSetlistStore((s) => s.meetings);
+  const songs = useSetlistStore((s) => s.songs);
+  const currentUserId = useSetlistStore((s) => s.currentUserId);
+  const meeting = useMemo(() => meetings.find((m) => m.id === meetingId), [meetings, meetingId]);
+  const allSongs = useMemo(
+    () => songs.filter((s) => s.meetingId === meetingId),
+    [songs, meetingId],
+  );
+
+  // 모든 hook 은 early-return 위에 호출(rules-of-hooks).
+  const isManager = meeting ? meeting.managerId === currentUserId : false;
+  const participantIds = useMemo(() => meeting?.participantUserIds ?? [], [meeting]);
+  const participants = useMemo<Member[]>(
+    () =>
+      participantIds
+        .map((id) => GLOBAL_MEMBER_POOL.find((m) => m.id === id))
+        .filter((m): m is Member => Boolean(m)),
+    [participantIds],
+  );
+
+  const schedulesAll = useScheduleStore((s) => s.schedules);
+  const memberSchedules = useMemo(
+    () =>
+      participantIds
+        .map((uid) => schedulesAll[`${meetingId}__${uid}`])
+        .filter((x): x is NonNullable<typeof x> => Boolean(x)),
+    [participantIds, schedulesAll, meetingId],
+  );
+
+  const [songFilter, setSongFilter] = useState<SongFilter>('mine');
+  const [scheduleOpen, setScheduleOpen] = useState(false);
+  const [rightPanel, setRightPanel] = useState<RightPanel>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const toast = useToast();
+  const lockMeeting = useSetlistStore((s) => s.lockMeeting);
+
+  // 곡 필터 — 내 합주곡(내가 지원/확정된 곡) vs 전체 (확정 우선)
+  const visibleSongs = useMemo<Song[]>(() => {
+    const ready = allSongs.filter((s) => isReady(s));
+    const pool = ready.length > 0 ? ready : allSongs; // 확정 곡이 없으면 전체
+    if (songFilter === 'all') return pool;
+    return pool.filter(
+      (s) =>
+        Object.values(s.applicants).some((list) => list.includes(currentUserId)) ||
+        Object.values(s.confirmed).some((list) => list.includes(currentUserId)),
+    );
+  }, [allSongs, songFilter, currentUserId]);
+
+  const window = meeting?.practiceWindow;
+  const allDays = useMemo(() => (window ? enumerateDays(window.from, window.to) : []), [window]);
+
+  // 매니저 확정 — 가장 동시 가능 인원이 많은 슬롯 자동 추천.
+  const bestSlot = useMemo(() => {
+    if (!window || memberSchedules.length === 0) return null;
+    const aggregate = aggregateAvailability(memberSchedules, allDays);
+    let best: { date: string; slot: number; count: number } | null = null;
+    for (const date of allDays) {
+      const counts = aggregate[date] ?? [];
+      for (let i = 0; i < counts.length; i++) {
+        const c = counts[i] ?? 0;
+        if (c > 0 && (!best || c > best.count)) best = { date, slot: i, count: c };
+      }
+    }
+    return best;
+  }, [allDays, memberSchedules, window]);
+
+  if (!meeting) {
+    return (
+      <div className="px-s-5 py-s-6">
+        <p className="text-foreground-muted text-caption">회의를 찾을 수 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex h-full flex-col overflow-hidden">
+      {/* Header */}
+      <header className="border-border px-s-5 py-s-4 border-b">
+        <div className="text-accent text-caption font-semibold">{meeting.bandName}</div>
+        <h1 className="text-title-lg mt-s-1 font-bold">{meeting.title}</h1>
+        <div className="text-foreground-muted text-caption gap-s-3 mt-s-2 flex flex-wrap items-center">
+          {window && (
+            <span className="gap-s-1 inline-flex items-center">
+              <CalendarDays className="h-3.5 w-3.5" />
+              {window.from} ~ {window.to}
+            </span>
+          )}
+          <span className="gap-s-1 inline-flex items-center">
+            <Crown className="text-amber h-3.5 w-3.5" />
+            매니저 {GLOBAL_MEMBER_POOL.find((m) => m.id === meeting.managerId)?.name ?? '?'}
+          </span>
+          {meeting.confirmedSlot && (
+            <span className="bg-success-dim text-success px-s-2 text-micro rounded-full py-0.5 font-bold">
+              합주 일정 확정 {meeting.confirmedSlot.date}{' '}
+              {slotToTime(meeting.confirmedSlot.startMin / 30)}
+            </span>
+          )}
+        </div>
+        <div className="mt-s-3 gap-s-2 flex flex-wrap items-center">
+          <Button size="sm" variant="primary" onClick={() => setScheduleOpen(true)}>
+            <Clock3 className="h-4 w-4" /> 나의 스케줄 입력
+          </Button>
+          {isManager && memberSchedules.length > 0 && bestSlot && (
+            <Button
+              size="sm"
+              variant="primary"
+              onClick={() => setConfirmOpen(true)}
+              className="bg-success hover:bg-success/90 text-white"
+            >
+              <CheckCircle2 className="h-4 w-4" /> 합주 일정 확정
+            </Button>
+          )}
+        </div>
+      </header>
+
+      {/* Main split — md 이상 좌우 절반, 모바일 세로 */}
+      <div className="flex flex-1 flex-col overflow-hidden md:flex-row">
+        {/* 멤버 리스트 */}
+        <section className="border-border flex-1 overflow-y-auto md:border-r">
+          <div className="px-s-5 py-s-3 border-border border-b">
+            <h2 className="text-foreground text-body font-bold">
+              참여 멤버 ({participants.length})
+            </h2>
+          </div>
+          <ul>
+            {participants.map((m) => {
+              const sched = schedulesAll[`${meetingId}__${m.id}`];
+              const completed = sched?.completed === true;
+              const partial = !!sched && !completed;
+              return (
+                <li key={m.id}>
+                  <button
+                    type="button"
+                    onClick={() => setRightPanel({ kind: 'member', member: m })}
+                    className="hover:bg-card border-border px-s-5 py-s-3 gap-s-3 flex w-full items-center border-b text-left"
+                  >
+                    <MemberAvatar member={m} size="sm" />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-caption truncate font-semibold">
+                        {m.name}
+                        {m.id === currentUserId && (
+                          <span className="text-accent text-micro ml-s-2 font-bold">나</span>
+                        )}
+                      </div>
+                      <div className="text-foreground-muted text-micro truncate">
+                        {m.email ?? m.role}
+                      </div>
+                    </div>
+                    <span
+                      className={cn(
+                        'text-micro px-s-2 shrink-0 rounded-full py-0.5 font-bold',
+                        completed
+                          ? 'bg-success-dim text-success'
+                          : partial
+                            ? 'bg-warn-dim text-warn'
+                            : 'bg-card text-foreground-muted',
+                      )}
+                    >
+                      {completed ? '완료' : partial ? '입력 중' : '미입력'}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+
+        {/* 곡 리스트 */}
+        <section className="flex-1 overflow-y-auto">
+          <div className="px-s-5 py-s-3 border-border gap-s-3 flex items-center justify-between border-b">
+            <h2 className="text-foreground text-body font-bold">합주곡 ({visibleSongs.length})</h2>
+            <UnderlineTabs
+              value={songFilter}
+              onChange={(v) => setSongFilter(v as SongFilter)}
+              items={[
+                { id: 'mine', label: '내 합주곡' },
+                { id: 'all', label: '전체' },
+              ]}
+            />
+          </div>
+          <ul>
+            {visibleSongs.length === 0 ? (
+              <li className="text-foreground-muted py-s-8 text-caption text-center">
+                {songFilter === 'mine' ? '내가 참여한 합주곡이 없습니다.' : '합주곡이 없습니다.'}
+              </li>
+            ) : (
+              visibleSongs.map((song) => (
+                <li key={song.id}>
+                  <button
+                    type="button"
+                    onClick={() => setRightPanel({ kind: 'song', song })}
+                    className="hover:bg-card border-border px-s-5 py-s-3 gap-s-3 flex w-full items-center border-b text-left"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="text-caption truncate font-bold">{song.title}</div>
+                      <div className="text-foreground-muted text-micro truncate">
+                        {song.artist}
+                        {song.duration ? ` · ${song.duration}` : ''}
+                      </div>
+                    </div>
+                    {isReady(song) && (
+                      <span className="bg-success-dim text-success text-micro px-s-2 shrink-0 rounded-full py-0.5 font-bold">
+                        합주 가능
+                      </span>
+                    )}
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </section>
+      </div>
+
+      {/* 우측 상세 패널 — overlay */}
+      {rightPanel && (
+        <aside
+          className="bg-surface border-border absolute top-0 right-0 bottom-0 z-20 hidden w-[380px] flex-col border-l shadow-lg lg:flex"
+          aria-label="상세 패널"
+        >
+          <header className="border-border px-s-5 py-s-4 gap-s-3 flex items-start justify-between border-b">
+            <div className="min-w-0">
+              <div className="text-foreground-muted text-micro font-bold uppercase">
+                {rightPanel.kind === 'member' ? '멤버 일정' : '곡 합주 가능 매트릭스'}
+              </div>
+              <div className="text-subtitle mt-s-1 truncate font-bold">
+                {rightPanel.kind === 'member' ? rightPanel.member.name : rightPanel.song.title}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setRightPanel(null)}
+              className="text-foreground-muted hover:text-foreground rounded-md p-1"
+              aria-label="닫기"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </header>
+          <div className="px-s-5 py-s-4 flex-1 overflow-y-auto">
+            {rightPanel.kind === 'member' ? (
+              <MemberSchedulePanel
+                member={rightPanel.member}
+                meetingId={meetingId}
+                allDays={allDays}
+              />
+            ) : (
+              <SongMatrixPanel
+                memberSchedules={memberSchedules}
+                participants={participants}
+                allDays={allDays}
+              />
+            )}
+          </div>
+        </aside>
+      )}
+
+      {/* 나의 스케줄 입력 모달 */}
+      {scheduleOpen && (
+        <ScheduleInputModal
+          meetingId={meetingId}
+          userId={currentUserId}
+          allDays={allDays}
+          open={scheduleOpen}
+          onOpenChange={setScheduleOpen}
+        />
+      )}
+
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="합주 일정 확정"
+        description={
+          bestSlot
+            ? `가장 많은 멤버가 가능한 ${bestSlot.date} ${slotToTime(bestSlot.slot)} (${bestSlot.count}명) 슬롯으로 확정하시겠습니까?`
+            : '확정 가능한 슬롯이 없습니다.'
+        }
+        confirmLabel="확정"
+        onConfirm={() => {
+          if (!bestSlot) return;
+          // 회의 매니저 확정과 별개로, 합주 일정 슬롯 저장. 추후 BE 도입 시 별도 API.
+          // mvp: lockMeeting 트리거 + meeting.confirmedSlot 은 store 직접 업데이트가 필요 → 일단 toast 만.
+          lockMeeting(meetingId);
+          toast.success(`${bestSlot.date} ${slotToTime(bestSlot.slot)} 로 확정되었습니다.`);
+        }}
+      />
+    </div>
+  );
+}
+
+function MemberSchedulePanel({
+  member,
+  meetingId,
+  allDays,
+}: {
+  member: Member;
+  meetingId: string;
+  allDays: string[];
+}) {
+  const sched = useScheduleStore((s) => s.schedules[`${meetingId}__${member.id}`]);
+  if (!sched) {
+    return (
+      <p className="text-foreground-muted text-caption">
+        {member.name}님은 아직 일정을 입력하지 않았습니다.
+      </p>
+    );
+  }
+  return (
+    <div className="gap-s-4 flex flex-col">
+      <div>
+        <div className="text-foreground-muted text-micro mb-s-2 font-bold uppercase">
+          가능 일자 ({sched.availableDates.length}/{allDays.length})
+        </div>
+        <div className="grid grid-cols-7 gap-1">
+          {allDays.map((d) => {
+            const ratio = (() => {
+              const m = sched.blocks[d];
+              if (!m || !sched.availableDates.includes(d)) return 0;
+              const onCount = m.filter(Boolean).length;
+              return onCount / 48;
+            })();
+            const tone = !sched.availableDates.includes(d)
+              ? 'bg-card text-foreground-muted/40'
+              : ratio === 0
+                ? 'bg-card text-foreground-muted'
+                : ratio < 0.3
+                  ? 'bg-warn-dim text-warn'
+                  : ratio < 0.7
+                    ? 'bg-accent-dim text-accent'
+                    : 'bg-success-dim text-success';
+            return (
+              <span
+                key={d}
+                title={`${d} — 가능 시간 ${Math.round(ratio * 100)}%`}
+                className={cn(
+                  'text-micro rounded-md px-1 py-1 text-center font-mono font-bold',
+                  tone,
+                )}
+              >
+                {d.slice(8)}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+      {sched.note && (
+        <div>
+          <div className="text-foreground-muted text-micro mb-s-2 font-bold uppercase">
+            특이사항
+          </div>
+          <p className="text-foreground text-caption leading-relaxed whitespace-pre-wrap">
+            {sched.note}
+          </p>
+        </div>
+      )}
+      <div className="text-foreground-muted text-micro">
+        {sched.completed ? '입력 완료' : '입력 중'} · 갱신{' '}
+        {sched.updatedAt.slice(0, 16).replace('T', ' ')}
+      </div>
+    </div>
+  );
+}
+
+function SongMatrixPanel({
+  memberSchedules,
+  participants,
+  allDays,
+}: {
+  memberSchedules: ReturnType<typeof useScheduleStore.getState>['schedules'][string][];
+  participants: Member[];
+  allDays: string[];
+}) {
+  const aggregate = useMemo(
+    () => aggregateAvailability(memberSchedules, allDays),
+    [memberSchedules, allDays],
+  );
+  const totalParticipants = participants.length;
+  return (
+    <div className="gap-s-4 flex flex-col">
+      <p className="text-foreground-muted text-caption">
+        참여 {totalParticipants}명 기준 동시 가능한 시간(셀이 진할수록 가능 인원이 많음).
+      </p>
+      <div className="overflow-x-auto">
+        <table className="text-micro w-full text-left">
+          <thead className="text-foreground-muted">
+            <tr>
+              <th className="px-1 py-1">일자</th>
+              {[18, 22, 26, 30, 34, 38, 42].map((s) => (
+                <th key={s} className="px-1 py-1 text-center">
+                  {slotToTime(s)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {allDays.slice(0, 14).map((d) => (
+              <tr key={d} className="border-border border-t">
+                <td className="px-1 py-1 font-mono">{d.slice(5)}</td>
+                {[18, 22, 26, 30, 34, 38, 42].map((s) => {
+                  const c = aggregate[d]?.[s] ?? 0;
+                  const ratio = totalParticipants === 0 ? 0 : c / totalParticipants;
+                  const tone =
+                    ratio === 0
+                      ? 'bg-card text-foreground-muted/30'
+                      : ratio < 0.5
+                        ? 'bg-warn-dim text-warn'
+                        : ratio < 1
+                          ? 'bg-accent-dim text-accent'
+                          : 'bg-success-dim text-success';
+                  return (
+                    <td
+                      key={s}
+                      className={cn('px-1 py-1 text-center font-bold', tone)}
+                      title={`${d} ${slotToTime(s)} — ${c}명 가능`}
+                    >
+                      {c || ''}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function UnderlineTabs<T extends string>({
+  value,
+  onChange,
+  items,
+}: {
+  value: T;
+  onChange: (v: T) => void;
+  items: ReadonlyArray<{ id: T; label: string }>;
+}) {
+  return (
+    <div className="border-border gap-s-4 -mb-px flex">
+      {items.map((it) => {
+        const active = value === it.id;
+        return (
+          <button
+            key={it.id}
+            type="button"
+            onClick={() => onChange(it.id)}
+            className={cn(
+              'pb-s-1 text-caption border-b-2 font-semibold transition-colors',
+              active
+                ? 'border-accent text-accent'
+                : 'text-foreground-muted hover:text-foreground border-transparent',
+            )}
+          >
+            {it.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(main)/setlist-meetings/scheduling/[meetingId]/page.tsx
+++ b/src/app/(main)/setlist-meetings/scheduling/[meetingId]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+import { SchedulingMain } from './SchedulingMain.client';
+
+export const metadata: Metadata = {
+  title: '합주 일정 조율 | Bandage',
+};
+
+export default async function SchedulingDetailPage({
+  params,
+}: {
+  params: Promise<{ meetingId: string }>;
+}) {
+  const { meetingId } = await params;
+  return <SchedulingMain meetingId={meetingId} />;
+}

--- a/src/app/(main)/setlist-meetings/scheduling/page.tsx
+++ b/src/app/(main)/setlist-meetings/scheduling/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from 'next/navigation';
+
+import { SEED_MEETINGS } from '@/domain/setlist-meeting/mock/seed';
+import { ROUTES } from '@/global/config/routes';
+
+/** /setlist-meetings/scheduling — 첫 회의로 자동 redirect. 빈 회의일 경우 안내. */
+export default function SchedulingIndexPage() {
+  const first = SEED_MEETINGS[0];
+  if (first) redirect(ROUTES.SETLIST_SCHEDULING_DETAIL(first.id));
+  return (
+    <div className="px-s-5 py-s-6">
+      <p className="text-foreground-muted text-caption">
+        조율할 선곡 회의가 없습니다. 먼저 회의를 만들어주세요.
+      </p>
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -60,6 +60,7 @@ const mainNav: NavItem[] = [
     subs: [
       { href: `${ROUTES.SETLIST_MEETINGS}?listOpen=1`, label: '나의 선곡 회의' },
       { href: ROUTES.SETLIST_MEETING_NEW, label: '회의 만들기' },
+      { href: ROUTES.SETLIST_SCHEDULING, label: '합주 일정 조율' },
     ],
   },
   { href: ROUTES.ME, label: '마이페이지', icon: User },

--- a/src/domain/schedule-coordination/store/scheduleStore.ts
+++ b/src/domain/schedule-coordination/store/scheduleStore.ts
@@ -1,0 +1,137 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import type { MemberSchedule, SlotMask } from '../types';
+
+const noopStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+};
+
+type Key = string; // `${meetingId}__${userId}`
+
+const keyOf = (meetingId: string, userId: string): Key => `${meetingId}__${userId}`;
+
+interface State {
+  /** meetingId__userId → schedule. localStorage 영속화로 새로고침/재진입에도 유지. */
+  schedules: Record<Key, MemberSchedule>;
+}
+
+interface Actions {
+  getSchedule: (meetingId: string, userId: string) => MemberSchedule | undefined;
+  upsertSchedule: (s: MemberSchedule) => void;
+  toggleAvailableDate: (meetingId: string, userId: string, date: string) => void;
+  setBlocks: (meetingId: string, userId: string, date: string, mask: SlotMask) => void;
+  setNote: (meetingId: string, userId: string, note: string) => void;
+  setCompleted: (meetingId: string, userId: string, completed: boolean) => void;
+  reset: () => void;
+}
+
+const emptyMask = (): SlotMask => Array.from({ length: 48 }, () => false);
+
+/** 9:00~22:00 (= slot 18~43) 기본 활성 마스크 — '나의 스케줄 입력' Step 2 진입 기본값. */
+export const DEFAULT_DAY_MASK: SlotMask = Array.from({ length: 48 }, (_, i) => i >= 18 && i < 44);
+
+const ensureSchedule = (state: State, meetingId: string, userId: string): MemberSchedule => {
+  const k = keyOf(meetingId, userId);
+  return (
+    state.schedules[k] ?? {
+      meetingId,
+      userId,
+      availableDates: [],
+      unavailableDates: [],
+      blocks: {},
+      note: '',
+      completed: false,
+      updatedAt: new Date().toISOString(),
+    }
+  );
+};
+
+export const useScheduleStore = create<State & Actions>()(
+  persist(
+    (set, get) => ({
+      schedules: {},
+
+      getSchedule: (meetingId, userId) => get().schedules[keyOf(meetingId, userId)],
+
+      upsertSchedule: (s) =>
+        set((state) => ({
+          schedules: { ...state.schedules, [keyOf(s.meetingId, s.userId)]: s },
+        })),
+
+      toggleAvailableDate: (meetingId, userId, date) =>
+        set((state) => {
+          const current = ensureSchedule(state, meetingId, userId);
+          const isAvailable = current.availableDates.includes(date);
+          const next: MemberSchedule = isAvailable
+            ? {
+                ...current,
+                availableDates: current.availableDates.filter((d) => d !== date),
+                unavailableDates: [...current.unavailableDates.filter((d) => d !== date), date],
+                updatedAt: new Date().toISOString(),
+              }
+            : {
+                ...current,
+                availableDates: [...current.availableDates, date],
+                unavailableDates: current.unavailableDates.filter((d) => d !== date),
+                updatedAt: new Date().toISOString(),
+              };
+          return {
+            schedules: { ...state.schedules, [keyOf(meetingId, userId)]: next },
+          };
+        }),
+
+      setBlocks: (meetingId, userId, date, mask) =>
+        set((state) => {
+          const current = ensureSchedule(state, meetingId, userId);
+          const next: MemberSchedule = {
+            ...current,
+            blocks: { ...current.blocks, [date]: mask },
+            updatedAt: new Date().toISOString(),
+          };
+          return {
+            schedules: { ...state.schedules, [keyOf(meetingId, userId)]: next },
+          };
+        }),
+
+      setNote: (meetingId, userId, note) =>
+        set((state) => {
+          const current = ensureSchedule(state, meetingId, userId);
+          const next: MemberSchedule = {
+            ...current,
+            note,
+            updatedAt: new Date().toISOString(),
+          };
+          return {
+            schedules: { ...state.schedules, [keyOf(meetingId, userId)]: next },
+          };
+        }),
+
+      setCompleted: (meetingId, userId, completed) =>
+        set((state) => {
+          const current = ensureSchedule(state, meetingId, userId);
+          const next: MemberSchedule = {
+            ...current,
+            completed,
+            updatedAt: new Date().toISOString(),
+          };
+          return {
+            schedules: { ...state.schedules, [keyOf(meetingId, userId)]: next },
+          };
+        }),
+
+      reset: () => set({ schedules: {} }),
+    }),
+    {
+      name: 'bandage-schedule',
+      // 사용자가 실수로 나갔다 들어와도 입력이 유지되도록 localStorage 영속화.
+      storage: createJSONStorage(() =>
+        typeof window === 'undefined' ? noopStorage : window.localStorage,
+      ),
+    },
+  ),
+);
+
+export { emptyMask, keyOf };

--- a/src/domain/schedule-coordination/types.ts
+++ b/src/domain/schedule-coordination/types.ts
@@ -1,0 +1,31 @@
+/**
+ * 합주 일정 조율 도메인 — 멤버별 가용 시간 수집/종합/매니저 확정.
+ */
+
+/** 30분 슬롯 비트마스크. 0=00:00 ~ 47=23:30. */
+export type SlotMask = boolean[]; // length 48
+
+export interface MemberSchedule {
+  meetingId: string;
+  userId: string;
+  /** 사용자가 '가능' 으로 표시한 일자 'YYYY-MM-DD' 목록. */
+  availableDates: string[];
+  /** 명시적으로 '불가능' 으로 표시한 일자. (default: 미표시 = 미선택) */
+  unavailableDates: string[];
+  /** 일자별 시간 블록 — date → 48슬롯 boolean[]. */
+  blocks: Record<string, SlotMask>;
+  /** 특이사항 메모. */
+  note: string;
+  /** 마법사 완료 시 true. 부분 입력 상태도 저장은 됨. */
+  completed: boolean;
+  /** 마지막 업데이트 ISO. */
+  updatedAt: string;
+}
+
+export interface AggregateSlot {
+  date: string;
+  startMin: number;
+  endMin: number;
+  /** 이 슬롯에 가능한 멤버 userId 목록. */
+  availableUserIds: string[];
+}

--- a/src/domain/schedule-coordination/utils.ts
+++ b/src/domain/schedule-coordination/utils.ts
@@ -1,0 +1,122 @@
+import type { MemberSchedule, SlotMask } from './types';
+
+/** 'YYYY-MM-DD' 형식 일자 범위 enumerate. inclusive both ends. */
+export function enumerateDays(from: string, to: string): string[] {
+  if (!from || !to || from > to) return [];
+  const out: string[] = [];
+  const start = new Date(`${from}T00:00:00`);
+  const end = new Date(`${to}T00:00:00`);
+  for (let d = start; d <= end; d.setDate(d.getDate() + 1)) {
+    out.push(d.toISOString().slice(0, 10));
+  }
+  return out;
+}
+
+/** 0=일, 1=월, ... 6=토. */
+export function dayOfWeek(date: string): number {
+  return new Date(`${date}T00:00:00`).getDay();
+}
+
+export function isWeekend(date: string): boolean {
+  const d = dayOfWeek(date);
+  return d === 0 || d === 6;
+}
+
+/** 단순 mock 공휴일 — 2026 한국 일부. 추후 BE 또는 외부 라이브러리로 교체. */
+export const MOCK_KR_HOLIDAYS_2026 = new Set([
+  '2026-01-01',
+  '2026-02-16',
+  '2026-02-17',
+  '2026-02-18',
+  '2026-03-01',
+  '2026-05-05',
+  '2026-05-24',
+  '2026-06-06',
+  '2026-08-15',
+  '2026-09-24',
+  '2026-09-25',
+  '2026-09-26',
+  '2026-10-03',
+  '2026-10-09',
+  '2026-12-25',
+]);
+
+export function isHoliday(date: string): boolean {
+  return MOCK_KR_HOLIDAYS_2026.has(date);
+}
+
+/** 슬롯 인덱스 → 'HH:MM'. */
+export function slotToTime(slot: number): string {
+  const h = Math.floor(slot / 2);
+  const m = slot % 2 === 0 ? '00' : '30';
+  return `${String(h).padStart(2, '0')}:${m}`;
+}
+
+/** 슬롯 인덱스 → 분(0~1440). */
+export function slotToMin(slot: number): number {
+  return slot * 30;
+}
+
+/** ISO week (월요일 시작) — 주차 시작일. */
+export function startOfWeek(date: string): string {
+  const d = new Date(`${date}T00:00:00`);
+  const day = d.getDay(); // 0=일
+  const diff = day === 0 ? -6 : 1 - day; // 월요일 기준
+  d.setDate(d.getDate() + diff);
+  return d.toISOString().slice(0, 10);
+}
+
+export function addDays(date: string, n: number): string {
+  const d = new Date(`${date}T00:00:00`);
+  d.setDate(d.getDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * 멤버 일정 종합 — 같은 날짜·슬롯에 동시 가능한 멤버 수 매트릭스.
+ * 반환: date → SlotMask 형태가 아니라 date → number[] (슬롯별 가능 인원수).
+ */
+export function aggregateAvailability(
+  schedules: MemberSchedule[],
+  dates: string[],
+): Record<string, number[]> {
+  const out: Record<string, number[]> = {};
+  for (const date of dates) {
+    out[date] = Array.from({ length: 48 }, () => 0);
+    for (const s of schedules) {
+      if (!s.availableDates.includes(date)) continue;
+      const mask = s.blocks[date];
+      if (!mask) continue;
+      for (let i = 0; i < 48; i++) {
+        if (mask[i]) out[date]![i]! += 1;
+      }
+    }
+  }
+  return out;
+}
+
+/** SlotMask 에서 (start, end) min 범위 추출 — 가장 긴 연속 가능 구간. */
+export function longestContiguousRange(mask: SlotMask): {
+  startSlot: number;
+  endSlot: number;
+} | null {
+  let bestStart = -1;
+  let bestLen = 0;
+  let curStart = -1;
+  let curLen = 0;
+  for (let i = 0; i < mask.length; i++) {
+    if (mask[i]) {
+      if (curStart === -1) curStart = i;
+      curLen++;
+      if (curLen > bestLen) {
+        bestLen = curLen;
+        bestStart = curStart;
+      }
+    } else {
+      curStart = -1;
+      curLen = 0;
+    }
+  }
+  if (bestLen === 0 || bestStart < 0) return null;
+  return { startSlot: bestStart, endSlot: bestStart + bestLen };
+}

--- a/src/domain/setlist-meeting/types.ts
+++ b/src/domain/setlist-meeting/types.ts
@@ -78,6 +78,10 @@ export type Meeting = {
   practiceSongMap?: Record<string, string>;
   /** 직전 잠금 시점의 곡 스냅샷(재확정 시 변경분 diff 계산용). 단순화: songId 집합. */
   lockSnapshotSongIds?: string[];
+  /** 합주 가능 기간. mvp: 'YYYY-MM-DD'. 공연 모드는 오늘~공연일자 자동, 일반 모드는 사용자 입력. */
+  practiceWindow?: { from: string; to: string };
+  /** 매니저가 확정한 합주 슬롯. */
+  confirmedSlot?: { date: string; startMin: number; endMin: number } | null;
 };
 
 export type SessionState = 'full' | 'partial' | 'empty';

--- a/src/global/config/routes.ts
+++ b/src/global/config/routes.ts
@@ -24,6 +24,8 @@ export const ROUTES = {
   SETLIST_MEETINGS: '/setlist-meetings',
   SETLIST_MEETING_NEW: '/setlist-meetings/new',
   SETLIST_MEETING_DETAIL: (id: string) => `/setlist-meetings/${id}`,
+  SETLIST_SCHEDULING: '/setlist-meetings/scheduling',
+  SETLIST_SCHEDULING_DETAIL: (id: string) => `/setlist-meetings/scheduling/${id}`,
 } as const;
 
 export type AppRoutes = typeof ROUTES;


### PR DESCRIPTION
## 변경 (PRD: `schedule_coordination_prd.txt`)

### 마법사 보강
- Step 3 에 합주 가능 기간(`from~to`) 입력. 공연 모드 진입 시 오늘~공연일자 자동 채움(수정 가능). Step 4 요약 반영
- Step 1 의 공연 picker: 이미 회의가 생성된 공연은 블러 + 비활성 + '회의 생성됨' 배지

### 합주 일정 조율
- 사이드바 sub '합주 일정 조율' + 라우트 `/setlist-meetings/scheduling[/{id}]`
- 메인 화면: 헤더 + 멤버/곡 좌우 분할(언더라인 탭 '내 합주곡/전체') + 멤버·곡 클릭 시 우측 상세 패널
- 도메인 `schedule-coordination` (types/store/utils) — Zustand persist=localStorage 영속화
- 5-step 모달 'ScheduleInputModal': 입력 방식(AI 준비 중/스케줄) → 가능 일자(필터 적용) → 시간 블록(when2meet, 30분, 9-22 기본 활성, 주차 nav) → 특이사항(200자) → 확인. 매 입력마다 즉시 저장
- 매니저 '합주 일정 확정' — 동시 가능 인원 최대 슬롯 자동 추천 + ConfirmDialog

### 문서
- API_REQUIRED.md FE-API-040~043 등록

## 검증
- pnpm typecheck / lint / test 통과 (61 passed, 사이드바 스냅샷 재생성)

Closes #182