### PR TITLE
[BD-14] fix: Kakao SDK 2.x authorize 흐름 + 외부 OAuth 프로필 이미지 fallback

### DIFF
--- a/src/app/(auth)/login/OAuthSection.client.tsx
+++ b/src/app/(auth)/login/OAuthSection.client.tsx
@@ -4,12 +4,7 @@ import { useRouter } from 'next/navigation';
 
 import { OAuthButton } from '@/components/ui/oauth-button';
 import { useGoogleLogin } from '@/domain/auth/hooks/useGoogleLogin';
-import { useKakaoLogin } from '@/domain/auth/hooks/useKakaoLogin';
-import {
-  oauthErrorMessage,
-  requestGoogleIdToken,
-  requestKakaoAccessToken,
-} from '@/domain/auth/oauth';
+import { oauthErrorMessage, requestGoogleIdToken, startKakaoAuthorize } from '@/domain/auth/oauth';
 import type { OAuthLoginResponse } from '@/domain/auth/types';
 import { env } from '@/global/config/env';
 import { ROUTES } from '@/global/config/routes';
@@ -17,7 +12,10 @@ import { useToast } from '@/hooks/useToast';
 
 /**
  * OAuth 로그인 섹션.
- * Kakao SDK / Google GIS 로 토큰 획득 → BE 에 전달 → JWT 수신 → /home.
+ *
+ * Kakao: SDK 2.x 가 popup `login` 을 제거했으므로 `Kakao.Auth.authorize` 로 페이지 redirect →
+ *        callback page 가 token 교환 + BE 호출. 클릭 시 페이지가 즉시 카카오로 이동한다.
+ * Google: GIS prompt() 로 in-place ID token 발급 → BE 에 바로 전달.
  *
  * BE contract:
  * - POST /api/v1/auth/oauth/kakao  body { accessToken }
@@ -36,16 +34,12 @@ export function OAuthSection() {
     router.replace(ROUTES.HOME);
   };
 
-  const kakaoMutation = useKakaoLogin({
-    onSuccess: onLoginSuccess,
-    onError: (err) => toast.error(oauthErrorMessage(err)),
-  });
   const googleMutation = useGoogleLogin({
     onSuccess: onLoginSuccess,
     onError: (err) => toast.error(oauthErrorMessage(err)),
   });
 
-  const busy = kakaoMutation.isPending || googleMutation.isPending;
+  const busy = googleMutation.isPending;
 
   async function handleKakao() {
     if (!kakaoEnabled) {
@@ -53,10 +47,10 @@ export function OAuthSection() {
       return;
     }
     try {
-      const accessToken = await requestKakaoAccessToken();
-      kakaoMutation.mutate({ accessToken });
+      // SDK 가 페이지를 카카오 authorize URL 로 이동시킨다. 이후 흐름은 callback page 가 담당.
+      await startKakaoAuthorize();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : '카카오 로그인에 실패했습니다.');
+      toast.error(err instanceof Error ? err.message : '카카오 로그인을 시작할 수 없습니다.');
     }
   }
 

--- a/src/app/(auth)/oauth/callback/kakao/KakaoCallback.client.tsx
+++ b/src/app/(auth)/oauth/callback/kakao/KakaoCallback.client.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+
+import { Spinner } from '@/components/ui/spinner';
+import { useKakaoLogin } from '@/domain/auth/hooks/useKakaoLogin';
+import {
+  buildKakaoRedirectUri,
+  consumeKakaoState,
+  exchangeKakaoCodeForAccessToken,
+  oauthErrorMessage,
+} from '@/domain/auth/oauth';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+/**
+ * Kakao OAuth callback handler.
+ *
+ * 1. URL 의 `code` / `state` 추출 (or `error` 파라미터)
+ * 2. state 검증 (CSRF)
+ * 3. Kakao token endpoint 직접 POST → access_token
+ * 4. BE `POST /auth/oauth/kakao` 로 access_token 전달 → JWT 수신
+ * 5. /home 으로 redirect (가입 / 로그인 분기 토스트 포함)
+ */
+export function KakaoCallback() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const toast = useToast();
+  const ran = useRef(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useKakaoLogin({
+    onSuccess: (data) => {
+      toast.success(data.isNewMember ? '환영합니다. 가입이 완료되었습니다.' : '로그인되었습니다.');
+      router.replace(ROUTES.HOME);
+    },
+    onError: (err) => {
+      const msg = oauthErrorMessage(err);
+      setError(msg);
+      toast.error(msg);
+    },
+  });
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+
+    const code = params.get('code');
+    const stateParam = params.get('state');
+    const providerError = params.get('error');
+    const providerErrorDesc = params.get('error_description');
+
+    if (providerError) {
+      const msg = providerErrorDesc || providerError;
+      const display = `카카오 인증이 취소되었거나 실패했습니다: ${msg}`;
+      setError(display);
+      toast.error('카카오 인증이 취소되었습니다.');
+      return;
+    }
+
+    if (!code) {
+      setError('카카오 인증 코드를 받지 못했습니다.');
+      return;
+    }
+
+    const expectedState = consumeKakaoState();
+    if (!expectedState || expectedState !== stateParam) {
+      setError('CSRF 검증에 실패했습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    const redirectUri = buildKakaoRedirectUri();
+
+    exchangeKakaoCodeForAccessToken({ code, redirectUri })
+      .then((accessToken) => mutation.mutate({ accessToken }))
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : '카카오 토큰 교환에 실패했습니다.';
+        setError(msg);
+        toast.error(msg);
+      });
+  }, [params, toast, mutation]);
+
+  return (
+    <div className="flex min-h-[40vh] items-center justify-center px-4">
+      <div className="text-center">
+        {error ? (
+          <div className="space-y-3">
+            <p className="text-danger text-sm">{error}</p>
+            <a href={ROUTES.LOGIN} className="text-accent text-sm hover:underline">
+              로그인 화면으로 돌아가기
+            </a>
+          </div>
+        ) : (
+          <div className="text-foreground-sub flex items-center gap-3 text-sm">
+            <Spinner size="md" />
+            <span>카카오 로그인 처리 중...</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/oauth/callback/kakao/page.tsx
+++ b/src/app/(auth)/oauth/callback/kakao/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+
+import { KakaoCallback } from './KakaoCallback.client';
+
+export const metadata: Metadata = {
+  title: '카카오 로그인 처리 중 | Bandage',
+};
+
+export default function KakaoCallbackPage() {
+  return (
+    <Suspense fallback={null}>
+      <KakaoCallback />
+    </Suspense>
+  );
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,5 +1,6 @@
 import { useState, type ImgHTMLAttributes } from 'react';
 
+import { normalizeProfileImgUrl } from '@/global/upload';
 import { cn } from '@/lib/cn';
 
 export type AvatarSize = 'sm' | 'md' | 'lg' | 'xl';
@@ -26,7 +27,8 @@ function initialsOf(name: string) {
 
 export function Avatar({ size = 'md', src, alt, fallback, className, ...props }: AvatarProps) {
   const [errored, setErrored] = useState(false);
-  const showImage = src && !errored;
+  const normalizedSrc = typeof src === 'string' ? (normalizeProfileImgUrl(src) ?? undefined) : src;
+  const showImage = normalizedSrc && !errored;
 
   return (
     <span
@@ -39,7 +41,7 @@ export function Avatar({ size = 'md', src, alt, fallback, className, ...props }:
       {showImage ? (
         // eslint-disable-next-line @next/next/no-img-element -- 프로필 아바타는 다양한 외부 origin을 허용해야 하므로 next/image 대신 native img 사용
         <img
-          src={src}
+          src={normalizedSrc}
           alt={alt ?? fallback ?? ''}
           className="h-full w-full object-cover"
           onError={() => setErrored(true)}

--- a/src/components/ui/profile-image-upload.tsx
+++ b/src/components/ui/profile-image-upload.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { ImagePlus, Loader2 } from 'lucide-react';
-import { useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 
 import {
   ALLOWED_IMAGE_ACCEPT,
   MAX_IMAGE_SIZE_BYTES,
+  normalizeProfileImgUrl,
   uploadProfileImage,
   type UploadDomain,
 } from '@/global/upload';
@@ -53,9 +54,15 @@ export function ProfileImageUpload({
   const [uploading, setUploading] = useState(false);
   /** 업로드 직후 BE 가 응답에 CloudFront URL 을 반영하기 전, 짧은 시간 동안 로컬 미리보기. */
   const [localPreview, setLocalPreview] = useState<string | null>(null);
+  /** 외부 URL 이 깨졌을 때 placeholder 로 fallback. value 가 바뀌면 reset. */
+  const [errored, setErrored] = useState(false);
+  useEffect(() => {
+    setErrored(false);
+  }, [value]);
 
   const isDisabled = disabled || uploading;
-  const display = localPreview ?? value;
+  const normalizedValue = normalizeProfileImgUrl(value);
+  const display = errored ? null : (localPreview ?? normalizedValue);
 
   function trigger() {
     if (isDisabled) return;
@@ -105,12 +112,18 @@ export function ProfileImageUpload({
           style={{ width: size, height: size }}
         >
           {display ? (
-            // eslint-disable-next-line @next/next/no-img-element -- CloudFront/Blob URL 둘 다 next/image 구성 회피
+            // eslint-disable-next-line @next/next/no-img-element -- CloudFront/Blob/외부 OAuth provider URL 모두 허용
             <img
               src={display}
               alt={label}
               className="h-full w-full object-cover"
-              onError={() => setLocalPreview(null)}
+              onError={() => {
+                if (localPreview) {
+                  setLocalPreview(null);
+                } else {
+                  setErrored(true);
+                }
+              }}
             />
           ) : (
             <ImagePlus className="h-6 w-6" />

--- a/src/domain/auth/oauth/index.ts
+++ b/src/domain/auth/oauth/index.ts
@@ -1,4 +1,10 @@
-export { loadKakao, requestKakaoAccessToken } from './kakao';
+export {
+  buildKakaoRedirectUri,
+  exchangeKakaoCodeForAccessToken,
+  loadKakao,
+  startKakaoAuthorize,
+} from './kakao';
+export { consumeKakaoState } from './kakaoState';
 export { loadGoogleGis, requestGoogleIdToken } from './google';
 
 import { ApiError } from '@/global/error/ApiError';

--- a/src/domain/auth/oauth/kakao.ts
+++ b/src/domain/auth/oauth/kakao.ts
@@ -1,11 +1,15 @@
 import { env } from '@/global/config/env';
 
+import { createKakaoState } from './kakaoState';
+
 const SDK_URL = 'https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js';
 /**
  * 공식 release 의 SRI 해시. SDK 버전 변경 시 함께 갱신.
  * https://developers.kakao.com/docs/latest/ko/javascript/getting-started
  */
 const SDK_INTEGRITY = 'sha384-DKYJZ8NLiK8MN4/C5P2dtSmLQ4KwPaoqAfyA/DfmEc1VDxu4yyC7wy6K1Hs90nka';
+
+const KAKAO_TOKEN_URL = 'https://kauth.kakao.com/oauth/token';
 
 let loadPromise: Promise<KakaoStatic> | null = null;
 
@@ -57,23 +61,90 @@ export async function loadKakao(): Promise<KakaoStatic> {
   return loadPromise;
 }
 
+/** 콜백 URL 빌더. start/callback 양쪽이 동일 값을 사용해야 token 교환 시 redirect_uri 검증 통과. */
+export function buildKakaoRedirectUri(): string {
+  if (typeof window === 'undefined') {
+    throw new Error('SSR 환경에서는 redirect URI 를 만들 수 없습니다.');
+  }
+  return `${window.location.origin}/oauth/callback/kakao`;
+}
+
 /**
- * Kakao 동의 popup 을 띄워 access token 을 발급받는다.
- * 사용자가 popup 을 닫거나 차단되면 reject. 정상 동의 시 access token 만 반환.
+ * Kakao authorize 페이지로 redirect.
+ * v2.x SDK 는 popup/callback 기반 `Kakao.Auth.login` 을 제공하지 않으므로
+ * 표준 OAuth 2.0 Authorization Code 흐름의 시작 단계만 SDK 가 담당하고,
+ * 이후 token 교환은 callback 페이지에서 FE 가 직접 처리한다.
  */
-export async function requestKakaoAccessToken(): Promise<string> {
+export async function startKakaoAuthorize(): Promise<void> {
   const kakao = await loadKakao();
-  return new Promise<string>((resolve, reject) => {
-    kakao.Auth.login({
-      scope: 'profile_nickname,account_email',
-      success: (response) => {
-        if (response.access_token) resolve(response.access_token);
-        else reject(new Error('Kakao 로그인 응답에 access_token 이 없습니다.'));
-      },
-      fail: (error) => {
-        const msg = error.error_description || error.error || '카카오 로그인에 실패했습니다.';
-        reject(new Error(msg));
-      },
-    });
+  const redirectUri = buildKakaoRedirectUri();
+  const state = createKakaoState();
+  kakao.Auth.authorize({
+    redirectUri,
+    scope: 'profile_nickname,account_email',
+    state,
   });
+  // 호출 직후 페이지가 Kakao authorize URL 로 이동한다. 이 함수는 사실상 반환하지 않음.
+}
+
+interface KakaoTokenSuccess {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+}
+
+interface KakaoTokenError {
+  error: string;
+  error_description?: string;
+  error_code?: string;
+}
+
+/**
+ * Kakao token endpoint 에 직접 POST 하여 access_token 을 받는다.
+ *
+ * 카카오 콘솔의 [보안 → Client Secret] 이 `사용 OFF` 인 경우 client_id (= JavaScript 키) 만으로
+ * 교환 가능. ON 이라면 client_secret 이 필요한데 FE 에는 보관하지 않으므로 콘솔에서 OFF 권장.
+ */
+export async function exchangeKakaoCodeForAccessToken(input: {
+  code: string;
+  redirectUri: string;
+}): Promise<string> {
+  if (!env.NEXT_PUBLIC_KAKAO_JS_KEY) {
+    throw new Error('NEXT_PUBLIC_KAKAO_JS_KEY 가 설정되지 않았습니다.');
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: env.NEXT_PUBLIC_KAKAO_JS_KEY,
+    redirect_uri: input.redirectUri,
+    code: input.code,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(KAKAO_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8' },
+      body,
+    });
+  } catch {
+    throw new Error('Kakao 토큰 교환 중 네트워크 오류가 발생했습니다.');
+  }
+
+  const json: KakaoTokenSuccess | KakaoTokenError = await response
+    .json()
+    .catch(() => ({}) as never);
+  if (!response.ok) {
+    const err = json as KakaoTokenError;
+    const detail = err.error_description || err.error || `HTTP ${response.status}`;
+    throw new Error(`Kakao 토큰 교환 실패: ${detail}`);
+  }
+
+  const ok = json as KakaoTokenSuccess;
+  if (!ok.access_token) {
+    throw new Error('Kakao 토큰 응답에 access_token 이 없습니다.');
+  }
+  return ok.access_token;
 }

--- a/src/domain/auth/oauth/kakaoState.ts
+++ b/src/domain/auth/oauth/kakaoState.ts
@@ -1,0 +1,16 @@
+/** Kakao authorize → callback 사이의 CSRF 방지 state. sessionStorage 에 1회용 저장. */
+const KEY = 'bandage-oauth-kakao-state';
+
+export function createKakaoState(): string {
+  const arr = new Uint8Array(16);
+  crypto.getRandomValues(arr);
+  const state = Array.from(arr, (b) => b.toString(16).padStart(2, '0')).join('');
+  sessionStorage.setItem(KEY, state);
+  return state;
+}
+
+export function consumeKakaoState(): string | null {
+  const state = sessionStorage.getItem(KEY);
+  if (state) sessionStorage.removeItem(KEY);
+  return state;
+}

--- a/src/global/config/routes.ts
+++ b/src/global/config/routes.ts
@@ -4,6 +4,7 @@ export const ROUTES = {
   LOGIN: '/login',
   JOIN: '/join',
   PASSWORD_CHANGE: '/password-change',
+  OAUTH_CALLBACK_KAKAO: '/oauth/callback/kakao',
 
   HOME: '/home',
 

--- a/src/global/types/kakao-sdk.d.ts
+++ b/src/global/types/kakao-sdk.d.ts
@@ -1,39 +1,29 @@
 /**
- * Kakao JavaScript SDK 2.x 의 최소 표면 (로그인용).
- * 전체 명세는 https://developers.kakao.com/sdk/reference/js/release/Kakao.html
+ * Kakao JavaScript SDK 2.x 의 최소 표면.
+ * v2.x 부터 `Kakao.Auth.login` 은 제거됨 — `Kakao.Auth.authorize` (redirect) 가 표준.
+ * 전체 명세는 https://developers.kakao.com/sdk/reference/js/release/Kakao.Auth.html
  */
-interface KakaoAuthSuccess {
-  /** Access token. BE 의 POST /api/v1/auth/oauth/kakao 의 accessToken 필드로 전달. */
-  access_token: string;
-  refresh_token?: string;
-  expires_in?: number;
-  scope?: string;
-  token_type?: string;
-}
-
-interface KakaoAuthError {
-  error: string;
-  error_description: string;
-}
-
-interface KakaoAuthLoginOptions {
+interface KakaoAuthAuthorizeOptions {
+  redirectUri: string;
   /** 동의 항목. 콤마 구분. 예: 'profile_nickname,account_email'. */
   scope?: string;
-  /** Kakao 로그인 popup 닫힘 후 호출. */
-  success: (response: KakaoAuthSuccess) => void;
-  /** popup 차단/사용자 취소/네트워크 오류 등. */
-  fail: (error: KakaoAuthError) => void;
-  /** 성공/실패와 무관하게 호출. */
-  always?: () => void;
+  /** CSRF 방지용 임의 문자열. callback URL 의 state 파라미터로 그대로 돌아옴. */
+  state?: string;
+  nonce?: string;
+  prompt?: 'login' | 'create' | 'none';
+  /** true 면 카카오톡 앱으로 인증 시도. default true. */
+  throughTalk?: boolean;
 }
 
 interface KakaoStatic {
   init(jsKey: string): void;
   isInitialized(): boolean;
   Auth: {
-    login(options: KakaoAuthLoginOptions): void;
-    logout(callback?: () => void): void;
+    /** Kakao 로그인 페이지로 redirect. 함수 호출 직후 페이지가 이동된다. */
+    authorize(options: KakaoAuthAuthorizeOptions): void;
+    setAccessToken(token: string): void;
     getAccessToken(): string | null;
+    logout(callback?: () => void): void;
   };
 }
 

--- a/src/global/upload/index.ts
+++ b/src/global/upload/index.ts
@@ -9,6 +9,7 @@ export {
 export { presignProfileImage } from './presignProfileImage';
 export { uploadProfileImage, type UploadProfileImageInput } from './uploadProfileImage';
 export { uploadToPresignedUrl } from './uploadToPresignedUrl';
+export { normalizeProfileImgUrl } from './normalizeProfileImgUrl';
 export type {
   ProfileImagePresignRequest,
   ProfileImagePresignResponse,

--- a/src/global/upload/normalizeProfileImgUrl.ts
+++ b/src/global/upload/normalizeProfileImgUrl.ts
@@ -1,0 +1,22 @@
+/**
+ * BE 의 `CloudFrontUrlResolver` 가 외부 URL(google profile picture, kakao thumbnail 등)을
+ * 무조건 `${cdn}/${input}` 으로 prefix 붙여서 깨진 URL 을 응답하는 케이스가 있다.
+ * (예: `https://<cdn>/https://lh3.googleusercontent.com/...`).
+ *
+ * BE 가 정상화될 때까지 FE 에서 임시로 정규화한다 — 입력 안에 `https?://` 가 두 번 등장하면
+ * 두 번째 등장부터를 그대로 잘라서 반환.
+ *
+ * BE 수정 후에도 멱등 — 정상 URL 은 그대로 통과.
+ */
+export function normalizeProfileImgUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  // URL 안에서 두 번째 `http(s)://` 의 위치를 찾는다.
+  const protoMatches = [...trimmed.matchAll(/https?:\/\//g)];
+  if (protoMatches.length >= 2) {
+    const second = protoMatches[1]!;
+    return trimmed.slice(second.index);
+  }
+  return trimmed;
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### Jira: [BD-14](https://sunwoo1137.atlassian.net/browse/BD-14) — OAuth-MemberAuth 연동 (#195 follow-up)

📌 **작업 내용 및 특이사항**

PR #195 머지 후 사용자 보고 두 건 분석 + 수정.

### 이슈 1) Google 로그인 시 프로필 이미지가 placeholder 로 깨져 표시됨

원인: BE `CloudFrontUrlResolver.resolve(objectKey)` 가 입력이 외부 URL(google profile picture, kakao thumbnail 등) 인지 검사하지 않고 무조건 `${cdn}/${input}` 으로 prefix 붙임 → `https://<cdn>/https://lh3.googleusercontent.com/...` 같은 깨진 URL 응답.

FE 임시 워크어라운드:
- `src/global/upload/normalizeProfileImgUrl.ts` — 입력 안에 `http(s)://` 가 두 번 등장하면 두 번째 위치부터 잘라서 반환 (멱등 — BE 수정 후에도 정상 URL 그대로 통과)
- `ProfileImageUpload`: `errored` state 추가 — `<img onError>` 시 `localPreview` 가 있으면 그걸 먼저 invalidate, 없으면 errored=true 로 placeholder(ImagePlus) 표시
- `Avatar`: `src` 도 normalize 적용

본질 수정은 BE 측 — Slack 으로 별도 보고.

### 이슈 2) "kakao.Auth.login is not a function" 토스트

원인: **Kakao JavaScript SDK 2.x 부터 `Kakao.Auth.login` 메서드가 제거됨** (popup 콜백 방식 미지원). v2 표준은 `Kakao.Auth.authorize` (페이지 redirect).

수정:
- `kakao.ts` 재작성:
  - `startKakaoAuthorize()` — `Kakao.Auth.authorize({ redirectUri, scope, state })` 호출 → 즉시 페이지 redirect
  - `exchangeKakaoCodeForAccessToken({ code, redirectUri })` — FE 가 `https://kauth.kakao.com/oauth/token` 에 직접 POST (CORS 허용됨, client_secret OFF 필요)
- 신규 callback page `/oauth/callback/kakao`:
  - `code` / `state` 추출, CSRF state 검증, token 교환, BE `useKakaoLogin` mutation 호출, /home redirect
- `kakaoState.ts` — sessionStorage 기반 CSRF state 발급/소비 (1회용)
- `OAuthSection`: 카카오 클릭 시 `startKakaoAuthorize` 만 호출 (Google 은 GIS in-place 흐름 그대로)
- `kakao-sdk.d.ts`: `KakaoStatic.Auth` 의 `login` → `authorize` 시그니처로 갱신
- `routes.ts`: `ROUTES.OAUTH_CALLBACK_KAKAO = '/oauth/callback/kakao'`

### 부수
- CSS preload 경고 (`The resource ... was preloaded using link preload but not used ...`) 는 Next.js 의 알려진 무해 동작 — 별도 수정 없음

📚 **참고사항**

**카카오 콘솔 추가 셋업 (사용자 확인 요청)**
- [보안 → Client Secret] **사용 OFF** 여야 token 교환 통과 (FE 에 secret 미보관). ON 이면 redirect-flow 자체 BE 이전 필요.
- [카카오 로그인 → Redirect URI] 에 `http://localhost:3000/oauth/callback/kakao` 등록 (이미 등록된 것으로 보임)

**BE 측 별도 이슈 (Slack 보고)**
- `CloudFrontUrlResolver.resolveOrNull` 가 입력이 이미 `http(s)://` 로 시작하면 그대로 반환하도록 수정 권고

[BD-14]: https://sunwoo1137.atlassian.net/browse/BD-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ