### PR TITLE
[BD-28] feat: BrandWordmark 컴포넌트 도입 — 사이드바 + 홈 hero

### DIFF
--- a/src/app/(main)/home/HomeGreeting.client.tsx
+++ b/src/app/(main)/home/HomeGreeting.client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { BrandWordmark } from '@/components/brand';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useMe } from '@/domain/member/hooks/useMe';
 
@@ -7,15 +8,18 @@ export function HomeGreeting() {
   const { data: me, isLoading } = useMe();
 
   return (
-    <header className="space-y-s-1" data-slot="home-greeting">
-      {isLoading ? (
-        <Skeleton className="h-8 w-64" rounded="md" />
-      ) : (
-        <h1 className="text-foreground text-title-lg font-extrabold">
-          {me?.name ? `안녕하세요, ${me.name} 님 👋` : '안녕하세요 👋'}
-        </h1>
-      )}
-      <p className="text-foreground-sub text-body">오늘도 좋은 합주 되세요.</p>
+    <header className="space-y-s-4" data-slot="home-greeting">
+      <BrandWordmark size="lg" title="Bandage" className="text-accent" />
+      <div className="space-y-s-1">
+        {isLoading ? (
+          <Skeleton className="h-8 w-64" rounded="md" />
+        ) : (
+          <h1 className="text-foreground text-title-lg font-extrabold">
+            {me?.name ? `안녕하세요, ${me.name} 님 👋` : '안녕하세요 👋'}
+          </h1>
+        )}
+        <p className="text-foreground-sub text-body">오늘도 좋은 합주 되세요.</p>
+      </div>
     </header>
   );
 }

--- a/src/components/brand/brand-wordmark.tsx
+++ b/src/components/brand/brand-wordmark.tsx
@@ -1,0 +1,60 @@
+import type { HTMLAttributes } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { BrandMark } from './brand-mark';
+
+type WordmarkSize = 'sm' | 'md' | 'lg';
+
+const SIZE_PRESETS: Record<
+  WordmarkSize,
+  { mark: number; textClass: string; gapClass: string; trackingClass: string }
+> = {
+  sm: { mark: 22, textClass: 'text-body', gapClass: 'gap-s-2', trackingClass: 'tracking-tight' },
+  md: {
+    mark: 30,
+    textClass: 'text-title-lg',
+    gapClass: 'gap-s-3',
+    trackingClass: 'tracking-tight',
+  },
+  lg: {
+    mark: 56,
+    textClass: 'text-display',
+    gapClass: 'gap-s-3',
+    trackingClass: 'tracking-tight',
+  },
+};
+
+export interface BrandWordmarkProps extends HTMLAttributes<HTMLSpanElement> {
+  /** 사이즈 프리셋. mark 픽셀과 워드마크 텍스트 크기를 함께 정한다. 기본 `md`. */
+  size?: WordmarkSize;
+  /** 접근성 라벨. 장식용이면 생략 — aria-hidden 자동 부여. */
+  title?: string;
+}
+
+/**
+ * Bandage 워드마크 (mark + 텍스트 lock-up).
+ * 텍스트는 부모의 `text-*` 색상 토큰을 그대로 따른다 (currentColor).
+ * mark 자체는 항상 풀컬러(#3563eb 액센트).
+ *
+ * design/bandage-logo/unfurl-pulse/wordmark.svg 의 lock-up 비율을 컴포넌트로 옮긴 것.
+ */
+export function BrandWordmark({ size = 'md', title, className, ...props }: BrandWordmarkProps) {
+  const preset = SIZE_PRESETS[size];
+  const decorated = Boolean(title);
+
+  return (
+    <span
+      className={cn('inline-flex items-center', preset.gapClass, className)}
+      role={decorated ? 'img' : undefined}
+      aria-label={decorated ? title : undefined}
+      aria-hidden={decorated ? undefined : true}
+      {...props}
+    >
+      <BrandMark size={preset.mark} />
+      <span className={cn(preset.textClass, preset.trackingClass, 'leading-none font-black')}>
+        Bandage
+      </span>
+    </span>
+  );
+}

--- a/src/components/brand/index.ts
+++ b/src/components/brand/index.ts
@@ -1,1 +1,2 @@
 export { BrandMark, type BrandMarkProps } from './brand-mark';
+export { BrandWordmark, type BrandWordmarkProps } from './brand-wordmark';

--- a/src/components/layout/__snapshots__/sidebar.test.tsx.snap
+++ b/src/components/layout/__snapshots__/sidebar.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
           />
         </svg>
         <span
-          class="text-body tracking-tight font-black leading-none"
+          class="text-body tracking-tight leading-none font-black"
         >
           Bandage
         </span>

--- a/src/components/layout/__snapshots__/sidebar.test.tsx.snap
+++ b/src/components/layout/__snapshots__/sidebar.test.tsx.snap
@@ -9,12 +9,12 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
     style="width: var(--sidebar-w);"
   >
     <div
-      class="border-border mb-s-2 gap-s-2 pb-s-4 px-s-2 pt-s-1 flex items-center border-b"
+      class="border-border mb-s-2 pb-s-4 px-s-2 pt-s-1 flex items-center border-b"
     >
       <span
-        aria-hidden="true"
-        class="bg-accent-dim flex h-8 w-8 items-center justify-center rounded-md border"
-        style="border-color: oklch(0.62 0.22 250 / 0.2);"
+        aria-label="Bandage"
+        class="inline-flex items-center gap-s-2 text-accent"
+        role="img"
       >
         <svg
           aria-hidden="true"
@@ -73,11 +73,11 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
             stroke-width="0.9"
           />
         </svg>
-      </span>
-      <span
-        class="text-accent text-body font-black tracking-tight"
-      >
-        Bandage
+        <span
+          class="text-body tracking-tight font-black leading-none"
+        >
+          Bandage
+        </span>
       </span>
     </div>
     <div

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -18,7 +18,7 @@ import { useMe } from '@/domain/member/hooks/useMe';
 import { ROUTES } from '@/global/config/routes';
 import { cn } from '@/lib/cn';
 
-import { BrandMark } from '../brand';
+import { BrandWordmark } from '../brand';
 import { Avatar } from '../ui/avatar';
 import { Skeleton } from '../ui/skeleton';
 
@@ -101,15 +101,8 @@ export function Sidebar({ className }: SidebarProps) {
       data-slot="sidebar"
       aria-label="주 탐색"
     >
-      <div className="border-border mb-s-2 gap-s-2 pb-s-4 px-s-2 pt-s-1 flex items-center border-b">
-        <span
-          className="bg-accent-dim flex h-8 w-8 items-center justify-center rounded-md border"
-          style={{ borderColor: 'oklch(0.62 0.22 250 / 0.2)' }}
-          aria-hidden="true"
-        >
-          <BrandMark size={22} />
-        </span>
-        <span className="text-accent text-body font-black tracking-tight">Bandage</span>
+      <div className="border-border mb-s-2 pb-s-4 px-s-2 pt-s-1 flex items-center border-b">
+        <BrandWordmark size="sm" title="Bandage" className="text-accent" />
       </div>
 
       <div className="text-foreground-muted px-s-3 pb-s-2 pt-s-1 text-micro font-bold tracking-wider uppercase">


### PR DESCRIPTION
## 🛠️ Issue Number
### Jira: [BD-28](https://sunwoo1137.atlassian.net/browse/BD-28) — 워드마크 적용 (사이드바 / 홈)

📌 **작업 내용 및 특이사항**

#203 에서 채택한 Unfurl Pulse 마크를 텍스트 lock-up 형태(워드마크)로 묶고, 사이드바 헤더와 홈 페이지 진입 영역에 일관 적용.

### 변경

- **`src/components/brand/brand-wordmark.tsx` (신규)**
  - `BrandMark` + 'Bandage' 텍스트의 lock-up 컴포넌트
  - `size`: `'sm' | 'md' | 'lg'` (각각 mark 22/30/56px + text-body / text-title-lg / text-display)
  - 텍스트는 부모의 `text-*` 토큰을 currentColor 로 따른다 (재배색 자유)
  - `title` 부여 시 role="img" + aria-label, 미부여 시 aria-hidden 자동
- **`src/components/brand/index.ts`**: `BrandWordmark` re-export
- **`src/components/layout/sidebar.tsx`**
  - 기존 `BrandMark` + 별도 `<span>Bandage</span>` 의 컨테이너 형태를 단일 `BrandWordmark size="sm"` 로 교체
  - 작은 액센트 박스 컨테이너 제거 (워드마크 자체가 lock-up 이므로 불필요)
- **`src/app/(main)/home/HomeGreeting.client.tsx`**
  - 페이지 진입 시 메인 헤더 위에 `BrandWordmark size="lg"` 배치 (text-accent)
  - 인사 / 안내 문구는 그대로 유지
- **`src/components/layout/__snapshots__/sidebar.test.tsx.snap`**: 마크업 변화 반영해 스냅샷 재생성

### 디자인 토큰 일관성

- 텍스트 사이즈는 모두 `globals.css` 의 정의 토큰(`text-display` `text-title-lg` `text-body`) 만 사용
- 마크 색상은 `BrandMark` 기본 (#3563eb / #0d0d12) 유지, 텍스트는 사용처에서 `text-accent` 등 토큰 클래스로 부여

### 검증

- `pnpm lint / typecheck / format / build / test` 모두 통과
- 빌드 산출물 변경 없음 (페이지 사이즈는 거의 동일)

📚 **참고사항**

- 본 PR 은 워드마크 lock-up 도입에 한정. 필요 시 `BrandWordmark` 의 size 프리셋은 후속 PR 로 확장 가능 (xl / 마이크로 등). globals.css 토큰 추가 동반 필요.
- Auth 좌측 패널의 `BrandMark` 는 둥근 사각형 컨테이너 안에 있는 형태로 의도되어 그대로 유지 (별도 작업 시 워드마크화 검토 가능).

[BD-28]: https://sunwoo1137.atlassian.net/browse/BD-28