### PR TITLE
[BD-14] feat: Kakao OAuth Authorization Code 흐름 BE 이관 + FE 동기화

### DIFF
--- a/API_REQUIRED_OAUTH_KAKAO_0504.md
+++ b/API_REQUIRED_OAUTH_KAKAO_0504.md
@@ -1,0 +1,216 @@
+# API_REQUIRED_OAUTH_KAKAO_0504.md
+
+작성일: 2026-05-04
+작성자: FE
+관련 작업: Kakao OAuth — Authorization Code Grant 흐름으로 BE 이관 (BD-14 follow-up)
+대상 BE: develop HEAD
+참조: `API_REQUIRED_OAUTH_0503.md`, `.taskmaster/report/auth-oauth-api-verification-2026-05-04.md`
+
+---
+
+## 0. 요약
+
+현재 BE Kakao 엔드포인트는 FE 가 발급한 access_token 을 받는 형태인데, **Kakao JavaScript SDK 2.x 가 access_token 을 직접 발급하지 못한다** (`Kakao.Auth.login` 제거됨). 우회로 FE 가 카카오 token endpoint 를 직접 호출해 access_token 을 발급하고 있는데, 이 과정에서 다음 문제가 있다:
+
+1. **client_secret 보관 위치 분산** — 카카오 콘솔 [보안 → Client Secret] 을 ON 으로 설정할 수 없음 (FE 가 secret 보유 불가). 보안성 ↓.
+2. **token endpoint 응답 처리가 FE 부담** — 에러 케이스 분기, refresh token 폐기 등이 FE 책임.
+3. **Provider 변경 시 FE/BE 양쪽 수정 필요** — 카카오 외 OAuth provider 추가 시 동일 패턴이 FE 에 누적.
+
+해결안: **FE 는 authorization code 만 BE 에 전달, BE 가 카카오 token endpoint POST 로 access_token 교환 + 기존 user info 검증 + JWT 발급**. (Google 은 ID token 흐름 유지 — 변경 없음.)
+
+---
+
+## 1. BE 변경 요청
+
+### 1-1. `POST /api/v1/auth/oauth/kakao` 시그니처 변경
+
+#### 변경 전 (현재)
+
+```kotlin
+data class KakaoLoginRequest(
+    @NotBlank
+    val accessToken: String,
+)
+```
+
+- BE 가 받은 access_token 으로 `KakaoOAuthClient.fetchUserInfo` 호출
+
+#### 변경 후 (요청)
+
+```kotlin
+data class KakaoLoginRequest(
+    @NotBlank
+    @Schema(description = "Kakao authorize 단계에서 받은 authorization code")
+    val code: String,
+
+    @NotBlank
+    @Schema(description = "FE 가 authorize 시 사용한 redirect URI. 카카오가 token 교환 시 동일성 검증")
+    val redirectUri: String,
+
+    @Schema(description = "(선택) FE CSRF state. BE 측 추가 검증이 필요한 경우만 사용")
+    val state: String? = null,
+)
+```
+
+### 1-2. 컨트롤러 동작 변경
+
+```kotlin
+@PostMapping
+fun loginWithKakao(
+    @Valid @RequestBody request: KakaoLoginRequest,
+    response: HttpServletResponse,
+): ApiResponse<OAuthLoginApiResponse> {
+    // 1) authorization code → access_token 교환 (신규)
+    val accessToken = kakaoOAuthClient.exchangeCodeForAccessToken(
+        code = request.code,
+        redirectUri = request.redirectUri,
+    )
+    // 2) access_token → user info (기존 fetchUserInfo 재사용)
+    val userInfo = kakaoOAuthClient.fetchUserInfo(accessToken)
+    // 3) login-or-join (기존 동일)
+    val result = oAuthLoginFacade.loginOrJoin(userInfo)
+    response.setHeader(HttpHeaders.SET_COOKIE, CookieUtil.generateCookieFrom(result.refreshToken))
+    return ApiResponse.success(OAuthLoginApiResponse.of(result))
+}
+```
+
+### 1-3. `KakaoOAuthClient.exchangeCodeForAccessToken` 신규 메서드
+
+```kotlin
+fun exchangeCodeForAccessToken(
+    code: String,
+    redirectUri: String,
+): String {
+    val body = LinkedMultiValueMap<String, String>().apply {
+        add("grant_type", "authorization_code")
+        add("client_id", properties.clientId)
+        add("redirect_uri", redirectUri)
+        add("code", code)
+        if (!properties.clientSecret.isNullOrBlank()) {
+            add("client_secret", properties.clientSecret)
+        }
+    }
+
+    val response = try {
+        restClient.post()
+            .uri(properties.tokenUri)  // https://kauth.kakao.com/oauth/token
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(body)
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError) { _, _ ->
+                throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+            }
+            .onStatus(HttpStatusCode::is5xxServerError) { _, _ ->
+                throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+            }
+            .body(KakaoTokenResponse::class.java)
+            ?: throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+    } catch (e: BusinessException) {
+        throw e
+    } catch (e: RestClientException) {
+        throw BusinessException(ErrorCode.OAUTH_PROVIDER_ERROR)
+    }
+
+    return response.accessToken
+        ?: throw BusinessException(ErrorCode.OAUTH_TOKEN_INVALID)
+}
+
+data class KakaoTokenResponse(
+    @field:JsonProperty("access_token") val accessToken: String?,
+    @field:JsonProperty("token_type") val tokenType: String?,
+    @field:JsonProperty("refresh_token") val refreshToken: String?,
+    @field:JsonProperty("expires_in") val expiresIn: Long?,
+    @field:JsonProperty("scope") val scope: String?,
+)
+```
+
+### 1-4. `KakaoOAuthProperties` 보강
+
+```kotlin
+@ConfigurationProperties(prefix = "oauth.kakao")
+data class KakaoOAuthProperties(
+    val userInfoUri: String = "https://kapi.kakao.com/v2/user/me",
+    /** 신규 — token 교환 endpoint. */
+    val tokenUri: String = "https://kauth.kakao.com/oauth/token",
+    /** 신규 — Kakao REST API Key 또는 JS Key. token 교환 시 client_id 로 전달. */
+    val clientId: String,
+    /** 신규 — 카카오 콘솔 [보안 → Client Secret] 활성화 시 발급된 값. nullable. */
+    val clientSecret: String? = null,
+)
+```
+
+### 1-5. `application-security.yaml` 보강
+
+```yaml
+oauth:
+  kakao:
+    user-info-uri: ${KAKAO_USER_INFO_URI:https://kapi.kakao.com/v2/user/me}
+    token-uri: ${KAKAO_TOKEN_URI:https://kauth.kakao.com/oauth/token}
+    client-id: ${KAKAO_OAUTH_CLIENT_ID} # 신규 — 필수
+    client-secret: ${KAKAO_OAUTH_CLIENT_SECRET:} # 신규 — 콘솔에서 활성화 시 주입
+  google:
+    token-info-uri: ${GOOGLE_TOKEN_INFO_URI:https://oauth2.googleapis.com/tokeninfo}
+    client-id: ${GOOGLE_OAUTH_CLIENT_ID:} # 변경 없음
+```
+
+### 1-6. 환경변수 (BE 운영 측)
+
+| 변수                        | 필수        | 값 출처                                                         | 비고                                                                         |
+| --------------------------- | ----------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `KAKAO_OAUTH_CLIENT_ID`     | 필수 (신규) | 카카오 콘솔 → 앱 설정 → 일반 → REST API 키 (또는 JavaScript 키) | FE `NEXT_PUBLIC_KAKAO_JS_KEY` 와 동일 값 권장 (콘솔이 동일 앱이면 자동 일치) |
+| `KAKAO_OAUTH_CLIENT_SECRET` | 선택 (신규) | 카카오 콘솔 → 보안 → Client Secret → 코드 발급 + ON             | 활성화 권고 (보안 ↑). OFF 면 비워두면 됨                                     |
+| `GOOGLE_OAUTH_CLIENT_ID`    | 필수 (기존) | Google Cloud Console                                            | 변경 없음                                                                    |
+
+### 1-7. 에러 응답 (변경 없음)
+
+기존 `OAUTH_TOKEN_INVALID` (401), `OAUTH_PROVIDER_ERROR` (502), `OAUTH_PROVIDER_MISMATCH` (409), `INVALID_INPUT_VALUE` (400) 그대로 유지. token 교환 실패도 `OAUTH_TOKEN_INVALID` 또는 `OAUTH_PROVIDER_ERROR` 로 매핑.
+
+---
+
+## 2. 마이그레이션 / 배포 순서
+
+1. **BE 작업 완료** (위 §1) → dev 환경 배포 + `KAKAO_OAUTH_CLIENT_ID` 환경변수 주입
+2. **FE 작업 완료** (본 PR) → dev 빌드 배포
+3. **사전 확인** — 카카오 콘솔에서 [보안 → Client Secret] 정책 결정 (ON/OFF)
+4. **라이브 검증** — `.taskmaster/report/auth-oauth-kakao-code-verification-YYYY-MM-DD.md`
+
+> BE 가 새 시그니처를 반영하기 전에 FE 만 먼저 배포하면 카카오 로그인이 즉시 깨진다. 반드시 BE 먼저.
+
+---
+
+## 3. FE 변경 (참고)
+
+본 PR (`feat/BD-14-kakao-be-code-exchange`) 에서 함께 수정.
+
+- `KakaoLoginRequest` 타입: `{ accessToken }` → `{ code, redirectUri, state? }`
+- `kakaoLogin` API: body 형식만 변경 (엔드포인트/응답 동일)
+- `KakaoCallback.client.tsx`: token 교환 로직 제거 → code/state 만 추출해 BE 호출
+- `kakao.ts`: `exchangeKakaoCodeForAccessToken` 함수 제거 (불필요)
+- `oauth/index.ts` barrel 정리
+
+SDK 사용 부분 (`loadKakao` + `Kakao.Auth.authorize`) 은 유지 — authorize URL 생성과 redirect 흐름은 SDK 가 담당.
+
+---
+
+## 4. 보안 효과
+
+| 측면                     | 변경 전                | 변경 후                                     |
+| ------------------------ | ---------------------- | ------------------------------------------- |
+| client_secret 위치       | (사용 불가, FE 무보관) | BE 에 보관 — 카카오 콘솔에서 ON 활성화 가능 |
+| token endpoint 호출 주체 | 브라우저 (CORS 의존)   | BE 서버 (안정성 ↑)                          |
+| FE 노출 정보             | code (단명) + JS Key   | code (단명) + JS Key (변경 없음)            |
+| Replay 방어              | code 일회성            | code 일회성 (동일)                          |
+
+추가 효과: BE 가 토큰 교환 응답에서 refresh_token 을 자체 보관/폐기 정책으로 관리 가능 (현재는 FE 가 받은 access_token 만 사용).
+
+---
+
+## 5. 후속 (별도 이슈 권고)
+
+- BE 가 받은 카카오 refresh_token 을 자체 보관해 long-session 지원 (선택)
+- 동일 패턴을 Apple OAuth (BD-13) 도입 시 적용
+- `OAUTH_PROVIDER_MISMATCH` 케이스에 대한 계정 연결 UX (이미 다른 provider 로 가입된 이메일을 추가 연결)
+
+---
+
+끝.

--- a/src/app/(auth)/oauth/callback/kakao/KakaoCallback.client.tsx
+++ b/src/app/(auth)/oauth/callback/kakao/KakaoCallback.client.tsx
@@ -5,12 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { Spinner } from '@/components/ui/spinner';
 import { useKakaoLogin } from '@/domain/auth/hooks/useKakaoLogin';
-import {
-  buildKakaoRedirectUri,
-  consumeKakaoState,
-  exchangeKakaoCodeForAccessToken,
-  oauthErrorMessage,
-} from '@/domain/auth/oauth';
+import { buildKakaoRedirectUri, consumeKakaoState, oauthErrorMessage } from '@/domain/auth/oauth';
 import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
 
@@ -19,9 +14,11 @@ import { useToast } from '@/hooks/useToast';
  *
  * 1. URL 의 `code` / `state` 추출 (or `error` 파라미터)
  * 2. state 검증 (CSRF)
- * 3. Kakao token endpoint 직접 POST → access_token
- * 4. BE `POST /auth/oauth/kakao` 로 access_token 전달 → JWT 수신
- * 5. /home 으로 redirect (가입 / 로그인 분기 토스트 포함)
+ * 3. BE `POST /auth/oauth/kakao { code, redirectUri, state }` — BE 가 token 교환 + user info + JWT 발급
+ * 4. /home 으로 redirect (가입 / 로그인 분기 토스트 포함)
+ *
+ * 본 화면은 token endpoint 를 직접 호출하지 않는다 — Authorization Code 흐름이 BE 로 이관됨.
+ * (자세한 BE 명세는 `API_REQUIRED_OAUTH_KAKAO_0504.md`)
  */
 export function KakaoCallback() {
   const router = useRouter();
@@ -71,14 +68,7 @@ export function KakaoCallback() {
     }
 
     const redirectUri = buildKakaoRedirectUri();
-
-    exchangeKakaoCodeForAccessToken({ code, redirectUri })
-      .then((accessToken) => mutation.mutate({ accessToken }))
-      .catch((err) => {
-        const msg = err instanceof Error ? err.message : '카카오 토큰 교환에 실패했습니다.';
-        setError(msg);
-        toast.error(msg);
-      });
+    mutation.mutate({ code, redirectUri, state: stateParam ?? undefined });
   }, [params, toast, mutation]);
 
   return (

--- a/src/domain/auth/oauth/index.ts
+++ b/src/domain/auth/oauth/index.ts
@@ -1,9 +1,4 @@
-export {
-  buildKakaoRedirectUri,
-  exchangeKakaoCodeForAccessToken,
-  loadKakao,
-  startKakaoAuthorize,
-} from './kakao';
+export { buildKakaoRedirectUri, loadKakao, startKakaoAuthorize } from './kakao';
 export { consumeKakaoState } from './kakaoState';
 export { loadGoogleGis, requestGoogleIdToken } from './google';
 

--- a/src/domain/auth/oauth/kakao.ts
+++ b/src/domain/auth/oauth/kakao.ts
@@ -9,8 +9,6 @@ const SDK_URL = 'https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js';
  */
 const SDK_INTEGRITY = 'sha384-DKYJZ8NLiK8MN4/C5P2dtSmLQ4KwPaoqAfyA/DfmEc1VDxu4yyC7wy6K1Hs90nka';
 
-const KAKAO_TOKEN_URL = 'https://kauth.kakao.com/oauth/token';
-
 let loadPromise: Promise<KakaoStatic> | null = null;
 
 /**
@@ -61,7 +59,7 @@ export async function loadKakao(): Promise<KakaoStatic> {
   return loadPromise;
 }
 
-/** 콜백 URL 빌더. start/callback 양쪽이 동일 값을 사용해야 token 교환 시 redirect_uri 검증 통과. */
+/** 콜백 URL 빌더. start/callback 양쪽이 동일 값을 사용해야 BE 의 token 교환 시 redirect_uri 검증 통과. */
 export function buildKakaoRedirectUri(): string {
   if (typeof window === 'undefined') {
     throw new Error('SSR 환경에서는 redirect URI 를 만들 수 없습니다.');
@@ -71,9 +69,11 @@ export function buildKakaoRedirectUri(): string {
 
 /**
  * Kakao authorize 페이지로 redirect.
- * v2.x SDK 는 popup/callback 기반 `Kakao.Auth.login` 을 제공하지 않으므로
- * 표준 OAuth 2.0 Authorization Code 흐름의 시작 단계만 SDK 가 담당하고,
- * 이후 token 교환은 callback 페이지에서 FE 가 직접 처리한다.
+ *
+ * v2.x SDK 는 popup 콜백 기반 `Kakao.Auth.login` 을 제공하지 않으므로
+ * 표준 OAuth 2.0 Authorization Code 흐름의 시작 단계만 SDK 가 담당한다.
+ * 이후 BE 가 받은 code 로 token 교환 + user info 조회 + JWT 발급을 모두 처리.
+ * (BE 명세는 `API_REQUIRED_OAUTH_KAKAO_0504.md`)
  */
 export async function startKakaoAuthorize(): Promise<void> {
   const kakao = await loadKakao();
@@ -85,66 +85,4 @@ export async function startKakaoAuthorize(): Promise<void> {
     state,
   });
   // 호출 직후 페이지가 Kakao authorize URL 로 이동한다. 이 함수는 사실상 반환하지 않음.
-}
-
-interface KakaoTokenSuccess {
-  access_token: string;
-  refresh_token?: string;
-  expires_in?: number;
-  scope?: string;
-  token_type?: string;
-}
-
-interface KakaoTokenError {
-  error: string;
-  error_description?: string;
-  error_code?: string;
-}
-
-/**
- * Kakao token endpoint 에 직접 POST 하여 access_token 을 받는다.
- *
- * 카카오 콘솔의 [보안 → Client Secret] 이 `사용 OFF` 인 경우 client_id (= JavaScript 키) 만으로
- * 교환 가능. ON 이라면 client_secret 이 필요한데 FE 에는 보관하지 않으므로 콘솔에서 OFF 권장.
- */
-export async function exchangeKakaoCodeForAccessToken(input: {
-  code: string;
-  redirectUri: string;
-}): Promise<string> {
-  if (!env.NEXT_PUBLIC_KAKAO_JS_KEY) {
-    throw new Error('NEXT_PUBLIC_KAKAO_JS_KEY 가 설정되지 않았습니다.');
-  }
-
-  const body = new URLSearchParams({
-    grant_type: 'authorization_code',
-    client_id: env.NEXT_PUBLIC_KAKAO_JS_KEY,
-    redirect_uri: input.redirectUri,
-    code: input.code,
-  });
-
-  let response: Response;
-  try {
-    response = await fetch(KAKAO_TOKEN_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8' },
-      body,
-    });
-  } catch {
-    throw new Error('Kakao 토큰 교환 중 네트워크 오류가 발생했습니다.');
-  }
-
-  const json: KakaoTokenSuccess | KakaoTokenError = await response
-    .json()
-    .catch(() => ({}) as never);
-  if (!response.ok) {
-    const err = json as KakaoTokenError;
-    const detail = err.error_description || err.error || `HTTP ${response.status}`;
-    throw new Error(`Kakao 토큰 교환 실패: ${detail}`);
-  }
-
-  const ok = json as KakaoTokenSuccess;
-  if (!ok.access_token) {
-    throw new Error('Kakao 토큰 응답에 access_token 이 없습니다.');
-  }
-  return ok.access_token;
 }

--- a/src/domain/auth/types/req.ts
+++ b/src/domain/auth/types/req.ts
@@ -8,10 +8,20 @@ export interface PasswordChangeRequest {
   newPassword: string;
 }
 
-/** BE: POST /api/v1/auth/oauth/kakao */
+/**
+ * BE: POST /api/v1/auth/oauth/kakao
+ *
+ * Authorization Code Grant — FE 는 Kakao authorize 단계에서 받은 code 만 BE 에 전달.
+ * BE 가 Kakao token endpoint 호출 + user info 조회 + JWT 발급까지 담당.
+ * (자세한 BE 명세는 `API_REQUIRED_OAUTH_KAKAO_0504.md` 참조.)
+ */
 export interface KakaoLoginRequest {
-  /** Kakao SDK 가 발급한 access token. */
-  accessToken: string;
+  /** Kakao authorize 단계에서 받은 authorization code. */
+  code: string;
+  /** FE 가 authorize 시 사용한 redirect URI. BE 의 token 교환에 동일값 필요. */
+  redirectUri: string;
+  /** (선택) FE CSRF state. BE 측 추가 검증이 필요한 경우만. */
+  state?: string;
 }
 
 /** BE: POST /api/v1/auth/oauth/google */


### PR DESCRIPTION
## 🛠️ Issue Number
### Jira: [BD-14](https://sunwoo1137.atlassian.net/browse/BD-14) — OAuth-MemberAuth 연동 (#196 follow-up)

📌 **작업 내용 및 특이사항**

PR #196 머지 후 사용자 결정에 따라, Kakao Authorization Code 흐름의 token 교환을 BE 로 이관. FE 는 code 만 BE 에 전달하고 token endpoint 는 호출하지 않는다.

### 동기
- Kakao SDK 2.x 가 access_token 직접 발급 메서드를 제공하지 않아 PR #196 에서는 FE 가 token endpoint 를 직접 호출
- 그 결과 카카오 콘솔 [보안 → Client Secret] 을 ON 으로 설정 불가 (FE 에 secret 미보관)
- 보안성 + provider 추가 시 FE 부담을 줄이기 위해 Authorization Code Grant 표준 흐름으로 BE 이관

### BE 명세 (동기 PR 필요)
신규 문서: `API_REQUIRED_OAUTH_KAKAO_0504.md`

핵심:
- `POST /api/v1/auth/oauth/kakao` body: `{ accessToken }` → `{ code, redirectUri, state? }`
- `KakaoOAuthClient.exchangeCodeForAccessToken(code, redirectUri)` 신규 — 카카오 token endpoint POST → access_token 추출
- 이후 흐름은 기존 그대로 (`fetchUserInfo` → `OAuthLoginFacade.loginOrJoin` → JWT)
- `KakaoOAuthProperties` 에 `tokenUri`, `clientId`, `clientSecret?` 추가
- 환경변수: `KAKAO_OAUTH_CLIENT_ID` (필수, 신규), `KAKAO_OAUTH_CLIENT_SECRET` (선택, 콘솔 ON 시)

### FE 변경
- `KakaoLoginRequest` 타입: `{ accessToken }` → `{ code, redirectUri, state? }`
- `KakaoCallback.client.tsx`: `exchangeKakaoCodeForAccessToken` 호출 제거 → URL 의 code 를 그대로 `useKakaoLogin.mutate({ code, redirectUri, state })`
- `kakao.ts`: `exchangeKakaoCodeForAccessToken` 함수 + `KAKAO_TOKEN_URL` 상수 제거
- `oauth/index.ts`: barrel 정리
- SDK 사용 부분 (`loadKakao` + `Kakao.Auth.authorize`) 은 유지 — authorize URL 생성과 redirect 흐름은 SDK 가 담당

### 효과

| 측면 | PR #196 | 본 PR |
|---|---|---|
| client_secret 위치 | (사용 불가) | BE 보관 가능 |
| token endpoint 호출 주체 | 브라우저 | BE 서버 |
| 카카오 콘솔 [Client Secret] | OFF 강제 | ON 권고 (보안 ↑) |

### 배포 순서 (중요)

1. **BE PR 머지 + dev 배포** (KakaoOAuthController 시그니처 변경, 환경변수 주입)
2. **FE 본 PR 머지 + dev 배포**

> BE 가 새 시그니처 반영 전에 FE 만 단독 배포하면 카카오 로그인이 즉시 깨진다.

📚 **참고사항**
- BE 측에서 이미 `KakaoOAuthController` 변경 작업이 시작됨이 확인됨 (시그니처 매칭)
- 라이브 검증 시 BE 가 401 OAUTH_TOKEN_INVALID / 502 OAUTH_PROVIDER_ERROR 를 적절히 매핑하는지 확인 필요 (token 교환 단계 + user info 단계 구분)

[BD-14]: https://sunwoo1137.atlassian.net/browse/BD-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ