### PR TITLE
[BD-14] feat: Kakao/Google OAuth FE — SDK 기반 토큰 제출 흐름

### DIFF
--- a/.taskmaster/report/auth-oauth-api-verification-2026-05-04.md
+++ b/.taskmaster/report/auth-oauth-api-verification-2026-05-04.md
@@ -1,0 +1,183 @@
+# OAuth FE 연동 검증 리포트 (2026-05-04)
+
+## 메타
+
+- 작성일: 2026-05-04
+- 작성자: FE
+- 대상 BE: `http://localhost:8080` (develop HEAD = e748f71 시점 BE 명세)
+- 대상 FE: `feat/BD-14-oauth-sdk-fe` (develop 분기, BD-14)
+- 검증 도구: curl + browser DevTools (정상 흐름은 브라우저 수동 테스트 필요)
+- BE 명세 출처: 사용자 제공 "v1 백엔드 OAuth 구성 / FE 연동 명세" + 직접 swagger 교차 + Kotlin 소스 확인
+
+---
+
+## 0. 한 줄 요약
+
+BE 가 token-submission 흐름(FE SDK → 토큰 → BE 검증) 으로 구현되어 있어, 기존 `feat/BD-14-oauth-fe` 의 redirect-flow 구현은 폐기. SDK 기반으로 전면 재작성하여 라이브 검증(BE 401/400/CORS) 통과. 정상 흐름(정상 토큰 발급 → JWT 수신) 은 외부 콘솔 셋업 + 브라우저 수동 테스트 필요.
+
+---
+
+## 1. BE Contract (검증 후 확정)
+
+| 항목 | 값 |
+|---|---|
+| Kakao endpoint | `POST /api/v1/auth/oauth/kakao` |
+| Kakao body | `{ accessToken: string }` (BE Bean Validation `@NotBlank`) |
+| Google endpoint | `POST /api/v1/auth/oauth/google` |
+| Google body | `{ idToken: string }` (BE Bean Validation `@NotBlank`) |
+| 응답 | `ApiResponse<{ accessToken, isNewMember }>` + `Set-Cookie: refreshToken=...; HttpOnly; Secure; SameSite=None; Path=/; Max-Age=14d` |
+| 인증 | 불필요 (FE 가 _skipAuthHeader + _skipAuthRefresh 로 호출) |
+
+---
+
+## 2. 라이브 검증 결과
+
+| # | 케이스 | 호출 | 응답 | 판정 |
+|---|---|---|---|---|
+| 1 | Kakao 잘못된 access token | `POST /auth/oauth/kakao { accessToken: "clearly-not-a-token" }` | `401 OAUTH_TOKEN_INVALID` | 정상 |
+| 2 | Google 잘못된 ID token | `POST /auth/oauth/google { idToken: "clearly-not-a-jwt" }` | `401 OAUTH_TOKEN_INVALID` | 정상 |
+| 3 | Google 빈 idToken | `POST /auth/oauth/google { idToken: "" }` | `400 INVALID_INPUT_VALUE` (`fieldErrors.idToken`) | 정상 |
+| 4 | refresh endpoint 존재 | `POST /api/v1/auth/refresh` (no cookie) | `401` | 정상 (인증 없으면 401) |
+| 5 | CORS preflight | `OPTIONS /auth/oauth/google` (Origin: localhost:3000) | `200`, `Allow-Origin: localhost:3000`, `Allow-Credentials: true`, `Expose-Headers: Set-Cookie` | 정상 |
+| 6 | OAuth Provider 정상 흐름 | (브라우저 SDK 호출 필요) | — | **사용자 수동 테스트 필요** |
+| 7 | 신규 가입 + 로그인 분기 | `isNewMember=true` 응답 | — | 사용자 수동 테스트 필요 |
+| 8 | provider mismatch (이메일 동일, 다른 provider) | `409 OAUTH_PROVIDER_MISMATCH` | — | 시나리오 재현 가능 시 검증 |
+
+응답 본문 raw:
+```json
+// case 1, 2
+{
+  "success": false,
+  "message": "유효하지 않은 소셜 인증 토큰입니다.",
+  "code": "OAUTH_TOKEN_INVALID",
+  "timestamp": "2026-05-04T16:29:11.060388"
+}
+// case 3
+{
+  "success": false,
+  "message": "공백일 수 없습니다",
+  "code": "INVALID_INPUT_VALUE",
+  "fieldErrors": { "idToken": "공백일 수 없습니다" },
+  "timestamp": "2026-05-04T16:29:11.494218"
+}
+```
+
+---
+
+## 3. FE 구현 요약
+
+### 3-1. 추가/변경 파일
+
+```
+src/global/config/env.ts                     # KAKAO_JS_KEY / GOOGLE_CLIENT_ID schema 추가 (optional + 빈문자열 normalize)
+src/global/types/kakao-sdk.d.ts              # Kakao SDK 2.x 최소 표면
+src/global/types/google-gsi.d.ts             # Google Identity Services 최소 표면
+
+src/domain/auth/oauth/kakao.ts               # SDK 동적 로드 (SRI 포함) + Kakao.init + Kakao.Auth.login → access token
+src/domain/auth/oauth/google.ts              # GIS 동적 로드 + initialize (FedCM on) + prompt() → ID token
+src/domain/auth/oauth/index.ts               # 배럴 + oauthErrorMessage (BE code → 한국어 안내)
+
+src/domain/auth/types/req.ts                 # KakaoLoginRequest / GoogleLoginRequest 추가
+src/domain/auth/types/res.ts                 # OAuthLoginResponse 추가
+src/domain/auth/types/index.ts               # barrel 갱신
+
+src/domain/auth/api/kakaoLogin.ts            # POST /auth/oauth/kakao + _skipAuthRefresh + _skipAuthHeader
+src/domain/auth/api/googleLogin.ts           # POST /auth/oauth/google + 동일
+
+src/domain/auth/hooks/useKakaoLogin.ts       # TanStack mutation
+src/domain/auth/hooks/useGoogleLogin.ts      # 동일
+
+src/app/(auth)/login/OAuthSection.client.tsx # 카카오/구글 버튼 onClick 연결, isNewMember 분기 메시지, busy 시 disabled
+```
+
+### 3-2. 핵심 결정
+
+- **`_skipAuthRefresh: true` + `_skipAuthHeader: true`** — OAuth 호출은 인증 전이므로 401 인터셉터의 refresh 루프를 건너뛴다. 이 두 옵션이 없으면 BE 의 `401 OAUTH_TOKEN_INVALID` 가 자동 refresh 시도 → refresh 실패 → 사용자 unauthenticated 처리로 빠져 도메인 메시지가 사용자에게 노출되지 않는다.
+- **SDK loader 는 singleton promise** — 한 번만 script 삽입, 이후 호출은 캐시된 promise.
+- **Kakao SDK SRI 해시 포함** — supply chain 공격 방지 (CDN 변조 시 브라우저가 거부).
+- **Google FedCM 활성화** (`use_fedcm_for_prompt: true`) — Chrome third-party cookie 정책과 무관하게 prompt 표시.
+- **isNewMember 분기** — 응답의 `isNewMember=true` 면 환영 토스트, 아니면 일반 로그인 토스트. (온보딩 페이지 라우팅은 별도 작업)
+- **버튼 disabled 처리** — 두 mutation 중 하나라도 pending 이면 모든 OAuth 버튼 disabled (중복 클릭 방지).
+
+### 3-3. 환경변수 명칭
+
+| FE | BE | 비고 |
+|---|---|---|
+| `NEXT_PUBLIC_KAKAO_JS_KEY` | (BE 미사용) | Kakao JavaScript SDK 키 |
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | `GOOGLE_OAUTH_CLIENT_ID` | **반드시 동일 값** (audience 검증) |
+
+`.env.local` (gitignored) 에 사용자 발급 키 주입 완료.
+
+---
+
+## 4. 미검증 항목 / 사용자 브라우저 테스트 필요
+
+다음은 라이브 환경(콘솔 셋업 + 브라우저 SDK + 사용자 동의) 이 필요해 자동화 검증 불가.
+
+### 4-1. 시나리오 (브라우저에서 수행)
+
+1. **Kakao 신규 가입**
+   - `pnpm dev` → `http://localhost:3000/login`
+   - "카카오로 계속하기" 클릭
+   - Kakao popup 에서 동의 (account_email 필수)
+   - 기대: 토스트 "환영합니다. 가입이 완료되었습니다." → `/home` 이동, DevTools Network 응답에 `isNewMember=true`, Set-Cookie `refreshToken` 확인
+
+2. **Kakao 기존 로그인**
+   - 위 1) 직후 로그아웃 → 다시 카카오 로그인
+   - 기대: 토스트 "로그인되었습니다.", `isNewMember=false`
+
+3. **Google 신규 가입**
+   - "구글로 계속하기" 클릭 → GIS prompt 동의
+   - 기대: 1) 과 동일 시나리오 (단 prompt 가 third-party cookie 차단으로 안 뜨면 fallback 안내 토스트)
+
+4. **Google 기존 로그인**
+   - 위 3) 직후 로그아웃 → 다시 구글 로그인
+   - 기대: 토스트 "로그인되었습니다.", `isNewMember=false`
+
+5. **Provider mismatch**
+   - 같은 이메일을 Kakao 와 Google 양쪽에 가지고 있는 사용자가 한쪽으로 가입 → 다른 쪽으로 로그인 시도
+   - 기대: 토스트 "이미 다른 소셜 계정으로 가입된 이메일입니다."
+
+6. **사용자 취소**
+   - SDK popup 에서 [취소] 클릭
+   - 기대: 토스트 "카카오 로그인이 취소되었습니다." (또는 GIS dismissed 메시지)
+
+### 4-2. 사전 콘솔 셋업 체크리스트
+
+- [ ] **Kakao Developers**: JavaScript SDK 도메인 등록 (`http://localhost:3000`), 카카오 로그인 활성화, 동의항목 `account_email` + `profile_nickname`, 카카오 로그인 리다이렉트 URI 등록 (사용은 안 하지만 콘솔이 요구)
+- [ ] **Google Cloud Console**: OAuth Web Client ID 발급 + 승인된 자바스크립트 출처 `http://localhost:3000`
+- [ ] **BE**: `GOOGLE_OAUTH_CLIENT_ID` 환경변수 = FE `NEXT_PUBLIC_GOOGLE_CLIENT_ID` 와 동일 값 + 재시작
+
+---
+
+## 5. 알려진 결함 / BE 측 확인 요청
+
+### 5-1. Refresh Token TTL mismatch (BE 명세 작성자 보고)
+
+- JWT exp: 25,200초 (7시간) — `application-security.yaml:3`
+- Cookie Max-Age: 14일 — `CookieUtil.kt:14`
+- 영향: 쿠키는 살아 있는데 JWT 가 만료된 상태 발생 가능. 7시간 후 refresh 시도 시 BE 가 JWT 검증 실패 → FE 가 401 받고 로그아웃 처리.
+- 권고: 둘 중 하나로 통일 (보통 14일이 표준).
+
+### 5-2. 일반 로그인 (`/auth/login`) 도 401 인터셉터 우회 검토
+
+- 현재 `src/domain/auth/api/login.ts` 는 `_skipAuthRefresh` 미설정.
+- BE 가 잘못된 비밀번호에 401 을 반환할 경우 동일한 자동 refresh 루프 발동.
+- 본 PR 범위 외 — 별도 이슈로 분리 권고.
+
+### 5-3. Apple OAuth (BD-13)
+
+- 본 PR 범위 외. id_token 기반 흐름이 다름 (form_post 또는 SDK 별도).
+
+---
+
+## 6. FE 후속 작업 (별도 이슈 권고)
+
+- [ ] `isNewMember=true` 시 온보딩 페이지로 라우팅 (`/onboarding` 신규)
+- [ ] Google prompt 가 차단된 경우 GIS 표준 버튼 fallback (현재는 안내 토스트만)
+- [ ] OAuth 사용자에 대해 비밀번호 변경 화면 비노출 (`OAUTH_PASSWORD_CHANGE_NOT_ALLOWED` 방지)
+- [ ] Apple OAuth (BD-13) 도입
+
+---
+
+끝.

--- a/src/app/(auth)/login/OAuthSection.client.tsx
+++ b/src/app/(auth)/login/OAuthSection.client.tsx
@@ -1,21 +1,85 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
 import { OAuthButton } from '@/components/ui/oauth-button';
+import { useGoogleLogin } from '@/domain/auth/hooks/useGoogleLogin';
+import { useKakaoLogin } from '@/domain/auth/hooks/useKakaoLogin';
+import {
+  oauthErrorMessage,
+  requestGoogleIdToken,
+  requestKakaoAccessToken,
+} from '@/domain/auth/oauth';
+import type { OAuthLoginResponse } from '@/domain/auth/types';
+import { env } from '@/global/config/env';
+import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
 
 /**
- * OAuth 로그인 섹션 (카카오/구글/애플 빈 버튼).
- * 실제 OAuth 연결은 후속 작업에서 구현. 현재는 토스트로 "준비 중" 안내.
+ * OAuth 로그인 섹션.
+ * Kakao SDK / Google GIS 로 토큰 획득 → BE 에 전달 → JWT 수신 → /home.
+ *
+ * BE contract:
+ * - POST /api/v1/auth/oauth/kakao  body { accessToken }
+ * - POST /api/v1/auth/oauth/google body { idToken }
+ * - 응답 { accessToken, isNewMember } + Set-Cookie refreshToken
  */
 export function OAuthSection() {
+  const router = useRouter();
   const toast = useToast();
+
+  const kakaoEnabled = !!env.NEXT_PUBLIC_KAKAO_JS_KEY;
+  const googleEnabled = !!env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+
+  const onLoginSuccess = (data: OAuthLoginResponse) => {
+    toast.success(data.isNewMember ? '환영합니다. 가입이 완료되었습니다.' : '로그인되었습니다.');
+    router.replace(ROUTES.HOME);
+  };
+
+  const kakaoMutation = useKakaoLogin({
+    onSuccess: onLoginSuccess,
+    onError: (err) => toast.error(oauthErrorMessage(err)),
+  });
+  const googleMutation = useGoogleLogin({
+    onSuccess: onLoginSuccess,
+    onError: (err) => toast.error(oauthErrorMessage(err)),
+  });
+
+  const busy = kakaoMutation.isPending || googleMutation.isPending;
+
+  async function handleKakao() {
+    if (!kakaoEnabled) {
+      toast.error('카카오 로그인이 설정되지 않았습니다.');
+      return;
+    }
+    try {
+      const accessToken = await requestKakaoAccessToken();
+      kakaoMutation.mutate({ accessToken });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : '카카오 로그인에 실패했습니다.');
+    }
+  }
+
+  async function handleGoogle() {
+    if (!googleEnabled) {
+      toast.error('구글 로그인이 설정되지 않았습니다.');
+      return;
+    }
+    try {
+      const idToken = await requestGoogleIdToken();
+      googleMutation.mutate({ idToken });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : '구글 로그인에 실패했습니다.');
+    }
+  }
+
   const notReady = () => toast.info('준비 중입니다.');
 
   return (
     <section aria-label="OAuth 로그인" className="space-y-s-3" data-slot="oauth-section">
-      <OAuthButton provider="kakao" onClick={notReady} />
-      <OAuthButton provider="google" onClick={notReady} />
-      <OAuthButton provider="apple" onClick={notReady} />
+      <OAuthButton provider="kakao" onClick={handleKakao} disabled={busy} />
+      <OAuthButton provider="google" onClick={handleGoogle} disabled={busy} />
+      <OAuthButton provider="apple" onClick={notReady} disabled={busy} />
       <div className="gap-s-3 py-s-2 flex items-center">
         <span className="bg-border h-px flex-1" aria-hidden="true" />
         <span className="text-foreground-muted text-micro">또는</span>

--- a/src/domain/auth/api/googleLogin.ts
+++ b/src/domain/auth/api/googleLogin.ts
@@ -1,0 +1,22 @@
+import { apiClient } from '@/global/api/apiClient';
+import { useAuthStore } from '@/global/store/authStore';
+
+import type { GoogleLoginRequest, OAuthLoginResponse } from '../types';
+
+/**
+ * BE: POST /api/v1/auth/oauth/google
+ *
+ * 본 호출은 인증 전 흐름이므로 401 인터셉터의 refresh 루프를 건너뛴다.
+ * (BE 의 401 OAUTH_TOKEN_INVALID 가 자동으로 refresh 시도로 가로채지지 않게.)
+ */
+export async function googleLogin(req: GoogleLoginRequest): Promise<OAuthLoginResponse> {
+  const data = await apiClient.post<OAuthLoginResponse>('/api/v1/auth/oauth/google', req, {
+    _skipAuthRefresh: true,
+    _skipAuthHeader: true,
+  });
+  if (!data?.accessToken) {
+    throw new Error('Google 로그인 응답에 accessToken 이 없습니다.');
+  }
+  useAuthStore.getState().setAccessToken(data.accessToken);
+  return data;
+}

--- a/src/domain/auth/api/kakaoLogin.ts
+++ b/src/domain/auth/api/kakaoLogin.ts
@@ -1,0 +1,22 @@
+import { apiClient } from '@/global/api/apiClient';
+import { useAuthStore } from '@/global/store/authStore';
+
+import type { KakaoLoginRequest, OAuthLoginResponse } from '../types';
+
+/**
+ * BE: POST /api/v1/auth/oauth/kakao
+ *
+ * 본 호출은 인증 전 흐름이므로 401 인터셉터의 refresh 루프를 건너뛴다.
+ * (BE 의 401 OAUTH_TOKEN_INVALID 가 자동으로 refresh 시도로 가로채지지 않게.)
+ */
+export async function kakaoLogin(req: KakaoLoginRequest): Promise<OAuthLoginResponse> {
+  const data = await apiClient.post<OAuthLoginResponse>('/api/v1/auth/oauth/kakao', req, {
+    _skipAuthRefresh: true,
+    _skipAuthHeader: true,
+  });
+  if (!data?.accessToken) {
+    throw new Error('Kakao 로그인 응답에 accessToken 이 없습니다.');
+  }
+  useAuthStore.getState().setAccessToken(data.accessToken);
+  return data;
+}

--- a/src/domain/auth/hooks/useGoogleLogin.ts
+++ b/src/domain/auth/hooks/useGoogleLogin.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { googleLogin } from '../api/googleLogin';
+import type { GoogleLoginRequest, OAuthLoginResponse } from '../types';
+
+type Options = {
+  onSuccess?: (data: OAuthLoginResponse) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useGoogleLogin(options?: Options) {
+  return useMutation<OAuthLoginResponse, Error, GoogleLoginRequest>({
+    mutationFn: googleLogin,
+    onSuccess: options?.onSuccess,
+    onError: options?.onError,
+  });
+}

--- a/src/domain/auth/hooks/useKakaoLogin.ts
+++ b/src/domain/auth/hooks/useKakaoLogin.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { kakaoLogin } from '../api/kakaoLogin';
+import type { KakaoLoginRequest, OAuthLoginResponse } from '../types';
+
+type Options = {
+  onSuccess?: (data: OAuthLoginResponse) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useKakaoLogin(options?: Options) {
+  return useMutation<OAuthLoginResponse, Error, KakaoLoginRequest>({
+    mutationFn: kakaoLogin,
+    onSuccess: options?.onSuccess,
+    onError: options?.onError,
+  });
+}

--- a/src/domain/auth/oauth/google.ts
+++ b/src/domain/auth/oauth/google.ts
@@ -1,0 +1,94 @@
+import { env } from '@/global/config/env';
+
+const SDK_URL = 'https://accounts.google.com/gsi/client';
+
+let loadPromise: Promise<NonNullable<Window['google']>> | null = null;
+let initialized = false;
+let pendingResolver: ((idToken: string) => void) | null = null;
+let pendingRejecter: ((err: Error) => void) | null = null;
+
+/**
+ * Google Identity Services 스크립트를 동적으로 로드.
+ * 이미 로드되어 있으면 바로 반환. 한 번만 로드되고 이후 호출은 캐시.
+ */
+export async function loadGoogleGis(): Promise<NonNullable<Window['google']>> {
+  if (typeof window === 'undefined') {
+    throw new Error('SSR 환경에서는 GIS 를 로드할 수 없습니다.');
+  }
+  if (!env.NEXT_PUBLIC_GOOGLE_CLIENT_ID) {
+    throw new Error('Google 로그인이 설정되지 않았습니다 (NEXT_PUBLIC_GOOGLE_CLIENT_ID 누락).');
+  }
+  if (window.google?.accounts?.id) return window.google;
+  if (loadPromise) return loadPromise;
+
+  loadPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = SDK_URL;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      if (window.google?.accounts?.id) resolve(window.google);
+      else reject(new Error('GIS 로드 후 window.google.accounts.id 가 비어 있습니다.'));
+    };
+    script.onerror = () => reject(new Error('Google GIS 스크립트를 로드할 수 없습니다.'));
+    document.head.appendChild(script);
+  });
+  return loadPromise;
+}
+
+function ensureInitialized(google: NonNullable<Window['google']>) {
+  if (initialized) return;
+  google.accounts.id.initialize({
+    client_id: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
+    callback: (response) => {
+      const resolver = pendingResolver;
+      const rejecter = pendingRejecter;
+      pendingResolver = null;
+      pendingRejecter = null;
+      if (response.credential) resolver?.(response.credential);
+      else rejecter?.(new Error('Google 로그인 응답에 credential 이 없습니다.'));
+    },
+    use_fedcm_for_prompt: true,
+    auto_select: false,
+    cancel_on_tap_outside: true,
+    context: 'signin',
+  });
+  initialized = true;
+}
+
+/**
+ * GIS One Tap / Sign In With Google prompt 를 띄워 ID token (JWT) 을 발급받는다.
+ *
+ * 주의: prompt 가 표시되지 않는 경우가 많다 (브라우저 third-party cookie 차단,
+ * 짧은 시간 내 반복 호출, 동의 거부 직후 등). FedCM 옵션을 켜서 최신 Chrome 에서는
+ * cookie 정책과 무관하게 동작하지만, Safari / Firefox 에서는 여전히 막힐 수 있다.
+ * 호출 측은 reject 메시지에 따라 표준 GIS 버튼으로 fallback 안내가 필요할 수 있다.
+ */
+export async function requestGoogleIdToken(): Promise<string> {
+  const google = await loadGoogleGis();
+  ensureInitialized(google);
+  // 이전 호출이 끝나기 전 동시에 호출되면 이전 호출은 취소.
+  if (pendingRejecter) pendingRejecter(new Error('이전 Google 로그인 시도가 취소되었습니다.'));
+
+  return new Promise<string>((resolve, reject) => {
+    pendingResolver = resolve;
+    pendingRejecter = reject;
+    google.accounts.id.prompt((notification) => {
+      if (notification.isNotDisplayed()) {
+        pendingResolver = null;
+        pendingRejecter = null;
+        const reason = notification.getNotDisplayedReason();
+        reject(
+          new Error(
+            `Google 로그인 창을 표시할 수 없습니다 (${reason}). 브라우저의 third-party cookie 차단 또는 시크릿 모드를 확인해주세요.`,
+          ),
+        );
+      } else if (notification.isSkippedMoment()) {
+        pendingResolver = null;
+        pendingRejecter = null;
+        reject(new Error('Google 로그인이 취소되었습니다.'));
+      }
+      // dismissed/displayed 는 callback 에서 처리됨.
+    });
+  });
+}

--- a/src/domain/auth/oauth/index.ts
+++ b/src/domain/auth/oauth/index.ts
@@ -1,0 +1,26 @@
+export { loadKakao, requestKakaoAccessToken } from './kakao';
+export { loadGoogleGis, requestGoogleIdToken } from './google';
+
+import { ApiError } from '@/global/error/ApiError';
+
+/**
+ * OAuth 응답의 BE 에러 코드를 사용자 안내 문구로 매핑.
+ * 코드 정의는 `v1/.../ErrorCode.kt` + 본 프로젝트 `API_REQUIRED_OAUTH_*` 참조.
+ */
+export function oauthErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    switch (err.code) {
+      case 'OAUTH_TOKEN_INVALID':
+        return '소셜 인증에 실패했습니다. 다시 시도해주세요.';
+      case 'OAUTH_PROVIDER_MISMATCH':
+        return '이미 다른 소셜 계정으로 가입된 이메일입니다.';
+      case 'OAUTH_PROVIDER_ERROR':
+        return '소셜 로그인 서버에 일시적인 오류가 있습니다. 잠시 후 다시 시도해주세요.';
+      case 'INVALID_INPUT_VALUE':
+        return '소셜 로그인 요청이 올바르지 않습니다.';
+    }
+    return err.message;
+  }
+  if (err instanceof Error) return err.message;
+  return '소셜 로그인에 실패했습니다.';
+}

--- a/src/domain/auth/oauth/kakao.ts
+++ b/src/domain/auth/oauth/kakao.ts
@@ -1,0 +1,79 @@
+import { env } from '@/global/config/env';
+
+const SDK_URL = 'https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js';
+/**
+ * 공식 release 의 SRI 해시. SDK 버전 변경 시 함께 갱신.
+ * https://developers.kakao.com/docs/latest/ko/javascript/getting-started
+ */
+const SDK_INTEGRITY = 'sha384-DKYJZ8NLiK8MN4/C5P2dtSmLQ4KwPaoqAfyA/DfmEc1VDxu4yyC7wy6K1Hs90nka';
+
+let loadPromise: Promise<KakaoStatic> | null = null;
+
+/**
+ * Kakao JavaScript SDK 를 동적으로 로드 + Kakao.init 까지 수행한다.
+ * 한 번만 로드되고 이후 호출은 캐시된 promise 를 반환.
+ */
+export async function loadKakao(): Promise<KakaoStatic> {
+  if (typeof window === 'undefined') {
+    throw new Error('SSR 환경에서는 Kakao SDK 를 로드할 수 없습니다.');
+  }
+  if (!env.NEXT_PUBLIC_KAKAO_JS_KEY) {
+    throw new Error('Kakao 로그인이 설정되지 않았습니다 (NEXT_PUBLIC_KAKAO_JS_KEY 누락).');
+  }
+  if (window.Kakao?.isInitialized?.()) return window.Kakao;
+  if (loadPromise) return loadPromise;
+
+  const jsKey = env.NEXT_PUBLIC_KAKAO_JS_KEY;
+  loadPromise = new Promise<KakaoStatic>((resolve, reject) => {
+    if (window.Kakao) {
+      try {
+        window.Kakao.init(jsKey);
+        resolve(window.Kakao);
+      } catch (e) {
+        reject(e);
+      }
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = SDK_URL;
+    script.integrity = SDK_INTEGRITY;
+    script.crossOrigin = 'anonymous';
+    script.async = true;
+    script.onload = () => {
+      if (!window.Kakao) {
+        reject(new Error('Kakao SDK 로드 후 window.Kakao 가 비어 있습니다.'));
+        return;
+      }
+      try {
+        window.Kakao.init(jsKey);
+        resolve(window.Kakao);
+      } catch (e) {
+        reject(e);
+      }
+    };
+    script.onerror = () => reject(new Error('Kakao SDK 스크립트를 로드할 수 없습니다.'));
+    document.head.appendChild(script);
+  });
+  return loadPromise;
+}
+
+/**
+ * Kakao 동의 popup 을 띄워 access token 을 발급받는다.
+ * 사용자가 popup 을 닫거나 차단되면 reject. 정상 동의 시 access token 만 반환.
+ */
+export async function requestKakaoAccessToken(): Promise<string> {
+  const kakao = await loadKakao();
+  return new Promise<string>((resolve, reject) => {
+    kakao.Auth.login({
+      scope: 'profile_nickname,account_email',
+      success: (response) => {
+        if (response.access_token) resolve(response.access_token);
+        else reject(new Error('Kakao 로그인 응답에 access_token 이 없습니다.'));
+      },
+      fail: (error) => {
+        const msg = error.error_description || error.error || '카카오 로그인에 실패했습니다.';
+        reject(new Error(msg));
+      },
+    });
+  });
+}

--- a/src/domain/auth/types/index.ts
+++ b/src/domain/auth/types/index.ts
@@ -1,4 +1,9 @@
-export type { LoginRequest, PasswordChangeRequest } from './req';
-export type { LoginResponse, RefreshResponse } from './res';
+export type {
+  GoogleLoginRequest,
+  KakaoLoginRequest,
+  LoginRequest,
+  PasswordChangeRequest,
+} from './req';
+export type { LoginResponse, OAuthLoginResponse, RefreshResponse } from './res';
 export { loginSchema, passwordChangeSchema } from './schema';
 export type { LoginSchema, PasswordChangeSchema } from './schema';

--- a/src/domain/auth/types/req.ts
+++ b/src/domain/auth/types/req.ts
@@ -7,3 +7,15 @@ export interface PasswordChangeRequest {
   originalPassword: string;
   newPassword: string;
 }
+
+/** BE: POST /api/v1/auth/oauth/kakao */
+export interface KakaoLoginRequest {
+  /** Kakao SDK 가 발급한 access token. */
+  accessToken: string;
+}
+
+/** BE: POST /api/v1/auth/oauth/google */
+export interface GoogleLoginRequest {
+  /** GIS 가 발급한 ID token (JWT). */
+  idToken: string;
+}

--- a/src/domain/auth/types/res.ts
+++ b/src/domain/auth/types/res.ts
@@ -5,3 +5,10 @@ export interface LoginResponse {
 export interface RefreshResponse {
   accessToken: string;
 }
+
+/** BE: POST /api/v1/auth/oauth/{provider} 응답 본문. */
+export interface OAuthLoginResponse {
+  accessToken: string;
+  /** true=신규 회원가입+로그인, false=기존 회원 로그인. 가입 직후 온보딩 분기에 사용. */
+  isNewMember: boolean;
+}

--- a/src/global/config/env.ts
+++ b/src/global/config/env.ts
@@ -1,13 +1,28 @@
 import { z } from 'zod';
 
+/**
+ * 빈 문자열은 미설정으로 간주 — `.env.local` 에 키가 빈 값으로 남아 있어도 통과시킨다.
+ * (OAuth 키 발급 전 placeholder 케이스)
+ */
+const optionalNonEmpty = z
+  .string()
+  .optional()
+  .transform((v) => (v === undefined || v === '' ? undefined : v));
+
 const envSchema = z.object({
   NEXT_PUBLIC_API_BASE_URL: z.string().url(),
   NEXT_PUBLIC_APP_ENV: z.enum(['local', 'dev', 'prod']),
+  /** Kakao JavaScript SDK 키 (REST API/Admin 키 아님). 미설정 시 카카오 로그인 비활성화. */
+  NEXT_PUBLIC_KAKAO_JS_KEY: optionalNonEmpty,
+  /** Google OAuth Web Client ID. BE GOOGLE_OAUTH_CLIENT_ID 와 동일 값이어야 audience 검증 통과. */
+  NEXT_PUBLIC_GOOGLE_CLIENT_ID: optionalNonEmpty,
 });
 
 const parsed = envSchema.safeParse({
   NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
   NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
+  NEXT_PUBLIC_KAKAO_JS_KEY: process.env.NEXT_PUBLIC_KAKAO_JS_KEY,
+  NEXT_PUBLIC_GOOGLE_CLIENT_ID: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
 });
 
 if (!parsed.success) {

--- a/src/global/types/google-gsi.d.ts
+++ b/src/global/types/google-gsi.d.ts
@@ -1,0 +1,47 @@
+/**
+ * Google Identity Services (GIS) 의 최소 표면 (ID token 발급용).
+ * 전체 명세는 https://developers.google.com/identity/gsi/web/reference/js-reference
+ */
+interface GoogleIdConfiguration {
+  client_id: string;
+  callback: (response: GoogleCredentialResponse) => void;
+  auto_select?: boolean;
+  cancel_on_tap_outside?: boolean;
+  /** FedCM 사용 (Chrome third-party cookie 정책 회피). default true (권장). */
+  use_fedcm_for_prompt?: boolean;
+  context?: 'signin' | 'signup' | 'use';
+  ux_mode?: 'popup' | 'redirect';
+}
+
+interface GoogleCredentialResponse {
+  /** ID token (JWT). BE 의 POST /api/v1/auth/oauth/google 의 idToken 필드로 전달. */
+  credential: string;
+  /** 이전 세션에서 자동 선택된 경우 true. */
+  select_by?: string;
+}
+
+interface GooglePromptMomentNotification {
+  isNotDisplayed(): boolean;
+  isSkippedMoment(): boolean;
+  isDismissedMoment(): boolean;
+  getNotDisplayedReason(): string;
+  getSkippedReason(): string;
+  getDismissedReason(): string;
+  getMomentType(): 'display' | 'skipped' | 'dismissed';
+}
+
+interface GoogleAccountsId {
+  initialize(config: GoogleIdConfiguration): void;
+  prompt(notification?: (n: GooglePromptMomentNotification) => void): void;
+  renderButton(parent: HTMLElement, options: Record<string, unknown>): void;
+  cancel(): void;
+  disableAutoSelect(): void;
+}
+
+interface Window {
+  google?: {
+    accounts: {
+      id: GoogleAccountsId;
+    };
+  };
+}

--- a/src/global/types/kakao-sdk.d.ts
+++ b/src/global/types/kakao-sdk.d.ts
@@ -1,0 +1,42 @@
+/**
+ * Kakao JavaScript SDK 2.x 의 최소 표면 (로그인용).
+ * 전체 명세는 https://developers.kakao.com/sdk/reference/js/release/Kakao.html
+ */
+interface KakaoAuthSuccess {
+  /** Access token. BE 의 POST /api/v1/auth/oauth/kakao 의 accessToken 필드로 전달. */
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+}
+
+interface KakaoAuthError {
+  error: string;
+  error_description: string;
+}
+
+interface KakaoAuthLoginOptions {
+  /** 동의 항목. 콤마 구분. 예: 'profile_nickname,account_email'. */
+  scope?: string;
+  /** Kakao 로그인 popup 닫힘 후 호출. */
+  success: (response: KakaoAuthSuccess) => void;
+  /** popup 차단/사용자 취소/네트워크 오류 등. */
+  fail: (error: KakaoAuthError) => void;
+  /** 성공/실패와 무관하게 호출. */
+  always?: () => void;
+}
+
+interface KakaoStatic {
+  init(jsKey: string): void;
+  isInitialized(): boolean;
+  Auth: {
+    login(options: KakaoAuthLoginOptions): void;
+    logout(callback?: () => void): void;
+    getAccessToken(): string | null;
+  };
+}
+
+interface Window {
+  Kakao?: KakaoStatic;
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### Jira: [BD-14](https://sunwoo1137.atlassian.net/browse/BD-14) — OAuth-MemberAuth 연동

📌 **작업 내용 및 특이사항**

BE 가 token-submission 흐름 (FE SDK → 토큰 → BE provider 검증) 으로 구현되어 있어, 기존 `feat/BD-14-oauth-fe` 의 redirect-flow 구현은 폐기하고 SDK 기반으로 전면 재작성.

### BE Contract (BE 명세서 + 직접 swagger/Kotlin 교차 확인)
- `POST /api/v1/auth/oauth/kakao` — body `{ accessToken: string }`
- `POST /api/v1/auth/oauth/google` — body `{ idToken: string }`
- 응답 `{ accessToken, isNewMember }` + `Set-Cookie: refreshToken=...; HttpOnly; Secure; SameSite=None; Max-Age=14d`

### 구현
- **`src/domain/auth/oauth/`**:
  - `kakao.ts` — Kakao JS SDK 동적 로드 (SRI 포함) + `Kakao.init` + `Kakao.Auth.login({ scope: 'profile_nickname,account_email' })` → access token
  - `google.ts` — GIS `https://accounts.google.com/gsi/client` 동적 로드 + `initialize({ use_fedcm_for_prompt: true })` + `prompt()` → ID token
  - `index.ts` — `oauthErrorMessage(err)` BE code (`OAUTH_TOKEN_INVALID`/`OAUTH_PROVIDER_MISMATCH`/`OAUTH_PROVIDER_ERROR`/`INVALID_INPUT_VALUE`) → 한국어 안내 매퍼
- **API**: `kakaoLogin`, `googleLogin` — `_skipAuthRefresh + _skipAuthHeader` 로 401 인터셉터 우회 (인증 전 흐름이므로 BE 의 401 OAUTH_TOKEN_INVALID 가 자동 refresh 시도로 가로채지면 도메인 에러 메시지가 사용자에게 노출되지 않음)
- **Hooks**: `useKakaoLogin`, `useGoogleLogin` — TanStack mutation
- **UI**: `OAuthSection.client.tsx` — 카카오/구글 버튼 SDK 호출, isNewMember 분기 (가입 토스트 vs 로그인 토스트), busy 시 모든 버튼 disabled (중복 클릭 방지)
- **Types**: `kakao-sdk.d.ts`, `google-gsi.d.ts` 신규 — SSR 안전한 SDK 타입 표면
- **env.ts**: `NEXT_PUBLIC_KAKAO_JS_KEY`, `NEXT_PUBLIC_GOOGLE_CLIENT_ID` (optional + 빈 문자열은 미설정으로 normalize)

### 라이브 검증 결과 (2026-05-04, BE develop HEAD e748f71)
- Kakao 잘못된 access token → `401 OAUTH_TOKEN_INVALID`
- Google 잘못된 ID token → `401 OAUTH_TOKEN_INVALID`
- Google 빈 idToken → `400 INVALID_INPUT_VALUE` (`fieldErrors.idToken`)
- `POST /api/v1/auth/refresh` 엔드포인트 존재
- CORS preflight (`OPTIONS`, Origin: `http://localhost:3000`): `Access-Control-Allow-Origin`, `Allow-Credentials: true`, `Expose-Headers: Set-Cookie` 정상

정상 토큰 발급 흐름은 외부 콘솔 셋업 + 브라우저 수동 테스트 필요 (`.taskmaster/report/auth-oauth-api-verification-2026-05-04.md` §4 시나리오 참조).

### BE 측 확인 요청 (별도)
- **Refresh Token TTL mismatch**: JWT exp 7시간 vs Cookie Max-Age 14일 — 권고 14일로 통일
- 일반 로그인 (`/auth/login`) 도 `_skipAuthRefresh` 미설정 — 본 PR 범위 외, 별도 이슈 권고

📚 **참고사항**
- `.taskmaster/report/auth-oauth-api-verification-2026-05-04.md` 검증 리포트 + 사용자 브라우저 테스트 시나리오
- 사전 콘솔 셋업: Kakao Developers JS SDK 도메인 등록 (`http://localhost:3000`), 동의항목 `account_email` + `profile_nickname` / Google Cloud Console OAuth Web Client + 승인된 자바스크립트 출처
- BE 환경변수: `GOOGLE_OAUTH_CLIENT_ID` = FE 의 `NEXT_PUBLIC_GOOGLE_CLIENT_ID` 와 동일 값 (audience 검증)
- 폐기: 기존 `feat/BD-14-oauth-fe` 로컬 브랜치 (redirect-flow, BE 와 incompatible)

[BD-14]: https://sunwoo1137.atlassian.net/browse/BD-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ