### PR TITLE
[BD-28] chore: 배포 워크플로우에 CloudFront invalidation 자동화

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -133,3 +133,14 @@ jobs:
             echo "fe-web 헬스체크 실패 — 로그 출력 후 종료" >&2
             docker logs --tail=200 bandage-fe || true
             exit 1
+
+      # 새 origin 응답이 정상화되어도 CloudFront 가 잘못 캐시했던 RSC payload 가
+      # TTL 만료 전까지 살아남는다. 배포가 healthy 로 통과한 직후 전체 invalidation
+      # 으로 즉시 새 응답을 강제 노출.
+      - name: Invalidate CloudFront Cache
+        env:
+          DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DIST_ID }}
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id $DISTRIBUTION_ID \
+            --paths "/*"


### PR DESCRIPTION
## 🛠️ Issue Number
### Jira: [BD-28](https://sunwoo1137.atlassian.net/browse/BD-28) — CloudFront RSC payload 캐시 mismatch 후속 (자동 invalidation)

📌 **작업 내용 및 특이사항**

#200 (middleware 측 origin 헤더 차단) 의 follow-up. 배포 시점마다 CloudFront 전체 invalidation 을 자동 실행해, 향후 다른 캐시 사고가 생겨도 새 배포로 즉시 복구되도록 한다.

### 변경

- **`.github/workflows/develop_deploy.yml`**
  - `Deploy to EC2` step (헬스체크 통과 후) 다음에 `Invalidate CloudFront Cache` step 추가
  - `aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"` 실행
  - `DISTRIBUTION_ID` 는 `secrets.CLOUDFRONT_DIST_ID` 로 주입
  - 기존 `Configure AWS Credentials` step 에서 export 된 자격증명을 같은 job 안에서 그대로 재사용 (별도 configure step 불필요)

### 머지 전 사용자 측 사전 작업 필요

머지 후 워크플로우가 실행되려면 **GitHub Secret 등록 + IAM 권한 추가** 두 가지가 선행되어야 한다.

1. **GitHub Secret 등록** (CLI 또는 Settings → Secrets and variables → Actions)
   ```bash
   gh secret set CLOUDFRONT_DIST_ID --body "EIDLV93N8ZFL1"
   ```
2. **IAM 정책 보강** — 현재 `AWS_ECR_*` 키는 ECR 전용 권한만 갖고 있다 (BD-10 PR 본문 참조). 동일 IAM 사용자에 다음 inline policy 추가 필요.
   ```json
   {
     "Version": "2012-10-17",
     "Statement": [
       {
         "Effect": "Allow",
         "Action": "cloudfront:CreateInvalidation",
         "Resource": "arn:aws:cloudfront::<ACCOUNT_ID>:distribution/EIDLV93N8ZFL1"
       }
     ]
   }
   ```
   (또는 IAM 키 전용성을 유지하고 싶다면 `AWS_CLOUDFRONT_*` 별도 키 + 별도 `Configure AWS Credentials` step 분기 — 그 방향이면 본 PR 수정 가능.)

### 동작 시나리오

- 머지 → develop push → 워크플로우 실행:
  1. ECR 이미지 빌드/푸시
  2. EC2 SCP + SSH 로 새 컨테이너 띄우기 + 헬스체크 통과
  3. **CloudFront `/*` invalidation** ← 새 step
- workflow_dispatch 재배포에도 동일하게 적용

📚 **참고사항**

- 시스템 사고 시 즉시 복구 메커니즘으로도 활용 가능 (workflow_dispatch 로 직전 태그 재배포 → invalidation 까지 자동).
- invalidation 은 AWS 가 매월 1,000건 무료 제공 후 건당 $0.005 — 일 1~2회 배포 기준으로 비용 영향 무시 수준.

[BD-28]: https://sunwoo1137.atlassian.net/browse/BD-28