### PR TITLE
[BD-28] fix: CloudFront invalidation step graceful skip (secret 미등록 대응)

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -137,10 +137,18 @@ jobs:
       # 새 origin 응답이 정상화되어도 CloudFront 가 잘못 캐시했던 RSC payload 가
       # TTL 만료 전까지 살아남는다. 배포가 healthy 로 통과한 직후 전체 invalidation
       # 으로 즉시 새 응답을 강제 노출.
+      #
+      # secrets.CLOUDFRONT_DIST_ID 가 비어 있으면 (또는 IAM 권한 미부여 상태이면)
+      # invalidation 만 스킵하고 배포 자체는 성공으로 종료. — 사고 직후 단계적 도입을
+      # 위해 graceful 처리.
       - name: Invalidate CloudFront Cache
         env:
           DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DIST_ID }}
         run: |
+          if [ -z "${DISTRIBUTION_ID:-}" ]; then
+            echo "::warning::CLOUDFRONT_DIST_ID secret 이 등록되어 있지 않다 — invalidation 스킵."
+            exit 0
+          fi
           aws cloudfront create-invalidation \
-            --distribution-id $DISTRIBUTION_ID \
+            --distribution-id "$DISTRIBUTION_ID" \
             --paths "/*"


### PR DESCRIPTION
## 🛠️ Issue Number
### Jira: [BD-28](https://sunwoo1137.atlassian.net/browse/BD-28) — invalidation step 안전화 (secret 미등록 대응)

📌 **작업 내용 및 특이사항**

#201 머지 후 develop 트리거 워크플로우의 `Invalidate CloudFront Cache` step 이 다음 에러로 실패.

```
aws: [ERROR]: An error occurred (ParamValidation): argument --distribution-id: expected one argument
Error: Process completed with exit code 252.
```

원인: `secrets.CLOUDFRONT_DIST_ID` 가 GitHub Secret 으로 아직 등록되지 않은 상태에서 워크플로우가 자동 트리거되어 빈 값으로 호출됨. 이 PR 은 step 자체를 graceful 하게 만들어 secret/IAM 단계적 도입 동안 배포 파이프라인이 깨지지 않도록 한다.

### 변경

- **`.github/workflows/develop_deploy.yml`**
  - `DISTRIBUTION_ID` 가 비어 있으면 `::warning::` 로그만 남기고 `exit 0` 으로 종료
  - 인용부호 추가 (`"$DISTRIBUTION_ID"`) 로 빈 값 expansion 시 ParamValidation 에러 차단
  - 본 step 의 graceful 처리에 한정 — 다른 배포 step 동작은 유지

### 동작 시나리오

| secret 상태 | IAM 권한 | invalidation step 결과 |
|---|---|---|
| 미등록 | — | `warning` 로그 + 스킵 → 배포 성공 |
| 등록 | 권한 없음 | aws CLI 가 `AccessDenied` 로 실패 → step 실패 (의도한 노출) |
| 등록 | 권한 있음 | 정상 invalidation → 배포 성공 |

### 사용자 측 후속 작업 (불변, 재안내)

```bash
gh secret set CLOUDFRONT_DIST_ID --body "EIDLV93N8ZFL1"
```

+ IAM 정책에 `cloudfront:CreateInvalidation` (Resource: 본 distribution) 추가.

📚 **참고사항**

- 검증: `pnpm lint / typecheck / format / build` 모두 통과 (yaml 만 변경, FE 산출물 영향 없음).

[BD-28]: https://sunwoo1137.atlassian.net/browse/BD-28