### PR TITLE
[BD-28] fix: CloudFront RSC payload 캐시 mismatch 차단 (hotfix)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,33 +3,54 @@ import { NextResponse, type NextRequest } from 'next/server';
 const PROTECTED_PREFIXES = ['/home', '/bands', '/practices', '/performances', '/me'];
 const REFRESH_COOKIE = 'refreshToken';
 
+/**
+ * 모든 페이지 응답에 적용할 캐시/Vary 헤더.
+ *
+ * Next.js App Router 는 동일 URL 에 두 가지 응답을 내보낸다:
+ *  - 일반 진입       → Content-Type: text/html
+ *  - <Link> prefetch → Content-Type: text/x-component (RSC flight payload)
+ *
+ * CloudFront 등 CDN 의 cache key 에 RSC 관련 요청 헤더가 포함되지 않으면 두 응답이
+ * 같은 키로 저장되어 사용자가 RSC payload 를 raw text 로 보게 되는 사고가 발생한다.
+ * Origin 응답에 명시적으로 `private, no-store` 를 박아 CDN 캐시를 우회시키고, `Vary`
+ * 로는 다른 프록시/브라우저 캐시에 RSC 분기를 알려둔다.
+ */
+function applyNoStoreHeaders(response: NextResponse): NextResponse {
+  response.headers.set('Cache-Control', 'private, no-store');
+  response.headers.set(
+    'Vary',
+    'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Url, Accept-Encoding',
+  );
+  return response;
+}
+
 export function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
   const hasRefreshToken = request.cookies.has(REFRESH_COOKIE);
 
   // 루트(/) 는 RootPage 가 /home 으로 redirect 한다 — 비인증이면 home 의 보호 규칙이
   // 자연스럽게 /login 으로 이어준다. 별도 onboarding 분기는 더 이상 두지 않는다.
-  if (pathname === '/') return NextResponse.next();
+  if (pathname === '/') return applyNoStoreHeaders(NextResponse.next());
 
   const requiresAuth = PROTECTED_PREFIXES.some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   );
-  if (!requiresAuth) return NextResponse.next();
 
-  if (hasRefreshToken) return NextResponse.next();
+  if (requiresAuth && !hasRefreshToken) {
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('from', pathname + search);
+    return applyNoStoreHeaders(NextResponse.redirect(loginUrl));
+  }
 
-  const loginUrl = new URL('/login', request.url);
-  loginUrl.searchParams.set('from', pathname + search);
-  return NextResponse.redirect(loginUrl);
+  return applyNoStoreHeaders(NextResponse.next());
 }
 
 export const config = {
+  /**
+   * 페이지 라우트 전체에 매칭. 정적 자원/이미지/API 는 제외해 long cache 와 BE 프록시
+   * 응답에 영향을 주지 않는다. 패턴 출처: Next.js 공식 미들웨어 예시.
+   */
   matcher: [
-    '/',
-    '/home/:path*',
-    '/bands/:path*',
-    '/practices/:path*',
-    '/performances/:path*',
-    '/me/:path*',
+    '/((?!api|_next/static|_next/image|favicon.ico|icon.svg|apple-icon.png|brand|.*\\.(?:png|jpg|jpeg|gif|svg|webp|ico|woff|woff2|ttf|otf)$).*)',
   ],
 };


### PR DESCRIPTION
## 🛠️ Issue Number
### Jira: [BD-28](https://sunwoo1137.atlassian.net/browse/BD-28) — CloudFront RSC payload 캐시 mismatch (hotfix)

📌 **작업 내용 및 특이사항**

운영 도메인(`bandage.team`) 진입 시 화면에 Next.js RSC flight payload 의 raw text 가 그대로 표시되는 사고가 발생. Origin 측 응답 헤더만으로 즉시 차단.

### 원인

Next.js App Router 는 동일 URL 에 두 가지 응답을 내보낸다.

| 진입 경로 | Content-Type | 본문 |
|---|---|---|
| 일반 진입 / 새로고침 | `text/html` | 완성된 HTML |
| `<Link>` prefetch / 클라이언트 nav | `text/x-component` | RSC flight payload (`__next_f.push(...)` chunk 들) |

CloudFront 의 cache policy 가 `RSC` / `Next-Router-State-Tree` / `Next-Router-Prefetch` / `Next-Url` 헤더를 cache key 에 포함하지 않으면, 두 응답이 같은 키로 저장되어 prefetch 된 RSC 응답이 일반 진입 사용자에게 그대로 내려간다 — 브라우저는 그걸 plaintext 로 표시.

응답 헤더 진단:
```
cache-control: s-maxage=31536000
vary: Accept-Encoding,Accept-Encoding   ← RSC 관련 헤더 없음
x-cache: Hit from cloudfront
via: 1.1 ...cloudfront.net (CloudFront)
```

### 변경

- **`src/middleware.ts`**
  - `matcher` 를 페이지 라우트 전체로 확장 (`/((?!api|_next/static|_next/image|favicon.ico|icon.svg|apple-icon.png|brand|.*\.(?:png|jpg|jpeg|gif|svg|webp|ico|woff|woff2|ttf|otf)$).*)`)
  - 모든 응답(통과/redirect 모두)에 `Cache-Control: private, no-store` + `Vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Url, Accept-Encoding` 강제
  - 보호 경로 redirect 로직은 동일, 헤더만 일관 적용
- 정적 자원(`/_next/static/*`)·이미지·폰트·API(`/api/v1/*`, `/api/health`) 는 matcher 에서 제외해 기존 long cache / BE 프록시 동작 유지

### 검증

- `pnpm lint / typecheck / format / build` 모두 통과 (Middleware bundle 34.1 kB)

### 배포 후 사용자 작업 필요

1. **CloudFront invalidation** (잘못 캐시된 응답 즉시 제거)
   ```bash
   aws cloudfront create-invalidation --distribution-id <ID> --paths "/*"
   ```
2. **(follow-up) CloudFront cache policy 보완**: cache key 에 `RSC`, `Next-Router-State-Tree`, `Next-Router-Prefetch`, `Next-Url` 헤더 포함 → middleware 의 `no-store` 를 풀고 페이지 캐시 효과 복구. 별도 이슈로 추적 권장.

📚 **참고사항**

- 이 PR 만 머지/배포되어도 사고 재발은 막힌다 (origin 응답이 `private, no-store` 라 CloudFront 가 캐시 자체를 안 함). cache policy 보완은 캐시 효과를 살리기 위한 후속 작업.

[BD-28]: https://sunwoo1137.atlassian.net/browse/BD-28