### PR TITLE
[BD-105] fix: Google 로그인 FedCM AbortError 버그 수정

### DIFF
--- a/src/domain/auth/oauth/google.ts
+++ b/src/domain/auth/oauth/google.ts
@@ -78,17 +78,29 @@ export async function requestGoogleIdToken(): Promise<string> {
         pendingResolver = null;
         pendingRejecter = null;
         const reason = notification.getNotDisplayedReason();
+        // opt_out_or_no_session: 브라우저에 구글 계정 로그인 없음
+        const isNoSession = reason === 'opt_out_or_no_session' || reason === 'suppressed_by_user';
         reject(
           new Error(
-            `Google 로그인 창을 표시할 수 없습니다 (${reason}). 브라우저의 third-party cookie 차단 또는 시크릿 모드를 확인해주세요.`,
+            isNoSession
+              ? 'Chrome에 구글 계정이 로그인되어 있지 않습니다. 브라우저에 구글 계정을 추가한 후 다시 시도해주세요.'
+              : `Google 로그인 창을 표시할 수 없습니다 (${reason}).`,
           ),
         );
       } else if (notification.isSkippedMoment()) {
         pendingResolver = null;
         pendingRejecter = null;
         reject(new Error('Google 로그인이 취소되었습니다.'));
+      } else if (notification.isDismissedMoment()) {
+        // FedCM abort 포함 — credential callback 없이 닫힌 경우
+        const reason = notification.getDismissedReason();
+        if (reason !== 'credential_returned') {
+          pendingResolver = null;
+          pendingRejecter = null;
+          reject(new Error('Google 로그인이 취소되었습니다.'));
+        }
+        // credential_returned 는 callback 에서 처리됨.
       }
-      // dismissed/displayed 는 callback 에서 처리됨.
     });
   });
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-105](https://sunwoo1137.atlassian.net/browse/BD-105)

📌 **작업 내용 및 특이사항**

- `prompt()` 알림 콜백에서 `isDismissedMoment()` 케이스 누락으로 FedCM abort 시 Promise가 영구 pending → 로그인 버튼 먹통 버그 수정
- 브라우저에 구글 계정 미로그인 시(`opt_out_or_no_session`) 사용자 친화적 에러 메시지 표시 개선

📚 **참고사항**

- 프로덕션 정상 로그인 흐름(`credential_returned`)은 영향 없음

[BD-105]: https://sunwoo1137.atlassian.net/browse/BD-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ