### PR TITLE
[BD-23] feat: presign 요청에 contentLength 반영 — BE 추가 스펙 동기화

### DIFF
--- a/src/global/upload/constants.ts
+++ b/src/global/upload/constants.ts
@@ -8,7 +8,10 @@ export type AllowedImageMime = (typeof ALLOWED_IMAGE_MIME)[number];
 /** `<input accept>` 용. */
 export const ALLOWED_IMAGE_ACCEPT = ALLOWED_IMAGE_MIME.join(',');
 
-/** S3 단일 PUT 한도 + UX 안전 마진. 5MB. */
+/**
+ * BE `ProfileImageUploadService.MAX_PROFILE_IMAGE_BYTES` 와 동일하게 유지 (5MB).
+ * 초과 시 BE 가 `413 FILE_SIZE_EXCEEDED` 반환.
+ */
 export const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
 
 export function extFromMime(mime: string): string | null {

--- a/src/global/upload/types.ts
+++ b/src/global/upload/types.ts
@@ -7,6 +7,11 @@ export interface ProfileImagePresignRequest {
   contentType: string;
   /** 점 제외, 소문자. */
   ext: string;
+  /**
+   * 업로드할 파일의 정확한 바이트 크기 (1 ~ 5,242,880).
+   * BE 가 contentLength 를 시그니처에 포함하므로 PUT body 크기와 정확히 일치해야 한다.
+   */
+  contentLength: number;
 }
 
 export interface ProfileImagePresignResponse {

--- a/src/global/upload/uploadProfileImage.ts
+++ b/src/global/upload/uploadProfileImage.ts
@@ -23,6 +23,9 @@ export async function uploadProfileImage({
   if (!isAllowedImageMime(file.type)) {
     throw new Error('JPEG / PNG / WEBP 형식만 업로드할 수 있습니다.');
   }
+  if (file.size <= 0) {
+    throw new Error('빈 파일은 업로드할 수 없습니다.');
+  }
   if (file.size > MAX_IMAGE_SIZE_BYTES) {
     throw new Error('이미지 크기는 5MB 이하여야 합니다.');
   }
@@ -37,6 +40,7 @@ export async function uploadProfileImage({
     bandId,
     contentType: file.type,
     ext,
+    contentLength: file.size,
   });
   await uploadToPresignedUrl(presign.uploadUrl, file);
   return presign.objectKey;


### PR DESCRIPTION
## 🛠️ Issue Number
### Jira: [BD-23](https://sunwoo1137.atlassian.net/browse/BD-23) — Multipart file 이미지 처리 구현(S3) (follow-up)

📌 **작업 내용 및 특이사항**

선행 PR #192 머지 후 BE `ProfileImageUploadService` 가 갱신되어 `contentLength` 가 presign 요청에 필수로 추가되었고, BE 가 5MB 한도를 직접 검증하도록 변경됨. FE 도 동일 계약에 맞춤.

### 변경
- `ProfileImagePresignRequest.contentLength: number` 추가 (1 ~ 5,242,880 바이트)
- `uploadProfileImage` 가 `file.size` 를 `contentLength` 로 전달
- `file.size <= 0` 사전 차단 (BE 가 `@Min(1)` 으로 거부)
- BE 가 `contentLength` 를 S3 시그니처에 포함하므로 PUT body 크기와 정확히 일치해야 함을 주석에 명시
- `MAX_IMAGE_SIZE_BYTES` 의 BE 대응 상수(`MAX_PROFILE_IMAGE_BYTES`) 와 413 FILE_SIZE_EXCEEDED 응답 매핑 주석 추가

### 라이브 검증 (2026-05-04)
- contentLength 누락 → `400 INVALID_INPUT_VALUE`
- contentLength=0 → `400 INVALID_INPUT_VALUE` (fieldErrors.contentLength)
- contentLength=5,242,881 → `413 FILE_SIZE_EXCEEDED`
- contentLength=5,242,880 (정확히 5MB) → `200`
- 정상 PUT (declared==actual=163) → `200`
- 거짓 declare (presign=163, PUT=300) → S3 `403 SignatureDoesNotMatch`

📚 **참고사항**
- 호출 측 (`ProfileImageUpload`) 는 변경 불필요 — `uploadProfileImage` 인터페이스 동일
- BE 변경 파일: `v1/src/main/kotlin/com/bandage/v1/domain/upload/service/ProfileImageUploadService.kt` (validateContentLength + S3 issuer 시그니처 보강)

[BD-23]: https://sunwoo1137.atlassian.net/browse/BD-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ