### PR TITLE
[BD-30] UI/UX polish pass — 브랜드 hero, 매트릭스 채도, 로고 토큰 동기화

### DIFF
--- a/src/app/(main)/home/HomeGreeting.client.tsx
+++ b/src/app/(main)/home/HomeGreeting.client.tsx
@@ -8,17 +8,24 @@ export function HomeGreeting() {
   const { data: me, isLoading } = useMe();
 
   return (
-    <header className="space-y-s-4" data-slot="home-greeting">
-      <BrandWordmark size="lg" title="Bandage" className="text-accent" />
+    <header className="space-y-s-6 pt-s-2 lg:pt-s-4" data-slot="home-greeting">
+      <div className="space-y-s-3">
+        <BrandWordmark size="lg" title="Bandage" className="text-accent lg:hidden" />
+        <BrandWordmark size="xl" title="Bandage" className="text-accent hidden lg:inline-flex" />
+        <p className="text-foreground-sub text-subtitle max-w-md leading-relaxed">
+          밴드의 합주, 공연, 선곡을 한곳에서.
+        </p>
+      </div>
+
       <div className="space-y-s-1">
         {isLoading ? (
-          <Skeleton className="h-8 w-64" rounded="md" />
+          <Skeleton className="h-7 w-64" rounded="md" />
         ) : (
-          <h1 className="text-foreground text-title-lg font-extrabold">
-            {me?.name ? `안녕하세요, ${me.name} 님 👋` : '안녕하세요 👋'}
-          </h1>
+          <h2 className="text-foreground text-title font-bold">
+            {me?.name ? `안녕하세요, ${me.name} 님` : '안녕하세요'}
+          </h2>
         )}
-        <p className="text-foreground-sub text-body">오늘도 좋은 합주 되세요.</p>
+        <p className="text-foreground-muted text-body">오늘도 좋은 합주 되세요.</p>
       </div>
     </header>
   );

--- a/src/components/brand/brand-mark.tsx
+++ b/src/components/brand/brand-mark.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/cn';
 export interface BrandMarkProps extends Omit<SVGProps<SVGSVGElement>, 'viewBox'> {
   /** 아이콘 픽셀 사이즈 (정사각). 기본 28. */
   size?: number;
-  /** 단색 모드. light = 흰색 단색, dark = 어두운 단색, undefined = 풀컬러(액센트 블루). */
+  /** 단색 모드. light = 흰색 단색, dark = 어두운 단색, undefined = 부모의 currentColor (보통 text-accent). */
   tone?: 'light' | 'dark';
   /** 접근성 라벨. 장식용이면 생략 — aria-hidden 자동 부여. */
   title?: string;
@@ -14,10 +14,12 @@ export interface BrandMarkProps extends Omit<SVGProps<SVGSVGElement>, 'viewBox'>
 /**
  * Bandage 브랜드 마크 (Unfurl Pulse).
  * 말린 붕대(좌측 원) + 펄스 띠(우측 라인). 64×64 viewBox.
- * design/bandage-logo/unfurl-pulse/ 의 SVG 와 동일.
+ *
+ * 기본 색상은 `currentColor` 를 따른다 — 부모에서 `text-accent` 등 토큰 클래스를 지정하면
+ * 시스템 컬러와 자동 동기화된다. 단색 처리가 필요한 경우만 `tone="light" | "dark"` 사용.
  */
 export function BrandMark({ size = 28, tone, title, className, ...props }: BrandMarkProps) {
-  const accent = tone === 'light' ? '#f4f4f8' : tone === 'dark' ? '#0d0d12' : '#3563eb';
+  const accent = tone === 'light' ? '#f4f4f8' : tone === 'dark' ? '#0d0d12' : 'currentColor';
   const ink = tone === 'dark' ? '#f4f4f8' : '#0d0d12';
   const decorated = Boolean(title);
 

--- a/src/components/brand/brand-wordmark.tsx
+++ b/src/components/brand/brand-wordmark.tsx
@@ -34,8 +34,8 @@ export interface BrandWordmarkProps extends HTMLAttributes<HTMLSpanElement> {
 
 /**
  * Bandage 워드마크 (mark + 텍스트 lock-up).
- * 텍스트는 부모의 `text-*` 색상 토큰을 그대로 따른다 (currentColor).
- * mark 자체는 항상 풀컬러(#3563eb 액센트).
+ * 마크와 텍스트 모두 부모의 `text-*` 색상 토큰을 그대로 따른다 (currentColor).
+ * 시스템 accent 토큰 변경 시 자동으로 동기화된다 — 별도 색상 하드코딩 없음.
  *
  * design/bandage-logo/unfurl-pulse/wordmark.svg 의 lock-up 비율을 컴포넌트로 옮긴 것.
  */

--- a/src/components/brand/brand-wordmark.tsx
+++ b/src/components/brand/brand-wordmark.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/cn';
 
 import { BrandMark } from './brand-mark';
 
-type WordmarkSize = 'sm' | 'md' | 'lg';
+type WordmarkSize = 'sm' | 'md' | 'lg' | 'xl';
 
 const SIZE_PRESETS: Record<
   WordmarkSize,
@@ -21,6 +21,12 @@ const SIZE_PRESETS: Record<
     mark: 56,
     textClass: 'text-display',
     gapClass: 'gap-s-3',
+    trackingClass: 'tracking-tight',
+  },
+  xl: {
+    mark: 80,
+    textClass: 'text-[56px]',
+    gapClass: 'gap-s-4',
     trackingClass: 'tracking-tight',
   },
 };

--- a/src/components/layout/__snapshots__/sidebar.test.tsx.snap
+++ b/src/components/layout/__snapshots__/sidebar.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
           <circle
             cx="18"
             cy="32"
-            fill="#3563eb"
+            fill="currentColor"
             r="11"
           />
           <circle
@@ -58,7 +58,7 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
           <path
             d="M 27 32 L 34 32 L 38 24 L 42 40 L 46 28 L 50 32 L 58 32"
             fill="none"
-            stroke="#3563eb"
+            stroke="currentColor"
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="4.5"

--- a/src/components/layout/auth-split.tsx
+++ b/src/components/layout/auth-split.tsx
@@ -63,7 +63,7 @@ export function AuthBrand({ className, ...props }: HTMLAttributes<HTMLElement>) 
           className="bg-accent-dim mb-s-5 mx-auto flex h-18 w-18 items-center justify-center rounded-xl border"
           style={{ borderColor: 'oklch(0.62 0.22 250 / 0.26)' }}
         >
-          <BrandMark size={48} />
+          <BrandMark size={48} className="text-accent" />
         </div>
         <h1 className="text-display text-foreground mb-s-3 font-black tracking-tight">Bandage</h1>
         <p className="text-foreground-sub mb-s-10 text-subtitle mx-auto max-w-[280px] leading-relaxed">

--- a/src/domain/schedule-coordination/components/MatrixView.client.tsx
+++ b/src/domain/schedule-coordination/components/MatrixView.client.tsx
@@ -775,8 +775,9 @@ function LockBlockCard({
       role="button"
       title={`${title} ${slotToTime(block.startSlot)}~${slotToTime(block.startSlot + dur)}`}
       className={cn(
-        'mx-0.5 my-0.5 flex h-[28px] cursor-pointer items-center gap-1 overflow-hidden rounded-md border border-white/30 px-2 text-left text-white shadow-sm transition-shadow hover:shadow-md hover:ring-2 hover:ring-white/60 hover:ring-inset',
-        tone.bg,
+        'text-foreground mx-0.5 my-0.5 flex h-[28px] cursor-pointer items-center gap-1 overflow-hidden rounded-md border px-2 text-left shadow-sm transition-shadow hover:shadow-md hover:ring-2 hover:ring-white/40 hover:ring-inset',
+        tone.softBg,
+        tone.softBorder,
       )}
     >
       {block.pinned && <Lock className="h-2.5 w-2.5 shrink-0 opacity-80" aria-hidden="true" />}

--- a/src/domain/schedule-coordination/components/ScheduleBoardEditor.client.tsx
+++ b/src/domain/schedule-coordination/components/ScheduleBoardEditor.client.tsx
@@ -353,8 +353,9 @@ export function ScheduleBoardEditor({
                   toast.success('합주 블록 삭제');
                 }}
                 className={cn(
-                  'm-0.5 cursor-grab overflow-hidden rounded px-1 py-0.5 text-left text-white shadow-sm ring-0 ring-white/0 transition-all duration-150 ease-out hover:scale-[1.02] hover:ring-2 hover:ring-white/40 hover:brightness-125 active:scale-[0.98] active:cursor-grabbing',
-                  tone.bg,
+                  'text-foreground m-0.5 cursor-grab overflow-hidden rounded border px-1 py-0.5 text-left shadow-sm ring-0 ring-white/0 transition-all duration-150 ease-out hover:scale-[1.02] hover:ring-2 hover:ring-white/40 hover:brightness-125 active:scale-[0.98] active:cursor-grabbing',
+                  tone.softBg,
+                  tone.softBorder,
                 )}
                 style={{
                   gridRow: `${rowStart} / span ${rowSpan}`,

--- a/src/domain/schedule-coordination/components/palette.ts
+++ b/src/domain/schedule-coordination/components/palette.ts
@@ -1,13 +1,53 @@
 /**
  * 시간표 블록 컬러 팔레트 — Task 6 에서 본격 도입.
  * 12색 순환. 시안별 paletteSeed 로 시작점 회전, 블록은 paletteIndex 로 고정.
+ *
+ * - `bg/border/text` : 풀 채도. 곡 풀(드래그 손잡이) 등 강한 식별이 필요한 곳.
+ * - `softBg/softBorder` : 다크 배경 위에 얹는 합주 블록용 톤다운 변형 (/25 bg + /60 border).
+ *   같은 hue 를 유지하면서 시각 피로를 줄인다.
+ * - `dim` : 12~15% 알파의 가장 약한 변형. 호버 프리뷰 등.
  */
 export const PALETTE_TONES = [
-  { bg: 'bg-accent', dim: 'bg-accent-dim', text: 'text-accent', border: 'border-accent' },
-  { bg: 'bg-success', dim: 'bg-success-dim', text: 'text-success', border: 'border-success' },
-  { bg: 'bg-warn', dim: 'bg-warn-dim', text: 'text-warn', border: 'border-warn' },
-  { bg: 'bg-amber', dim: 'bg-amber-dim', text: 'text-amber', border: 'border-amber' },
-  { bg: 'bg-danger', dim: 'bg-danger-dim', text: 'text-danger', border: 'border-danger' },
+  {
+    bg: 'bg-accent',
+    dim: 'bg-accent-dim',
+    text: 'text-accent',
+    border: 'border-accent',
+    softBg: 'bg-accent/25',
+    softBorder: 'border-accent/60',
+  },
+  {
+    bg: 'bg-success',
+    dim: 'bg-success-dim',
+    text: 'text-success',
+    border: 'border-success',
+    softBg: 'bg-success/25',
+    softBorder: 'border-success/60',
+  },
+  {
+    bg: 'bg-warn',
+    dim: 'bg-warn-dim',
+    text: 'text-warn',
+    border: 'border-warn',
+    softBg: 'bg-warn/25',
+    softBorder: 'border-warn/60',
+  },
+  {
+    bg: 'bg-amber',
+    dim: 'bg-amber-dim',
+    text: 'text-amber',
+    border: 'border-amber',
+    softBg: 'bg-amber/25',
+    softBorder: 'border-amber/60',
+  },
+  {
+    bg: 'bg-danger',
+    dim: 'bg-danger-dim',
+    text: 'text-danger',
+    border: 'border-danger',
+    softBg: 'bg-danger/25',
+    softBorder: 'border-danger/60',
+  },
 ] as const;
 
 export type PaletteTone = (typeof PALETTE_TONES)[number];


### PR DESCRIPTION
## Issue Number
### Jira: BD-30

**작업 내용 및 특이사항**

UI/UX 피드백 검토 후 즉시 가치 있는 3개 항목을 한 PR 로 정리. 시스템 토큰·디자인 일관성 손익이 큰 변경 위주.

### 1. BrandMark 색상을 accent 토큰과 동기화 (`fix`)
- `src/components/brand/brand-mark.tsx` 의 default fill 하드코딩 `#3563eb` 를 `currentColor` 로 전환
- 부모의 `text-accent` 클래스가 SVG 마크에까지 자동 전파 → globals.css `--color-accent` 변경 시 마크도 함께 갱신
- 단독 사용처(`auth-split`) 에 명시적으로 `text-accent` 부여
- 워드마크 doc, sidebar snapshot 동기화

### 2. 스케줄 매트릭스 합주 블록 채도 톤다운 (`refactor`)
- `PALETTE_TONES` 에 `softBg` (`/25`) + `softBorder` (`/60`) 변형 추가
- 그리드에 배치된 합주 블록은 soft 변형으로 전환 (MatrixView, ScheduleBoardEditor)
- 다크 배경 위 풀 채도 fill 의 시각 피로 완화, hue 식별성은 유지
- 곡 풀(드래그 손잡이) 은 강한 식별이 필요해 기존 풀 채도 유지

### 3. 홈 첫 진입 화면의 브랜드 hero 강화 (`feat`)
- `BrandWordmark` 에 `xl` 사이즈 추가 (mark 80px / text 56px)
- HomeGreeting 재구성: 로고를 hero 영역으로 승격, 보조 tagline 추가
  - 데스크톱(lg+) `xl`, 모바일은 기존 `lg` 유지로 좁은 폭 줄바꿈 방지
- 인사말은 `text-title-lg/extrabold` → `text-title/bold` 로 위계 하향, 로고와 시각 경합 해소
- 인사말 이모지 제거 (workspace AI 스타일 규칙 §7-1)

**참고사항**

- 검토에서 도출한 P1 4건 중 시스템 accent chroma 톤다운(전 컴포넌트 영향)은 별도 디자인 합의 후 단독 PR 로 분리.
- `pnpm lint` / `pnpm typecheck` / `pnpm format:check` / `pnpm test` (61 tests) 모두 통과.
- 사전 검토 보고: https://bandagedev.slack.com/archives/C0B15M28A4V/p1777986210172519