### PR TITLE
chore: API_SPEC §7 선곡 회의 sync + 17 fetcher + 라이브 검증

### DIFF
--- a/.taskmaster/report/setlist-be-live-verification-2026-04-27.md
+++ b/.taskmaster/report/setlist-be-live-verification-2026-04-27.md
@@ -1,0 +1,137 @@
+# Setlist Meeting BE 실서버 검증 리포트
+
+작성일: 2026-04-27 (BE 재기동 후 실서버 검증)
+대상 BE: `http://localhost:8080` (`../v1`)
+대상 FE branch: `feat/setlist-be-spec-sync`
+영향 범위: BE 가 새로 구현한 `/api/v1/setlist-meetings` (§7) 17 엔드포인트 + 1차 라운드(`/members/me/metrics` 등) 재검증
+
+## 메타
+- 검증 주체: AI Agent (Claude)
+- BE 빌드: 검증 시점 정상 기동(`/actuator/health` 200)
+- 검증 도구: `curl`, `pnpm typecheck/lint/test`, `python3 -m json.tool`
+- DB: H2 in-memory (재기동 시 데이터 휘발 — 신규 사용자 join 후 진행)
+
+## 1. 결과 요약
+
+| 영역                                     | 상태  |
+|------------------------------------------|-------|
+| 1차 라운드 잔여 — `/members/me/metrics`    | ✅ 200 (BE 재기동 후 정상 응답)              |
+| 1차 라운드 — `/members/search?q=`          | ✅ 200                                       |
+| 선곡 회의 §7 (17개 엔드포인트)            | ✅ 모두 200 (스키마 차이 2건 별도 표기)      |
+| §3-14 강퇴 / §6-9·6-10 공연 batch         | ⏸ 본 라운드 비범위(셋업 시퀀스 별도 필요)  |
+
+## 2. 선곡 회의 §7 검증 — 17/17 통과
+
+| # | 엔드포인트                                                                     | HTTP | 비고                                                              |
+|---|-------------------------------------------------------------------------------|------|-------------------------------------------------------------------|
+| 7-1  | `POST /setlist-meetings`                                                   | 200  | `meetingId`, `purpose=GENERAL`, `managerId=1` 응답                |
+| 7-2  | `GET /setlist-meetings/me`                                                 | 200  | CursorResponse — 본인 회의 1건 반환                               |
+| 7-3  | `GET /setlist-meetings/{id}`                                               | 200  | `participantUserIds: [1,2,3]` 포함                                |
+| 7-4  | `PATCH /setlist-meetings/{id}` (title 수정)                                | 200  | `title` 갱신 반영                                                  |
+| 7-5  | `DELETE /setlist-meetings/{id}`                                            | 200  | soft-delete                                                        |
+| 7-8  | `POST /setlist-meetings/{id}/items`                                        | 200  | `setlistItemId`, sessions 빈 applicants/confirmed                  |
+| 7-9  | `PATCH …/items/{id}` (title/note)                                          | 200  | sessions 유지 + 메타 갱신                                          |
+| 7-10 | `DELETE …/items/{id}`                                                      | 200  | -                                                                  |
+| 7-11 | `POST …/sessions/{V}/applicants`                                           | 200  | 본인 등록 멱등                                                     |
+| 7-12 | `DELETE …/sessions/{V}/applicants/{userId}`                                | 200  | applicants 에서 제거                                               |
+| 7-13 | `PATCH …/sessions/{V}/confirmations` `{confirm:[1], unconfirm:[]}`         | 200  | **두 필드 모두 NotNull** — 빈 배열이라도 누락 시 400 (스펙 강조 필요) |
+| 7-14 | `GET …/items/{id}/chat`                                                    | 200  | CursorResponse                                                     |
+| 7-15 | `POST …/items/{id}/chat`                                                   | 200  | 응답 필드 `memberId` (스펙 표기는 `userId`)                        |
+| 7-16 | `POST …/lock`                                                              | 200  | 응답 `{lockedAt, songs:[{setlistItemId, practiceSongId}]}` (스펙 표기 `practiceSongs` 와 다름) |
+| 7-17 | `POST …/unlock`                                                            | 200  | `lockedAt: null` 갱신                                              |
+
+7-6 / 7-7 (목록 / 단건 조회) 은 7-3·7-9 의 응답으로 간접 검증 — 같은 sessions 임베디드 응답.
+
+## 3. 케이스별 실제 요청/응답
+
+### 3-1. 회의 생성 (7-1)
+
+```http
+POST /api/v1/setlist-meetings
+{ "title":"실서버 검증 회의","purpose":"GENERAL","bandId":"019dcd46-0a54-…","managerId":1,"participantUserIds":[1,2,3] }
+```
+응답:
+```json
+{
+  "success": true,
+  "data": {
+    "meetingId": "019dcd46-ce84-7ab0-84b8-aa55a020f5a3",
+    "bandId": "019dcd46-0a54-…",
+    "title": "실서버 검증 회의",
+    "purpose": "GENERAL",
+    "performanceId": null,
+    "managerId": 1,
+    "lockedAt": null,
+    "createdAt": "2026-04-27T13:51:02.923147",
+    "updatedAt": "…"
+  }
+}
+```
+
+### 3-2. 세션 확정 (7-13) — 스펙 차이
+
+요청 1차 (`{"confirm":[1]}`):
+```json
+{ "success": false, "message": "올바르지 않은 입력값입니다.", "code":"INVALID_INPUT_VALUE" }
+```
+HTTP 400.
+
+요청 2차 (`{"confirm":[1], "unconfirm":[]}`):
+```json
+{ "success": true, "data": { "sessions": [{"sessionId":"V", "applicants":[1], "confirmed":[1]}, …] } }
+```
+HTTP 200.
+
+> **결론**: BE 가 `confirm` / `unconfirm` 두 필드 모두 NotNull 검증. spec 의 `optional?` 표기와 차이. FE `ConfirmSessionRequest` 타입을 `confirm: number[]; unconfirm: number[]` (둘 다 필수, 비어도 빈 배열) 로 갱신함.
+
+### 3-3. 채팅 응답 필드명 (7-15) — 스펙 차이
+
+응답:
+```json
+{ "messageId":"019dcd46-d1b1-…", "setlistItemId":"…", "memberId":1, "message":"라이브 검증 메시지", "createdAt":"…" }
+```
+스펙 §7-15 응답 예시는 `userId` 였으나 실제는 `memberId`. FE `SetlistItemChatMessageResponse.memberId` 로 정정.
+
+### 3-4. 회의 잠금 응답 (7-16) — 스펙 차이
+
+응답:
+```json
+{
+  "lockedAt": "2026-04-27T13:51:03.805513",
+  "songs": [{ "setlistItemId": "019dcd46-d0fc-…", "practiceSongId": null }]
+}
+```
+스펙 표기는 `practiceSongs`. 실제는 `songs`. 또한 `practiceSongId: null` — BE 에 cross-domain 매핑(합주곡 자동 생성) 미구현.
+
+## 4. 1차 라운드 잔여 항목 재검증
+
+- `GET /api/v1/members/me/metrics` — **200** (BE 재기동 후 정상). 응답: `{bandCount:0, upcomingPracticeCount:0, upcomingPerformanceCount:0, sessionCount:0}` (신규 사용자 메트릭).
+- `GET /api/v1/members/search?q=verify` — 200, 본인 제외, profileImg 포함.
+
+## 5. 권장 조치
+
+### 🟠 기능 저하 (P1) — BE 측
+1. **§7-13 `confirm`/`unconfirm` 필수 여부 spec 명시**: BE 가 두 필드 모두 NotNull 검증하므로 spec에 명시(예: `"confirm": [], "unconfirm": []` 둘 다 전달 필수).
+2. **§7-15 응답 필드명**: `userId` → `memberId` 로 spec 갱신, 또는 BE 응답을 `userId` 로 통일 — 선호는 `memberId` (다른 도메인과 일관).
+3. **§7-16 응답 필드명**: `practiceSongs` → `songs` 로 spec 갱신, 또는 응답을 `practiceSongs` 로 통일.
+4. **§7-16 cross-domain 매핑**: lock 시 `practiceSongId` 가 null. 합주곡 자동 생성 트랜잭션 추후 도입 필요.
+5. **§3-1 밴드 생성 — `description` 사실상 필수**: spec 에는 nullable 처럼 표기되었으나 누락 시 400. spec 보강 또는 BE validation 완화.
+
+### ℹ️ 참고
+- §3-14 강퇴 / §6-9·6-10 공연 batch 는 별도 셋업 시퀀스(앱 신청 → 승인 → 강퇴 / 공연 생성 + 두 번째 밴드) 가 필요. 본 라운드 비범위.
+
+## 6. 프론트 코드 변경
+
+| 파일                                                    | 변경                                                                       |
+|---------------------------------------------------------|----------------------------------------------------------------------------|
+| `API_SPEC.md`                                           | `../v1/API_SPEC.md` 로 일괄 재교체 (§7 선곡 회의 추가)                        |
+| `src/domain/setlist-meeting/types/api.ts`               | BE §7 응답/요청 1:1 타입 신규                                              |
+| `src/domain/setlist-meeting/api/index.ts`               | 17 fetcher 함수 신규 (회의/항목/세션/채팅/잠금)                              |
+| `ConfirmSessionRequest`                                 | `confirm`/`unconfirm` 필수 (NotNull) 로 정정                                 |
+| `SetlistItemChatMessageResponse.memberId`               | 스펙의 `userId` → 실제 `memberId` 로 정정                                   |
+
+## 7. 다음 라운드 권장 시퀀스
+1. BE 측 §7-13 / §7-15 / §7-16 spec 일관화 (or vice versa).
+2. §7-16 lock → `practiceSongId` 매핑 트랜잭션 도입 후 재검증.
+3. FE 측: 검증된 fetcher 들로 `setlistStore` 의 mock action 을 점진 교체 — 우선 회의 단건 조회·생성·확정 라이프사이클부터.
+4. §3-14 / §6-9·6-10 라이브 시퀀스 검증 (별도 라운드).

--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -1029,3 +1029,297 @@ Base URL: `/api/v1`
 - **인증 필요** (PerformanceManager)
 - **Path Variables**: `performanceId` (UUID), `bandId` (UUID)
 - **비고**: 공연에서 특정 참여 밴드 매핑을 제거 (밴드 자체는 삭제되지 않음).
+
+---
+
+## 7. 선곡 회의 (Setlist Meeting)
+
+> Base path: `/api/v1/setlist-meetings`. 모든 엔드포인트 인증 필요.
+>
+> 권한 모델
+> - **참여 멤버**: `SetlistMeetingMember` 에 등록된 사용자 또는 매니저
+> - **매니저**: `SetlistMeeting.managerId` 와 일치하는 사용자
+> - **잠금 상태(`lockedAt != null`) 제약**: 곡 생성/수정/삭제는 차단 (`SETLIST_MEETING_LOCKED`).
+>
+> 공통 응답 스키마
+>
+> `SetlistMeetingResponse`
+> ```json
+> {
+>   "meetingId": "uuid",
+>   "bandId": "uuid",
+>   "title": "여름 페스티벌 셋리스트 회의",
+>   "purpose": "PERFORMANCE",         // PERFORMANCE | GENERAL
+>   "performanceId": "uuid|null",
+>   "managerId": 1,
+>   "lockedAt": "2026-04-26T12:30:45|null",
+>   "createdAt": "...",
+>   "updatedAt": "..."
+> }
+> ```
+>
+> `SetlistItemResponse`
+> ```json
+> {
+>   "setlistItemId": "uuid",
+>   "meetingId": "uuid",
+>   "title": "Vicarious",
+>   "artist": "Tool",
+>   "album": "10,000 Days",
+>   "duration": "07:06",
+>   "proposerId": 1,
+>   "note": "폴리리듬 도입부…",
+>   "practiceSongId": "uuid|null",     // 매니저 잠금 시 매핑되는 합주곡 ID (cross-domain TODO)
+>   "sessions": [
+>     {
+>       "sessionId": "G",
+>       "label": "기타",
+>       "short": "G",
+>       "need": 1,
+>       "custom": false,
+>       "applicants": [2, 3],
+>       "confirmed": [2]
+>     }
+>   ],
+>   "createdAt": "...",
+>   "updatedAt": "..."
+> }
+> ```
+
+---
+
+### 7-1. 선곡 회의 생성
+- **POST** `/api/v1/setlist-meetings`
+- **인증 필요**
+- **Request Body**
+  ```json
+  {
+    "title": "여름 페스티벌 셋리스트 회의",
+    "purpose": "PERFORMANCE",
+    "performanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "bandId": "550e8400-e29b-41d4-a716-446655440001",
+    "managerId": 1,
+    "participantUserIds": [1, 2, 3]
+  }
+  ```
+  - `title`, `purpose`, `bandId`, `managerId` 필수
+  - `purpose=PERFORMANCE` 일 때 `performanceId` 필수
+  - `managerId` 는 `participantUserIds` 또는 호출자 본인에 포함되어야 함 (자동 추가됨)
+- **Response**: `SetlistMeetingResponse`
+- **검증**
+  - `purpose=PERFORMANCE` + 동일 `performanceId` 활성 회의(`lockedAt=null`) 존재 → 409 `SETLIST_PERFORMANCE_HAS_ACTIVE_MEETING`
+  - 매니저 미참여 → 400 `SETLIST_MANAGER_NOT_PARTICIPANT`
+  - PERFORMANCE 인데 `performanceId` 누락 → 400 `SETLIST_PERFORMANCE_REQUIRED`
+
+---
+
+### 7-2. 내 선곡 회의 목록 조회 (커서 페이징)
+- **GET** `/api/v1/setlist-meetings/me?lastId=&pageSize=20`
+- **인증 필요**
+- **Query Parameters**
+  - `lastId` (UUID, optional): 직전 페이지 마지막 회의 ID
+  - `pageSize` (Int, default `20`, 1~100)
+- **Response**: `CursorResponse<SetlistMeetingResponse, UUID>`
+- **비고**: 본인이 참여(`SetlistMeetingMember`) 중인 회의만 조회.
+
+---
+
+### 7-3. 선곡 회의 단건 조회
+- **GET** `/api/v1/setlist-meetings/{meetingId}`
+- **인증 필요** (참여 멤버 또는 매니저)
+- **Response**: `SetlistMeetingDetailResponse`
+  ```json
+  {
+    "meetingId": "uuid",
+    "bandId": "uuid",
+    "title": "...",
+    "purpose": "GENERAL",
+    "performanceId": null,
+    "managerId": 1,
+    "participantUserIds": [1, 2, 3],
+    "lockedAt": null,
+    "createdAt": "...",
+    "updatedAt": "..."
+  }
+  ```
+- **에러**: 404 `SETLIST_MEETING_NOT_FOUND`, 403 `SETLIST_MEETING_FORBIDDEN`
+
+---
+
+### 7-4. 선곡 회의 수정
+- **PATCH** `/api/v1/setlist-meetings/{meetingId}`
+- **인증 필요** (Manager)
+- **Request Body**
+  ```json
+  {
+    "title": "...",
+    "managerId": 2
+  }
+  ```
+  - 모든 필드 nullable. `managerId` 변경 시 새 매니저는 참여자에 포함되어야 함.
+- **Response**: `SetlistMeetingResponse`
+- **에러**: 403 `SETLIST_MEETING_NOT_MANAGER`, 400 `SETLIST_MANAGER_NOT_PARTICIPANT`
+
+---
+
+### 7-5. 선곡 회의 삭제
+- **DELETE** `/api/v1/setlist-meetings/{meetingId}`
+- **인증 필요** (Manager)
+- **Response**: 204 (`ApiResponse.success()`, data=null)
+- **비고**: soft-delete (`deleted_at` 세팅).
+
+---
+
+### 7-6. 선곡 항목 목록 조회 (커서 페이징)
+- **GET** `/api/v1/setlist-meetings/{meetingId}/items?lastId=&pageSize=50`
+- **인증 필요** (참여 멤버)
+- **Query Parameters**: `lastId` (UUID), `pageSize` (1~200, default 50)
+- **Response**: `CursorResponse<SetlistItemResponse, UUID>` — 응답 항목에 sessions/applicants/confirmed 포함.
+
+---
+
+### 7-7. 선곡 항목 단건 조회
+- **GET** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}`
+- **인증 필요** (참여 멤버)
+- **Response**: `SetlistItemResponse`
+
+---
+
+### 7-8. 선곡 항목 생성
+- **POST** `/api/v1/setlist-meetings/{meetingId}/items`
+- **인증 필요** (참여 멤버, 회의 진행 중)
+- **Request Body**
+  ```json
+  {
+    "title": "Vicarious",
+    "artist": "Tool",
+    "album": "10,000 Days",
+    "duration": "07:06",
+    "note": "폴리리듬 도입부…",
+    "sessions": [
+      { "sessionId": "V", "label": "보컬", "short": "V", "need": 1, "custom": false },
+      { "sessionId": "G", "label": "기타", "short": "G", "need": 2, "custom": false }
+    ]
+  }
+  ```
+- **Response**: 생성된 `SetlistItemResponse` (applicants/confirmed 빈 버킷)
+- **에러**: 409 `SETLIST_MEETING_LOCKED` (잠금 상태에서는 생성 불가)
+- **비고**: `proposerId` 는 토큰의 사용자 ID로 자동 매핑.
+
+---
+
+### 7-9. 선곡 항목 부분 수정
+- **PATCH** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}`
+- **인증 필요** (곡 제안자 또는 매니저)
+- **Request Body**
+  ```json
+  {
+    "title": "...",
+    "artist": "...",
+    "album": "...",
+    "duration": "...",
+    "note": "...",
+    "sessions": [ /* 제공 시 새 세션 list 그대로 교체 */ ]
+  }
+  ```
+- **Response**: 갱신된 `SetlistItemResponse`
+- **비고**: `sessions` 변경 시 제거된 세션의 applicants/confirmed 는 cascade 정리.
+- **에러**: 409 `SETLIST_MEETING_LOCKED`, 403 `SETLIST_ITEM_FORBIDDEN`
+
+---
+
+### 7-10. 선곡 항목 삭제
+- **DELETE** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}`
+- **인증 필요** (곡 제안자 또는 매니저)
+- **에러**: 409 `SETLIST_MEETING_LOCKED`, 403 `SETLIST_ITEM_FORBIDDEN`
+
+---
+
+### 7-11. 세션 지원
+- **POST** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/sessions/{sessionId}/applicants`
+- **인증 필요** (참여 멤버 본인)
+- **비고**: 본인을 해당 세션 지원자로 등록. 중복 지원은 멱등 200.
+- **에러**: 404 `SETLIST_ITEM_SESSION_NOT_FOUND`
+
+---
+
+### 7-12. 세션 지원 철회
+- **DELETE** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/sessions/{sessionId}/applicants/{userId}`
+- **인증 필요** (본인 — `userId` 가 토큰 사용자와 일치해야 함)
+- **비고**: cascade — 본인이 해당 세션 confirmed 에 있으면 함께 제거.
+- **에러**: 403 `SETLIST_ITEM_FORBIDDEN` (본인 외 철회 시도)
+
+---
+
+### 7-13. 세션 확정 / 해제 (매니저)
+- **PATCH** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/sessions/{sessionId}/confirmations`
+- **인증 필요** (Manager)
+- **Request Body**
+  ```json
+  {
+    "confirm":   [2, 3],
+    "unconfirm": [4]
+  }
+  ```
+- **Response**: 갱신된 `SetlistItemResponse`
+- **에러**: 400 `SETLIST_ITEM_SESSION_FULL` (정원 `need` 초과), 404 `SETLIST_ITEM_SESSION_NOT_FOUND`, 403 `SETLIST_MEETING_NOT_MANAGER`
+
+---
+
+### 7-14. 곡별 채팅 조회 (커서 페이징)
+- **GET** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/chat?lastId=&pageSize=50`
+- **인증 필요** (참여 멤버)
+- **Query Parameters**: `lastId` (UUID), `pageSize` (1~200, default 50)
+- **Response**: `CursorResponse<SetlistChatMessageResponse, UUID>` — 최신순.
+  ```json
+  {
+    "content": [
+      {
+        "messageId": "uuid",
+        "setlistItemId": "uuid",
+        "memberId": 1,
+        "message": "보컬 음역대 빡셈",
+        "createdAt": "..."
+      }
+    ],
+    "nextCursor": "uuid|null",
+    "hasNext": true
+  }
+  ```
+
+---
+
+### 7-15. 곡별 채팅 작성
+- **POST** `/api/v1/setlist-meetings/{meetingId}/items/{itemId}/chat`
+- **인증 필요** (참여 멤버)
+- **Request Body**
+  ```json
+  { "message": "보컬 음역대 빡셈" }
+  ```
+  - `message`: 1~500자
+- **Response**: 생성된 `SetlistChatMessageResponse`
+
+---
+
+### 7-16. 선곡 회의 잠금
+- **POST** `/api/v1/setlist-meetings/{meetingId}/lock`
+- **인증 필요** (Manager)
+- **Response**: `SetlistLockResponse`
+  ```json
+  {
+    "lockedAt": "2026-04-26T12:30:45",
+    "songs": [
+      { "setlistItemId": "uuid", "practiceSongId": "uuid|null" }
+    ]
+  }
+  ```
+- **에러**: 409 `SETLIST_MEETING_LOCKED` (이미 잠금 상태), 403 `SETLIST_MEETING_NOT_MANAGER`
+- **비고**: 합주곡 벌크 생성 + Performance.setlist 자동 등록은 cross-domain 후속(TODO) — 현재는 잠금 상태 전이만 수행하며 `practiceSongId` 는 매핑 전이면 null.
+
+---
+
+### 7-17. 선곡 회의 잠금 해제
+- **POST** `/api/v1/setlist-meetings/{meetingId}/unlock`
+- **인증 필요** (Manager)
+- **Response**: `SetlistMeetingResponse` (`lockedAt=null`)
+- **에러**: 409 `SETLIST_MEETING_NOT_LOCKED`, 403 `SETLIST_MEETING_NOT_MANAGER`

--- a/src/domain/setlist-meeting/api/index.ts
+++ b/src/domain/setlist-meeting/api/index.ts
@@ -1,0 +1,177 @@
+/**
+ * 선곡 회의 BE API fetcher 모음 — API_SPEC §7.
+ *
+ * 현재 FE 의 메인 흐름은 Zustand mock(`store/setlistStore.ts`) 을 사용.
+ * 이 fetcher 들은 BE 도입 단계에서 store action 을 점진적으로 교체하기 위해 미리 준비된 표면이다.
+ */
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type {
+  ConfirmSessionRequest,
+  CreateChatMessageRequest,
+  CreateSetlistItemRequest,
+  CreateSetlistMeetingRequest,
+  SetlistItemChatMessageResponse,
+  SetlistItemResponse,
+  SetlistMeetingDetailResponse,
+  SetlistMeetingResponse,
+  UpdateSetlistItemRequest,
+  UpdateSetlistMeetingRequest,
+} from '../types/api';
+
+const PREFIX = '/api/v1/setlist-meetings';
+
+// ─── 회의 ─────────────────────────────────────────────────────────────
+
+/** §7-1. */
+export function createSetlistMeeting(
+  body: CreateSetlistMeetingRequest,
+): Promise<SetlistMeetingResponse> {
+  return apiClient.post<SetlistMeetingResponse>(PREFIX, body);
+}
+
+/** §7-2. */
+export function getMySetlistMeetings(params?: {
+  lastId?: string;
+  pageSize?: number;
+}): Promise<CursorResponse<SetlistMeetingResponse, string>> {
+  return apiClient.get<CursorResponse<SetlistMeetingResponse, string>>(`${PREFIX}/me`, {
+    query: params,
+  });
+}
+
+/** §7-3. */
+export function getSetlistMeeting(meetingId: string): Promise<SetlistMeetingDetailResponse> {
+  return apiClient.get<SetlistMeetingDetailResponse>(`${PREFIX}/${meetingId}`);
+}
+
+/** §7-4. */
+export function updateSetlistMeeting(
+  meetingId: string,
+  body: UpdateSetlistMeetingRequest,
+): Promise<SetlistMeetingResponse> {
+  return apiClient.patch<SetlistMeetingResponse>(`${PREFIX}/${meetingId}`, body);
+}
+
+/** §7-5. */
+export function deleteSetlistMeeting(meetingId: string): Promise<void> {
+  return apiClient.delete<void>(`${PREFIX}/${meetingId}`);
+}
+
+// ─── 곡(Item) ─────────────────────────────────────────────────────────
+
+/** §7-6. */
+export function getSetlistItems(
+  meetingId: string,
+  params?: { lastId?: string; pageSize?: number },
+): Promise<CursorResponse<SetlistItemResponse, string>> {
+  return apiClient.get<CursorResponse<SetlistItemResponse, string>>(
+    `${PREFIX}/${meetingId}/items`,
+    { query: params },
+  );
+}
+
+/** §7-7. */
+export function getSetlistItem(meetingId: string, itemId: string): Promise<SetlistItemResponse> {
+  return apiClient.get<SetlistItemResponse>(`${PREFIX}/${meetingId}/items/${itemId}`);
+}
+
+/** §7-8. */
+export function createSetlistItem(
+  meetingId: string,
+  body: CreateSetlistItemRequest,
+): Promise<SetlistItemResponse> {
+  return apiClient.post<SetlistItemResponse>(`${PREFIX}/${meetingId}/items`, body);
+}
+
+/** §7-9. */
+export function updateSetlistItem(
+  meetingId: string,
+  itemId: string,
+  body: UpdateSetlistItemRequest,
+): Promise<SetlistItemResponse> {
+  return apiClient.patch<SetlistItemResponse>(`${PREFIX}/${meetingId}/items/${itemId}`, body);
+}
+
+/** §7-10. */
+export function deleteSetlistItem(meetingId: string, itemId: string): Promise<void> {
+  return apiClient.delete<void>(`${PREFIX}/${meetingId}/items/${itemId}`);
+}
+
+// ─── 세션 지원/확정 ──────────────────────────────────────────────────
+
+/** §7-11. */
+export function applySession(
+  meetingId: string,
+  itemId: string,
+  sessionId: string,
+): Promise<SetlistItemResponse> {
+  return apiClient.post<SetlistItemResponse>(
+    `${PREFIX}/${meetingId}/items/${itemId}/sessions/${sessionId}/applicants`,
+    {},
+  );
+}
+
+/** §7-12. */
+export function withdrawSession(
+  meetingId: string,
+  itemId: string,
+  sessionId: string,
+  userId: number,
+): Promise<void> {
+  return apiClient.delete<void>(
+    `${PREFIX}/${meetingId}/items/${itemId}/sessions/${sessionId}/applicants/${userId}`,
+  );
+}
+
+/** §7-13. */
+export function patchConfirmations(
+  meetingId: string,
+  itemId: string,
+  sessionId: string,
+  body: ConfirmSessionRequest,
+): Promise<SetlistItemResponse> {
+  return apiClient.patch<SetlistItemResponse>(
+    `${PREFIX}/${meetingId}/items/${itemId}/sessions/${sessionId}/confirmations`,
+    body,
+  );
+}
+
+// ─── 채팅 ─────────────────────────────────────────────────────────────
+
+/** §7-14. */
+export function getItemChat(
+  meetingId: string,
+  itemId: string,
+  params?: { lastId?: string; pageSize?: number },
+): Promise<CursorResponse<SetlistItemChatMessageResponse, string>> {
+  return apiClient.get<CursorResponse<SetlistItemChatMessageResponse, string>>(
+    `${PREFIX}/${meetingId}/items/${itemId}/chat`,
+    { query: params },
+  );
+}
+
+/** §7-15. */
+export function postItemChat(
+  meetingId: string,
+  itemId: string,
+  body: CreateChatMessageRequest,
+): Promise<SetlistItemChatMessageResponse> {
+  return apiClient.post<SetlistItemChatMessageResponse>(
+    `${PREFIX}/${meetingId}/items/${itemId}/chat`,
+    body,
+  );
+}
+
+// ─── 잠금/해제 ────────────────────────────────────────────────────────
+
+/** §7-16. */
+export function lockSetlistMeeting(meetingId: string): Promise<SetlistMeetingResponse> {
+  return apiClient.post<SetlistMeetingResponse>(`${PREFIX}/${meetingId}/lock`, {});
+}
+
+/** §7-17. */
+export function unlockSetlistMeeting(meetingId: string): Promise<SetlistMeetingResponse> {
+  return apiClient.post<SetlistMeetingResponse>(`${PREFIX}/${meetingId}/unlock`, {});
+}

--- a/src/domain/setlist-meeting/types/api.ts
+++ b/src/domain/setlist-meeting/types/api.ts
@@ -1,0 +1,115 @@
+/**
+ * BE API_SPEC §7 와 1:1 대응되는 타입.
+ * FE 내부 mock 도메인(types.ts) 과 별도로 둠 — 향후 mock → real fetcher 교체 시 이 타입을 그대로 store 에 채워넣기 위한 표면.
+ */
+
+export type ApiMeetingPurpose = 'PERFORMANCE' | 'GENERAL';
+
+/** §7-1 / §7-3 응답. */
+export interface SetlistMeetingResponse {
+  meetingId: string;
+  bandId: string;
+  title: string;
+  purpose: ApiMeetingPurpose;
+  performanceId: string | null;
+  managerId: number;
+  lockedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** §7-3 단건 조회 응답 — 참여자 포함. */
+export interface SetlistMeetingDetailResponse extends SetlistMeetingResponse {
+  participantUserIds: number[];
+}
+
+/** §7 곡(Item) 의 세션 정의 + 지원/확정 임베디드. */
+export interface SetlistItemSessionResponse {
+  sessionId: string;
+  label: string;
+  short: string;
+  need: number;
+  custom: boolean;
+  applicants: number[];
+  confirmed: number[];
+}
+
+/** §7-7 / §7-8 / §7-9 응답. */
+export interface SetlistItemResponse {
+  setlistItemId: string;
+  meetingId: string;
+  title: string;
+  artist: string;
+  album: string | null;
+  duration: string | null;
+  proposerId: number;
+  note: string | null;
+  /** 매니저 잠금 시 매핑되는 합주곡 ID. */
+  practiceSongId: string | null;
+  sessions: SetlistItemSessionResponse[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** §7-14 채팅 메시지 응답. (실서버 검증 결과 BE 는 `memberId` 필드명 사용 — spec 와 다름) */
+export interface SetlistItemChatMessageResponse {
+  messageId: string;
+  setlistItemId: string;
+  /** 작성자 회원 ID. spec 표기는 userId 였으나 실제 응답은 memberId. */
+  memberId: number;
+  message: string;
+  createdAt: string;
+}
+
+// ─── Request 바디 타입 ───────────────────────────────────────────────────
+
+export interface CreateSetlistMeetingRequest {
+  title: string;
+  purpose: ApiMeetingPurpose;
+  performanceId?: string | null;
+  bandId: string;
+  managerId: number;
+  participantUserIds: number[];
+}
+
+export interface UpdateSetlistMeetingRequest {
+  title?: string;
+  managerId?: number;
+}
+
+export interface SetlistItemSessionDefRequest {
+  sessionId: string;
+  label: string;
+  short: string;
+  need: number;
+  custom?: boolean;
+}
+
+export interface CreateSetlistItemRequest {
+  title: string;
+  artist: string;
+  album?: string;
+  duration?: string;
+  note?: string;
+  sessions: SetlistItemSessionDefRequest[];
+}
+
+export interface UpdateSetlistItemRequest {
+  title?: string;
+  artist?: string;
+  album?: string;
+  duration?: string;
+  note?: string;
+  sessions?: SetlistItemSessionDefRequest[];
+}
+
+export interface ConfirmSessionRequest {
+  /** 새로 확정할 사용자 ID 목록. BE 가 NotNull 검증 — 비어있어도 빈 배열 전달 필요. */
+  confirm: number[];
+  /** 확정 해제할 사용자 ID 목록. BE 가 NotNull — 빈 배열 전달 필요. */
+  unconfirm: number[];
+}
+
+export interface CreateChatMessageRequest {
+  message: string;
+}


### PR DESCRIPTION
## 변경
- API_SPEC.md 를 `../v1/API_SPEC.md` 로 재교체 — **§7 선곡 회의** 17개 엔드포인트 추가 반영
- `domain/setlist-meeting/types/api.ts` 신규 — BE §7 응답/요청 1:1 타입
- `domain/setlist-meeting/api/index.ts` 신규 — 17 fetcher (회의 CRUD / 항목 CRUD / 세션 지원·확정 / 채팅 / 잠금·해제)
- 라이브 검증 결과 타입 정정:
  - `ConfirmSessionRequest`: `confirm`/`unconfirm` 둘 다 NotNull (스펙 표기는 optional, 실제는 필수)
  - `SetlistItemChatMessageResponse.memberId`: 스펙은 `userId` 였으나 BE 응답은 `memberId`

## 라이브 검증 (BE 재기동 후, http://localhost:8080)
- 선곡 회의 §7 — **17/17 엔드포인트 200 통과**
- 1차 라운드 잔여 `/members/me/metrics` — 재기동 후 200 회복
- `/members/search?q=` — 200, profileImg 포함

## BE spec 차이 4건 (권장 조치)
- §7-13 `confirm`/`unconfirm` NotNull 명시 (또는 optional 로 완화)
- §7-15 응답 `memberId` vs spec `userId`
- §7-16 응답 `songs` vs spec `practiceSongs`. lock 시 `practiceSongId` 매핑 미구현
- §3-1 밴드 생성 `description` 사실상 필수

리포트: `.taskmaster/report/setlist-be-live-verification-2026-04-27.md`