### PR TITLE
fix: schedule utils 빈/잘못된 일자 가드

### DIFF
--- a/src/domain/schedule-coordination/utils.ts
+++ b/src/domain/schedule-coordination/utils.ts
@@ -57,9 +57,16 @@ export function slotToMin(slot: number): number {
   return slot * 30;
 }
 
-/** ISO week (월요일 시작) — 주차 시작일. */
+/** YYYY-MM-DD 유효성 가드 — 잘못된/빈 입력은 오늘 일자로 폴백. */
+function safeDate(input: string): Date {
+  const d = input ? new Date(`${input}T00:00:00`) : new Date();
+  if (isNaN(d.getTime())) return new Date();
+  return d;
+}
+
+/** ISO week (월요일 시작) — 주차 시작일. 빈 문자열/잘못된 입력 시 오늘 기준. */
 export function startOfWeek(date: string): string {
-  const d = new Date(`${date}T00:00:00`);
+  const d = safeDate(date);
   const day = d.getDay(); // 0=일
   const diff = day === 0 ? -6 : 1 - day; // 월요일 기준
   d.setDate(d.getDate() + diff);
@@ -67,7 +74,7 @@ export function startOfWeek(date: string): string {
 }
 
 export function addDays(date: string, n: number): string {
-  const d = new Date(`${date}T00:00:00`);
+  const d = safeDate(date);
   d.setDate(d.getDate() + n);
   return d.toISOString().slice(0, 10);
 }


### PR DESCRIPTION
## 증상
`Invalid time value` at `startOfWeek` — `new Date('T00:00:00')` 가 invalid.

## 원인
`SchedulingMain` 에서 `allDays` 가 비어있을 때 모달의 `firstWeekStart = startOfWeek(allDays[0] ?? '')` 로 빈 문자열이 전달됨.

## 수정
`safeDate` 헬퍼 추가 — 빈 입력/parse 실패 시 오늘 일자 폴백. `startOfWeek`/`addDays` 모두 통과시킴.