### PR TITLE
chore: API_SPEC sync (BE) + 신규 fetcher (메트릭·회원 검색·강퇴) + 라이브 검증

### DIFF
--- a/.taskmaster/report/api-spec-sync-verify-2026-04-27.md
+++ b/.taskmaster/report/api-spec-sync-verify-2026-04-27.md
@@ -1,0 +1,211 @@
+# API_SPEC 동기화 + 실서버 검증 리포트
+
+작성일: 2026-04-27
+대상 BE: `http://localhost:8080` (`../v1`)
+대상 FE branch: `feat/api-spec-sync-and-verify`
+영향 범위: BE 가 추가한 신규/변경 엔드포인트 (총 9건) 와 FE 측 fetcher/타입 접목
+
+## 메타
+- 검증 주체: AI Agent (Claude)
+- BE 빌드: 검증 시점 기동 중. 도중 한 번 다운/재기동 발생.
+- 검증 도구: `curl`, `pnpm typecheck/lint/test`
+
+## 1. API_SPEC 동기화
+
+### 1-1. 변경 요지
+
+`../v1/API_SPEC.md` 가 BE 의 신규/수정 사항을 반영해 다음 항목이 추가/갱신됨. FE 의 `API_SPEC.md` 를 BE 본으로 일괄 교체.
+
+| # | 변경 항목                                            | 분류  | FE 영향                                  |
+|---|-----------------------------------------------------|-------|------------------------------------------|
+| 1 | `MemberInfoResponse` 에 `id` alias + `profileImg` 노출 | 수정  | 타입 갱신                                |
+| 2 | `BandMemberInfoResponse` 에 `name`, `profileImg` 노출  | 수정  | `getMemberDisplayName` 폴백 정상화       |
+| 3 | `BandApplicationInfoResponse` 에 `applicantName`, `applicantProfileImg`, `appliedAt` | 수정 | 신청 카드 정상 표기 |
+| 4 | `GET /members/me/metrics` (§2-5)                    | 신규  | 홈 통계 카드 backing                     |
+| 5 | `GET /members/search?q=` (§2-6)                     | 신규  | 글로벌 멤버 검색 — 선곡 회의 마법사 등   |
+| 6 | `PATCH /bands/{id}` (§3-12)                         | 신규  | 밴드 정보 수정                           |
+| 7 | `DELETE /bands/{id}` (§3-13)                        | 신규  | 밴드 삭제                                |
+| 8 | `DELETE /bands/{id}/members/{bandMemberId}` (§3-14) | 신규  | 밴드 멤버 강퇴 (리더)                    |
+| 9 | `PATCH /bands/{id}/members/{bandMemberId}` 본문 `role` 으로 역할 변경 (§3-10 확장) | 수정 | 역할 변경 API 일원화 |
+| 10| `POST /performances/{id}/bands/batch` (§6-9)        | 신규  | 공연 참여 밴드 일괄 추가                 |
+| 11| `DELETE /performances/{id}/bands/{bandId}` (§6-10)  | 신규  | 공연 참여 밴드 단건 제거                 |
+
+### 1-2. FE 적용
+
+- `src/domain/member/types/res.ts`
+  - `MemberInfoResponse`: `id`, `memberId?`, `profileImg?`, optional `createdAt` 으로 갱신
+  - `MemberMetricsResponse` 신규
+  - `MemberSearchItemResponse` 신규
+- `src/domain/member/api/`
+  - `getMyMetrics.ts` 신규 — §2-5
+  - `searchMembers.ts` 신규 — §2-6
+- `src/domain/member/hooks/`
+  - `useMyMetrics.ts` 신규
+  - `useMemberSearch.ts` 신규
+- `src/domain/band/api/removeBandMember.ts` 신규 — §3-14
+- `src/global/config/queryKeys.ts` — `member.myMetrics` / `member.search` 추가
+- `API_SPEC.md` 를 `../v1/API_SPEC.md` 로 일괄 교체
+
+§3-12 (밴드 수정) / §3-13 (밴드 삭제) / §6-9 / §6-10 은 이미 FE 에 fetcher 가 존재 (`updateBand.ts` / `deleteBand.ts` / `batchAddPerformancePractices.ts` / `removePerformancePractice.ts` 외 — `BandPickerModal` 에서 사용 가능 상태). 본 라운드는 호출만 가능하도록 표면을 정리.
+
+### 1-3. 검증 결과 (검증 도구: `pnpm`)
+
+- `pnpm typecheck` — 통과
+- `pnpm lint` — 통과
+- `pnpm test --run` — 61 passed, 12 files
+
+## 2. 실서버 curl 검증
+
+### 2-1. 검증 대상 + 결과 표
+
+| 엔드포인트                                                    | 상태 | 메모                                                      |
+|---------------------------------------------------------------|------|-----------------------------------------------------------|
+| `POST /api/v1/members/join`                                   | ✅   | `id`/`email` 응답                                          |
+| `POST /api/v1/auth/login`                                     | ✅   | `accessToken` 발급                                         |
+| `GET /api/v1/members/me`                                      | ✅   | `id`, `memberId`, `profileImg` alias 모두 노출 ✅           |
+| `GET /api/v1/members/me/metrics` (§2-5 신규)                   | ⚠️    | 검증 시점 BE 라우트 404 — **BE 빌드 동기화 필요**          |
+| `GET /api/v1/members/search?q=verify` (§2-6 신규)              | ✅   | `[{memberId,name,email,profileImg}]` 정상 응답             |
+| `POST /api/v1/bands` (§3-1)                                   | ✅   | `bandId`/`bandName`                                        |
+| `PATCH /api/v1/bands/{id}` (§3-12 신규)                        | ✅   | `description` 부분 수정 후 GET 으로 변경 확인              |
+| `GET /api/v1/bands/{id}` (§3-2)                               | ✅   | `description`, `profileImg` 포함                           |
+| `DELETE /api/v1/bands/{id}` (§3-13 신규)                       | ✅   | 204 (성공)                                                  |
+| `GET /api/v1/bands/me` (§3-3-1)                               | ✅   | 빈 커서 응답                                               |
+| `GET /api/v1/bands/search?keyword=` (§3-3-2)                   | ✅   | 파라미터 `keyword` (NotBlank). 빈/누락 시 400              |
+| `GET /api/v1/practices/me` (§4-1-1)                           | ✅   | 빈 커서 응답                                               |
+| `GET /api/v1/performances/me` (§6-2-1)                        | ✅   | 빈 커서 응답                                               |
+| `GET /api/v1/practice-songs/search?keyword=tool`              | ✅   | TOOL 곡 2건 (Vicarious / Schism)                           |
+| `DELETE /api/v1/bands/{id}/members/{bandMemberId}` (§3-14 신규) | ⏸    | BE 일시 다운으로 단건 검증 보류 — FE fetcher 만 추가       |
+| `POST /api/v1/performances/{id}/bands/batch` (§6-9 신규)       | ⏸    | BE 일시 다운으로 보류                                      |
+| `DELETE /api/v1/performances/{id}/bands/{bandId}` (§6-10 신규) | ⏸    | BE 일시 다운으로 보류                                      |
+
+### 2-2. 케이스별 실제 요청/응답
+
+#### 2-2-1. `/members/me`
+
+요청:
+```http
+GET /api/v1/members/me
+Authorization: Bearer <token>
+```
+응답:
+```json
+{
+  "success": true,
+  "data": {
+    "id": 18,
+    "memberId": 18,
+    "email": "verify-sync@bandage.test",
+    "name": "검증유저",
+    "contact": "010-9999-0001",
+    "profileImg": null
+  }
+}
+```
+판정: **정상**. `id` alias + `memberId` 동시 노출, `profileImg` 필드 추가됨 (FE 타입과 일치).
+
+#### 2-2-2. `/members/me/metrics` (404)
+
+요청:
+```http
+GET /api/v1/members/me/metrics
+Authorization: Bearer <token>
+```
+응답:
+```json
+{ "success": false, "message": "요청한 리소스를 찾을 수 없습니다.", "code": "RESOURCE_NOT_FOUND" }
+```
+HTTP 404.
+
+원인 추정: BE 소스(`MemberController.kt` line 68: `@GetMapping("/me/metrics")`) 에는 라우트가 존재하나 **현재 기동 중인 빌드는 갱신 전**. BE 측 재배포 또는 ./gradlew bootRun 재실행 필요.
+
+확인 체크리스트:
+- [ ] BE 가 최신 소스로 재기동되었는지 (`./gradlew bootRun --args='--spring.profiles.active=local'`)
+- [ ] `MemberMetricsFacade` 가 빈으로 등록되어 있는지
+
+#### 2-2-3. `/members/search?q=verify`
+
+요청/응답:
+```http
+GET /api/v1/members/search?q=verify
+```
+```json
+{
+  "success": true,
+  "data": [
+    { "memberId": 17, "name": "V3VerifyQA", "email": "v3verify+1777177029@bandage.test", "profileImg": null }
+  ]
+}
+```
+판정: **정상**. 본인(memberId=18)은 결과에서 제외됨.
+
+#### 2-2-4. `/bands/{id}` PATCH/GET
+
+요청 PATCH:
+```http
+PATCH /api/v1/bands/019dcd37-4699-7106-8d21-7bba260ab9b3
+{ "description": "수정 테스트" }
+```
+응답: 200 — `BandResponse` (`bandId`, `bandName`).
+
+요청 GET:
+```http
+GET /api/v1/bands/019dcd37-4699-7106-8d21-7bba260ab9b3
+```
+응답:
+```json
+{
+  "success": true,
+  "data": {
+    "bandId": "019dcd37-4699-7106-8d21-7bba260ab9b3",
+    "bandName": "검증밴드SYNC",
+    "description": "수정 테스트",
+    "profileImg": null
+  }
+}
+```
+판정: **정상**. `description` 부분 수정 반영 확인.
+
+#### 2-2-5. 파라미터 네이밍 — `keyword` vs `q`
+
+- `GET /bands/search` — `keyword` (NotBlank). FE `searchBands.ts` 이미 `keyword` 사용 ✅
+- `GET /practice-songs/search` — `keyword` (NotBlank). FE `searchSongs.ts` 이미 `keyword` 사용 ✅
+- `GET /members/search` — `q` (default `""`). FE `searchMembers.ts` 신규 — `q` 사용 ✅
+
+## 3. 권장 조치 내용 및 검토 필요 사항
+
+### 🟠 기능 저하 (P1)
+1. **`/members/me/metrics` 404** — 신규 라우트가 실제 응답하지 않음. BE 측 재기동 후 재검증 필요. FE 는 fetcher 를 추가해 두었으므로 빌드 갱신 시 자동 동작.
+   - 재현: `curl -H "Authorization: Bearer <token>" http://localhost:8080/api/v1/members/me/metrics` → 404
+   - 추정 원인: 컨트롤러 코드는 존재(line 68)하나 기동 중 JAR 이 구버전.
+   - 체크리스트: `./gradlew clean bootRun` 재실행 후 200 반환 여부 확인.
+
+### 🟡 품질 (P2)
+2. **세 검색 API 의 파라미터 네이밍 일관성** — `bands/search`·`practice-songs/search` 는 `keyword`, `members/search` 는 `q`. 클라이언트 혼동 가능. 본 라운드는 BE 결정을 그대로 반영하되, 향후 `q` 로 통일 검토 가치.
+
+### ℹ️ 참고
+3. **§3-14 / §6-9 / §6-10** 단건 통합 검증은 BE 일시 다운 직전까지 진행하지 못함. FE 의 `removeBandMember.ts` / 기존 `batchAddPerformancePractices` / `removePerformancePractice` 는 호출 시그니처가 SPEC 과 일치 — 다음 라운드에서 라이브 시퀀스(밴드 생성 → 가입 → 강퇴 / 공연 생성 → 밴드 batch 추가 → 단건 제거) 로 검증 권장.
+
+## 4. 프론트 관련 구현 지점
+
+| 파일                                                | 변경                                                            |
+|-----------------------------------------------------|-----------------------------------------------------------------|
+| `API_SPEC.md`                                       | BE 본으로 일괄 교체                                             |
+| `src/domain/member/types/res.ts`                    | `MemberInfoResponse` 보강 + `MemberMetricsResponse` / `MemberSearchItemResponse` 신규 |
+| `src/domain/member/types/index.ts`                  | 신규 타입 export                                                |
+| `src/domain/member/api/getMyMetrics.ts`             | 신규 (§2-5)                                                     |
+| `src/domain/member/api/searchMembers.ts`            | 신규 (§2-6)                                                     |
+| `src/domain/member/hooks/useMyMetrics.ts`           | 신규                                                            |
+| `src/domain/member/hooks/useMemberSearch.ts`        | 신규                                                            |
+| `src/domain/band/api/removeBandMember.ts`           | 신규 (§3-14)                                                    |
+| `src/global/config/queryKeys.ts`                    | `member.myMetrics`, `member.search` 추가                        |
+
+## 5. 재현용 페이로드 위치
+
+`/tmp/sync-verify/` 에 검증 셸이 일부 남아있음 (BE 다운 직전까지 cookies/headers/JSON). 다음 라운드 검증 시 동일 위치 재사용 가능.
+
+## 6. 다음 라운드 권장 시퀀스
+
+1. BE 재기동 후 `/members/me/metrics` 200 응답 확인.
+2. 강퇴(§3-14) — 신규 사용자 join → 밴드 가입 → 승인 → 강퇴 → 멤버 목록에서 제거 확인.
+3. 공연 batch (§6-9 / §6-10) — 공연 생성 → `bandIds` 일괄 추가 → 응답의 `performanceBandId` 확인 → 단건 제거 → 멤버십 정리 확인.
+4. 위 결과를 `.taskmaster/report/api-spec-sync-verify-2026-04-28.md` 로 후속 리포트 작성 권장.

--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -41,9 +41,17 @@ Base URL: `/api/v1`
 | 12 | 입력 검증 메시지 정제 (T3, T6) | API_ISSUE_REPORT §4-3 | ✅ 해소 | `HttpMessageNotReadableException` 핸들러가 `KotlinInvalidNullException`/`InvalidFormatException` 을 한국어 메시지 + `fieldErrors` 로 매핑 |
 | 13 | 과거 시각 startAt 검증 (T17) | API_ISSUE_REPORT §4-4 | ✅ 해소 | Practice/Performance 생성·수정·합주 일정 변경 DTO 의 `startAt` 에 `@Future` 적용 (4-1/4-8/6-1/6-4 참조) |
 
-### 미해소 / 프론트 책임
+### 추가 반영 (2026-04-27)
 
-- **`MemberInfoResponse.memberId` vs 프론트 기대 `id`** (MVP 통합 §3): 백엔드는 도메인 prefix 컨벤션(`bandId`, `practiceId`, `songId`, `bandMemberId`...)을 따르므로 `memberId` 유지. 프론트 타입을 `memberId`로 갱신 필요.
+| # | 이슈 | 출처 | 상태 | 비고 |
+|---|---|---|---|---|
+| 14 | `MemberInfoResponse.id` alias / `profileImg` 노출 | MVP 통합 §3 | ✅ 해소 | `id` 와 `memberId` 동시 노출 (alias), `profileImg` 필드 추가 (2-2 참조) |
+| 15 | `BandMemberInfoResponse` 에 회원 이름/프로필 이미지 포함 | FE-API-012 | ✅ 해소 | `name`, `profileImg` 추가 (3-4/3-5 참조) |
+| 16 | `BandApplicationInfoResponse` 에 신청자 정보 포함 | FE-API-013 | ✅ 해소 | `applicantName`, `applicantProfileImg`, `appliedAt` 추가 (3-7 참조) |
+| 17 | 회원 메트릭 (밴드 수 / 다가오는 합주·공연 수 / 세션 수) | FE-API-014 | ✅ 해소 | `GET /members/me/metrics` 신규 (2-5 참조). 네이밍은 Stat → Metrics 로 통일 |
+| 18 | 회원 검색 (이름/이메일 부분 일치) | FE-API-032 | ✅ 해소 | `GET /members/search?q=` 신규, 본인 제외, 최대 20건 (2-6 참조) |
+| 19 | 밴드 정보 수정 / 삭제 / 멤버 강퇴 / 역할 변경 | FE-API-022/023, §8-2 | ✅ 해소 | 3-12 ~ 3-15 참조 |
+| 20 | 공연 참여 밴드 일괄 추가/단건 제거 | FE-API-017 | ✅ 해소 | 6-9 / 6-10 참조 |
 
 ---
 
@@ -131,7 +139,18 @@ Base URL: `/api/v1`
 ### 2-2. 내 정보 조회
 - **GET** `/api/v1/members/me`
 - **인증 필요**
-- **Response**: (구현 예정 — 현재 `Unit` 반환)
+- **Response**: `MemberInfoResponse`
+  ```json
+  {
+    "id": 1,
+    "memberId": 1,
+    "email": "member@google.com",
+    "name": "홍길동",
+    "contact": "010-1234-5678",
+    "profileImg": "https://cdn/...jpg"
+  }
+  ```
+- **비고**: `id` 는 `memberId` 의 프론트 호환 alias 필드. `profileImg` 는 미설정 시 `null`.
 
 ---
 
@@ -153,6 +172,44 @@ Base URL: `/api/v1`
 - **DELETE** `/api/v1/members/me`
 - **인증 필요**
 - **비고**: 회원 정보 삭제(soft delete) 및 로그아웃 처리 (쿠키 만료)
+
+---
+
+### 2-5. 내 메트릭 조회
+- **GET** `/api/v1/members/me/metrics`
+- **인증 필요**
+- **Response**: `MemberMetricsResponse`
+  ```json
+  {
+    "bandCount": 3,
+    "upcomingPracticeCount": 2,
+    "upcomingPerformanceCount": 1,
+    "sessionCount": 5
+  }
+  ```
+- **비고**: 본인이 소속된 밴드 수, 본인이 참여한 다가오는 합주 수(`startAt > now`), 본인 소속 밴드의 다가오는 공연 수(`startAt > now`), 본인이 참여 중인 합주 세션 수. 도메인 간 의존(`Band`/`Practice`/`Performance`)이 있어 `MemberMetricsFacade` 에서 집계.
+
+---
+
+### 2-6. 회원 검색
+- **GET** `/api/v1/members/search`
+- **인증 필요**
+- **Query Parameters**
+  | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+  |---------|------|------|--------|------|
+  | `q` | String | N | `""` | 검색 키워드 (이름 또는 이메일) |
+- **Response**: `List<MemberSearchItemResponse>`
+  ```json
+  [
+    {
+      "memberId": 1,
+      "name": "홍길동",
+      "email": "user@bandage.test",
+      "profileImg": "https://cdn/...jpg"
+    }
+  ]
+  ```
+- **비고**: 이름/이메일 부분 일치 (대소문자 구분 X). 본인은 결과에서 제외. 최대 20건.
 
 ---
 
@@ -255,15 +312,17 @@ Base URL: `/api/v1`
 - **GET** `/api/v1/bands/{bandId}/members/{bandMemberId}`
 - **인증 필요**
 - **Path Variables**: `bandId` (UUID), `bandMemberId` (UUID)
-- **Response**
+- **Response**: `BandMemberInfoResponse`
   ```json
   {
     "bandMemberId": "550e8400-e29b-41d4-a716-446655440000",
     "memberId": 1,
-    "role": "MEMBER"
+    "role": "MEMBER",
+    "name": "홍길동",
+    "profileImg": "https://cdn/...jpg"
   }
   ```
-- **비고**: `role` enum — `LEADER` | `ADMIN` | `MEMBER`
+- **비고**: `role` enum — `LEADER` | `ADMIN` | `MEMBER`. `name`/`profileImg` 는 회원 조회 후 매핑 (FE-API-012).
 
 ---
 
@@ -299,9 +358,13 @@ Base URL: `/api/v1`
   {
     "bandApplicationId": "550e8400-...",
     "memberId": 1,
-    "status": "PENDING"
+    "status": "PENDING",
+    "applicantName": "홍길동",
+    "applicantProfileImg": "https://cdn/...jpg",
+    "appliedAt": "2026-04-26T12:34:56"
   }
   ```
+- **비고**: `applicantName`/`applicantProfileImg` 는 신청자 회원 조회 후 매핑 (FE-API-013). `appliedAt` 은 신청 생성 시각.
 
 ---
 
@@ -321,11 +384,20 @@ Base URL: `/api/v1`
 
 ---
 
-### 3-10. 밴드 리더 권한 위임
+### 3-10. 밴드 멤버 역할 변경 / 리더 위임
 - **PATCH** `/api/v1/bands/{bandId}/members/{bandMemberId}/role`
 - **인증 필요** (리더)
 - **Path Variables**: `bandId` (UUID), `bandMemberId` (UUID)
-- **비고**: 현재 리더 권한을 지정 멤버에게 양도
+- **Request Body** (optional)
+  ```json
+  {
+    "role": "ADMIN"
+  }
+  ```
+  - `role` enum — `LEADER` | `ADMIN` | `MEMBER`
+- **비고**:
+  - body 미제공 또는 `role=LEADER` 면 **리더 권한 위임** 동작 (현재 리더가 지정 멤버에게 권한 양도)
+  - `role=ADMIN` / `role=MEMBER` 면 해당 역할로 변경
 
 ---
 
@@ -333,6 +405,44 @@ Base URL: `/api/v1`
 - **DELETE** `/api/v1/bands/{bandId}/members/me`
 - **인증 필요**
 - **Path Variable**: `bandId` (UUID)
+
+---
+
+### 3-12. 밴드 정보 수정
+- **PATCH** `/api/v1/bands/{bandId}`
+- **인증 필요** (리더)
+- **Path Variable**: `bandId` (UUID)
+- **Request Body** (모든 필드 optional, 전달된 필드만 갱신)
+  ```json
+  {
+    "name": "TuNA",
+    "description": "성균관대학교 락밴드입니다.",
+    "profileImg": "https://cdn/...jpg"
+  }
+  ```
+- **Response**: `BandResponse`
+  ```json
+  {
+    "bandId": "550e8400-e29b-41d4-a716-446655440000",
+    "bandName": "TuNA"
+  }
+  ```
+
+---
+
+### 3-13. 밴드 삭제
+- **DELETE** `/api/v1/bands/{bandId}`
+- **인증 필요** (리더)
+- **Path Variable**: `bandId` (UUID)
+- **비고**: 밴드 및 소속 멤버를 cascade soft-delete.
+
+---
+
+### 3-14. 밴드 멤버 강퇴
+- **DELETE** `/api/v1/bands/{bandId}/members/{bandMemberId}`
+- **인증 필요** (리더)
+- **Path Variables**: `bandId` (UUID), `bandMemberId` (UUID)
+- **비고**: 리더 자신은 강퇴 불가.
 
 ---
 
@@ -884,3 +994,38 @@ Base URL: `/api/v1`
 - **인증 필요** (PerformanceManager)
 - **Path Variable**: `performanceId` (UUID)
 - **비고**: 연관된 합주도 함께 삭제
+
+---
+
+### 6-9. 공연 참여 밴드 일괄 추가
+- **POST** `/api/v1/performances/{performanceId}/bands/batch`
+- **인증 필요** (PerformanceManager)
+- **Path Variable**: `performanceId` (UUID)
+- **Request Body**
+  ```json
+  {
+    "bandIds": [
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001"
+    ]
+  }
+  ```
+  - `bandIds`: not empty
+- **Response**: `List<PerformanceBandResponse>`
+  ```json
+  [
+    {
+      "performanceBandId": "550e8400-e29b-41d4-a716-446655440010",
+      "bandId": "550e8400-e29b-41d4-a716-446655440000"
+    }
+  ]
+  ```
+- **비고**: append 시맨틱. 이미 등록된 밴드는 무시하고 응답에서도 제외.
+
+---
+
+### 6-10. 공연 참여 밴드 단건 제거
+- **DELETE** `/api/v1/performances/{performanceId}/bands/{bandId}`
+- **인증 필요** (PerformanceManager)
+- **Path Variables**: `performanceId` (UUID), `bandId` (UUID)
+- **비고**: 공연에서 특정 참여 밴드 매핑을 제거 (밴드 자체는 삭제되지 않음).

--- a/src/domain/band/api/removeBandMember.ts
+++ b/src/domain/band/api/removeBandMember.ts
@@ -1,0 +1,6 @@
+import { apiClient } from '@/global/api/apiClient';
+
+/** API_SPEC §3-14 — 밴드 멤버 강퇴 (리더만). 리더 자신은 강퇴 불가. */
+export async function removeBandMember(bandId: string, bandMemberId: string): Promise<void> {
+  await apiClient.delete<null>(`/api/v1/bands/${bandId}/members/${bandMemberId}`);
+}

--- a/src/domain/member/api/getMyMetrics.ts
+++ b/src/domain/member/api/getMyMetrics.ts
@@ -1,0 +1,8 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { MemberMetricsResponse } from '../types';
+
+/** API_SPEC §2-5 — 본인 메트릭(밴드/다가오는 합주/공연/세션 수). */
+export async function getMyMetrics(): Promise<MemberMetricsResponse> {
+  return apiClient.get<MemberMetricsResponse>('/api/v1/members/me/metrics');
+}

--- a/src/domain/member/api/searchMembers.ts
+++ b/src/domain/member/api/searchMembers.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { MemberSearchItemResponse } from '../types';
+
+/**
+ * API_SPEC §2-6 — 글로벌 회원 검색.
+ * 이름/이메일 부분 일치(대소문자 무시). 본인 제외, 최대 20건.
+ * 빈 q 는 빈 배열을 반환하도록 호출 측에서 검증.
+ */
+export async function searchMembers(q: string): Promise<MemberSearchItemResponse[]> {
+  return apiClient.get<MemberSearchItemResponse[]>('/api/v1/members/search', {
+    query: { q },
+  });
+}

--- a/src/domain/member/hooks/useMemberSearch.ts
+++ b/src/domain/member/hooks/useMemberSearch.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+
+import { searchMembers } from '../api/searchMembers';
+import type { MemberSearchItemResponse } from '../types';
+
+/** API_SPEC §2-6 — 글로벌 회원 검색. q 가 빈 문자열이면 호출하지 않고 빈 배열 반환. */
+export function useMemberSearch(q: string, options?: { enabled?: boolean }) {
+  const authenticated = useIsAuthenticated();
+  const trimmed = q.trim();
+  return useQuery<MemberSearchItemResponse[], Error>({
+    queryKey: queryKeys.member.search(trimmed),
+    queryFn: () => searchMembers(trimmed),
+    enabled: (options?.enabled ?? true) && authenticated && trimmed.length > 0,
+    staleTime: 30 * 1000,
+  });
+}

--- a/src/domain/member/hooks/useMyMetrics.ts
+++ b/src/domain/member/hooks/useMyMetrics.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+
+import { getMyMetrics } from '../api/getMyMetrics';
+import type { MemberMetricsResponse } from '../types';
+
+/** API_SPEC §2-5 — 본인 메트릭 (홈 화면 통계 카드 backing). */
+export function useMyMetrics(options?: { enabled?: boolean; staleTime?: number }) {
+  const authenticated = useIsAuthenticated();
+  return useQuery<MemberMetricsResponse, Error>({
+    queryKey: [...queryKeys.member.myMetrics],
+    queryFn: getMyMetrics,
+    enabled: (options?.enabled ?? true) && authenticated,
+    staleTime: options?.staleTime ?? 60 * 1000,
+  });
+}

--- a/src/domain/member/types/index.ts
+++ b/src/domain/member/types/index.ts
@@ -1,4 +1,9 @@
 export type { JoinRequest, UpdateMeRequest } from './req';
-export type { JoinResponse, MemberInfoResponse } from './res';
+export type {
+  JoinResponse,
+  MemberInfoResponse,
+  MemberMetricsResponse,
+  MemberSearchItemResponse,
+} from './res';
 export { joinSchema, updateMeSchema } from './schema';
 export type { JoinSchema, UpdateMeSchema } from './schema';

--- a/src/domain/member/types/res.ts
+++ b/src/domain/member/types/res.ts
@@ -4,9 +4,29 @@ export interface JoinResponse {
 }
 
 export interface MemberInfoResponse {
+  /** API_SPEC §2-2: `id` 는 `memberId` 의 프론트 호환 alias. */
   id: number;
+  memberId?: number;
   email: string;
   name: string;
   contact: string;
-  createdAt: string;
+  /** 프로필 이미지 URL. 미설정 시 null. */
+  profileImg?: string | null;
+  createdAt?: string;
+}
+
+/** API_SPEC §2-5 — 홈 화면 통계 카드. */
+export interface MemberMetricsResponse {
+  bandCount: number;
+  upcomingPracticeCount: number;
+  upcomingPerformanceCount: number;
+  sessionCount: number;
+}
+
+/** API_SPEC §2-6 — 회원 검색 결과 단건. */
+export interface MemberSearchItemResponse {
+  memberId: number;
+  name: string;
+  email: string;
+  profileImg?: string | null;
 }

--- a/src/global/config/queryKeys.ts
+++ b/src/global/config/queryKeys.ts
@@ -4,6 +4,8 @@ export const queryKeys = {
   },
   member: {
     me: ['member', 'me'] as const,
+    myMetrics: ['member', 'me', 'metrics'] as const,
+    search: (q: string) => ['member', 'search', q] as const,
   },
   band: {
     all: ['band'] as const,


### PR DESCRIPTION
## 변경
- API_SPEC.md 를 `../v1/API_SPEC.md` (BE 최신본) 으로 일괄 교체
- 신규 fetcher: `getMyMetrics` (§2-5), `searchMembers` (§2-6), `removeBandMember` (§3-14)
- 신규 hook: `useMyMetrics`, `useMemberSearch`
- `MemberInfoResponse` 보강 (id/memberId alias, profileImg)
- 검증 리포트: `.taskmaster/report/api-spec-sync-verify-2026-04-27.md`

## 실서버 검증 요약
- 통과: /members/me · /members/search · /bands CRUD · /bands/me · /practices/me · /performances/me · /practice-songs/search?keyword= · /bands/search?keyword=
- ⚠️ /members/me/metrics: 404 — BE 컨트롤러는 존재하나 기동 빌드가 구버전. **BE 재기동 후 재검증 필요**
- ⏸ §3-14 (강퇴), §6-9/§6-10 (공연 밴드 batch) — BE 일시 다운으로 단건 검증 보류