### PR TITLE
[BD-64] feat: 공연 생성 위저드 Step2 셋리스트 피커로 교체

### DIFF
--- a/.taskmaster/state.json
+++ b/.taskmaster/state.json
@@ -1,6 +1,6 @@
 {
-  "currentTag": "BD-66-member-availability-timetable",
-  "lastSwitched": "2026-06-05T15:28:19.343Z",
+  "currentTag": "BD-64-create-performance-ui",
+  "lastSwitched": "2026-06-09T21:24:45.500Z",
   "branchTagMapping": {},
   "migrationNoticeShown": true
 }

--- a/.taskmaster/tasks/task_001_BD-64-create-performance-ui.md
+++ b/.taskmaster/tasks/task_001_BD-64-create-performance-ui.md
@@ -1,0 +1,65 @@
+# Task ID: 1
+
+**Title:** 공연 생성 위저드 Step2 셋리스트 피커 교체
+
+**Status:** in-progress
+
+**Dependencies:** None
+
+**Priority:** high
+
+**Description:** PerformanceCreateWizard의 Step2 '참여 밴드'를 '셋리스트' 단계로 교체. SetlistPickerModal 신규 구현, CreatePerformanceRequest에 setlistMeetingIds 필드 추가, 위저드 submit 로직 업데이트.
+
+**Details:**
+
+No details provided.
+
+**Test Strategy:**
+
+No test strategy provided.
+
+## Subtasks
+
+### 1.1. CreatePerformanceRequest 타입 및 스키마에 setlistMeetingIds 필드 추가
+
+**Status:** pending  
+**Dependencies:** None  
+
+CreatePerformanceRequest 타입에서 bandIds 필드를 setlistMeetingIds로 교체하고, createPerformanceSchema zod 스키마 업데이트
+
+**Details:**
+
+src/domain/performance/types/req.ts에서 CreatePerformanceRequest 인터페이스의 bandIds?: string[] 필드를 setlistMeetingIds?: string[]로 변경. src/domain/performance/types/schema.ts의 createPerformanceSchema에서 해당 필드 검증 로직 업데이트. 백엔드 API 스펙과 필드명 일치 확인 필요.
+
+### 1.2. SetlistPickerModal 컴포넌트 신규 구현
+
+**Status:** pending  
+**Dependencies:** 1.1  
+
+EntityPickerModal 패턴 기반으로 셋리스트 미팅 선택용 SetlistPickerModal.client.tsx 구현
+
+**Details:**
+
+src/domain/setlist-meeting/components/SetlistPickerModal.client.tsx 생성. BandPickerModal 패턴 참조하여 EntityPickerModal<SetlistMeetingResponse> 래핑. fetcher로 getMySetlistMeetings API 활용(keyword 검색 지원 여부 확인 후 필터링 로직 결정). multiple={true} 다중 선택 지원. renderItem에서 미팅 제목, 밴드명, purpose 표시. 선택 상태 UI는 Chip 형태로 표현.
+
+### 1.3. PerformanceCreateWizard Step1을 셋리스트 피커로 교체
+
+**Status:** pending  
+**Dependencies:** 1.2  
+
+위저드의 Step1 '참여 밴드' UI를 '셋리스트' 단계로 전환, BandPickerModal 대신 SetlistPickerModal 사용
+
+**Details:**
+
+PerformanceCreateWizard.client.tsx에서 selectedBands 상태를 selectedSetlistMeetings: SetlistMeetingResponse[]로 변경. Step1 라벨 '참여 밴드' → '셋리스트'로 수정. BandPickerModal import 제거, SetlistPickerModal로 교체. 선택된 셋리스트 Chip 렌더링 로직 업데이트(미팅 제목+밴드명 표시). Step1 → Step2 이동 시 별도 검증 없음(선택 optional 유지).
+
+### 1.4. 위저드 submit 로직 및 Review 단계 업데이트
+
+**Status:** pending  
+**Dependencies:** 1.1, 1.3  
+
+공연 생성 mutation 호출 시 setlistMeetingIds 전달, Step2 검토 화면에 셋리스트 요약 표시
+
+**Details:**
+
+handleSubmit 함수에서 mutationRequest 객체의 bandIds를 setlistMeetingIds로 변경(selectedSetlistMeetings에서 meetingId 추출). WizardSummaryCard에 셋리스트 필드 추가(label: '셋리스트', value: 선택된 미팅 제목 나열 또는 개수 표시, onEdit: setStep(1)). useCreatePerformance 훅이 새 필드 전달하도록 확인. 최종 API 호출 전 데이터 구조 로깅으로 검증.

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -5364,7 +5364,7 @@
   "BD-66-member-availability-timetable": {
     "tasks": [
       {
-        "id": "1",
+        "id": 1,
         "title": "마이페이지 주간 타임테이블 UI 구현 (BD-66)",
         "description": "마이페이지 프로필 정보 하단에 주간 타임테이블 섹션을 추가한다. 본인의 합주·공연 일정이 컬러 블록으로 표시되고, 불가능 시간대는 회색으로 표시된다. [나의 스케줄 관리] 버튼으로 가능 시간대를 설정하는 2단계 모달을 제공한다. API: GET/PUT /api/v1/me/availability, GET /api/v1/practices/me, GET /api/v1/performances/me",
         "details": "",
@@ -5453,7 +5453,7 @@
         "updatedAt": "2026-06-05T15:24:03.521Z"
       },
       {
-        "id": "2",
+        "id": 2,
         "title": "마이페이지 주간 타임테이블 UI 수정",
         "description": "WeeklyTimetable 상단 여백 60px, 시간 레이블 그리드 라인 정렬, PC 세로 스크롤, ScheduleManagerModal 스크롤 처리",
         "details": "",
@@ -5513,6 +5513,86 @@
       "completedCount": 2,
       "tags": [
         "BD-66-member-availability-timetable"
+      ],
+      "created": "2026-06-09T21:24:33.429Z",
+      "description": "Tasks for BD-66-member-availability-timetable context",
+      "updated": "2026-06-09T21:24:33.429Z"
+    }
+  },
+  "BD-64-create-performance-ui": {
+    "tasks": [
+      {
+        "id": "1",
+        "title": "공연 생성 위저드 Step2 셋리스트 피커 교체",
+        "description": "PerformanceCreateWizard의 Step2 '참여 밴드'를 '셋리스트' 단계로 교체. SetlistPickerModal 신규 구현, CreatePerformanceRequest에 setlistMeetingIds 필드 추가, 위저드 submit 로직 업데이트.",
+        "details": "",
+        "testStrategy": "",
+        "status": "done",
+        "dependencies": [],
+        "priority": "high",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "CreatePerformanceRequest 타입 및 스키마에 setlistMeetingIds 필드 추가",
+            "description": "CreatePerformanceRequest 타입에서 bandIds 필드를 setlistMeetingIds로 교체하고, createPerformanceSchema zod 스키마 업데이트",
+            "dependencies": [],
+            "details": "src/domain/performance/types/req.ts에서 CreatePerformanceRequest 인터페이스의 bandIds?: string[] 필드를 setlistMeetingIds?: string[]로 변경. src/domain/performance/types/schema.ts의 createPerformanceSchema에서 해당 필드 검증 로직 업데이트. 백엔드 API 스펙과 필드명 일치 확인 필요.",
+            "status": "done",
+            "testStrategy": "타입 체크(pnpm typecheck) 통과 확인, 기존 bandIds 참조 코드 컴파일 에러 발생 시 연쇄 수정 필요",
+            "parentId": "undefined",
+            "updatedAt": "2026-06-09T21:27:19.377Z"
+          },
+          {
+            "id": 2,
+            "title": "SetlistPickerModal 컴포넌트 신규 구현",
+            "description": "EntityPickerModal 패턴 기반으로 셋리스트 미팅 선택용 SetlistPickerModal.client.tsx 구현",
+            "dependencies": [
+              1
+            ],
+            "details": "src/domain/setlist-meeting/components/SetlistPickerModal.client.tsx 생성. BandPickerModal 패턴 참조하여 EntityPickerModal<SetlistMeetingResponse> 래핑. fetcher로 getMySetlistMeetings API 활용(keyword 검색 지원 여부 확인 후 필터링 로직 결정). multiple={true} 다중 선택 지원. renderItem에서 미팅 제목, 밴드명, purpose 표시. 선택 상태 UI는 Chip 형태로 표현.",
+            "status": "done",
+            "testStrategy": "Storybook 또는 단독 렌더링 테스트로 모달 열기/닫기, 검색, 선택/해제 동작 확인",
+            "parentId": "undefined",
+            "updatedAt": "2026-06-09T21:28:30.826Z"
+          },
+          {
+            "id": 3,
+            "title": "PerformanceCreateWizard Step1을 셋리스트 피커로 교체",
+            "description": "위저드의 Step1 '참여 밴드' UI를 '셋리스트' 단계로 전환, BandPickerModal 대신 SetlistPickerModal 사용",
+            "dependencies": [
+              2
+            ],
+            "details": "PerformanceCreateWizard.client.tsx에서 selectedBands 상태를 selectedSetlistMeetings: SetlistMeetingResponse[]로 변경. Step1 라벨 '참여 밴드' → '셋리스트'로 수정. BandPickerModal import 제거, SetlistPickerModal로 교체. 선택된 셋리스트 Chip 렌더링 로직 업데이트(미팅 제목+밴드명 표시). Step1 → Step2 이동 시 별도 검증 없음(선택 optional 유지).",
+            "status": "done",
+            "testStrategy": "위저드 Step1 진입 시 셋리스트 피커 모달 정상 동작 확인, 선택/해제 후 Chip UI 반영 테스트",
+            "parentId": "undefined",
+            "updatedAt": "2026-06-09T21:30:00.635Z"
+          },
+          {
+            "id": 4,
+            "title": "위저드 submit 로직 및 Review 단계 업데이트",
+            "description": "공연 생성 mutation 호출 시 setlistMeetingIds 전달, Step2 검토 화면에 셋리스트 요약 표시",
+            "dependencies": [
+              1,
+              3
+            ],
+            "details": "handleSubmit 함수에서 mutationRequest 객체의 bandIds를 setlistMeetingIds로 변경(selectedSetlistMeetings에서 meetingId 추출). WizardSummaryCard에 셋리스트 필드 추가(label: '셋리스트', value: 선택된 미팅 제목 나열 또는 개수 표시, onEdit: setStep(1)). useCreatePerformance 훅이 새 필드 전달하도록 확인. 최종 API 호출 전 데이터 구조 로깅으로 검증.",
+            "status": "done",
+            "testStrategy": "공연 생성 전체 플로우 E2E 테스트: Step0 → Step1(셋리스트 선택) → Step2(검토) → Submit 성공 확인. Network 탭에서 setlistMeetingIds 포함 여부 검증",
+            "parentId": "undefined",
+            "updatedAt": "2026-06-09T21:30:01.949Z"
+          }
+        ],
+        "updatedAt": "2026-06-09T21:30:01.949Z"
+      }
+    ],
+    "metadata": {
+      "version": "1.0.0",
+      "lastModified": "2026-06-09T21:30:01.949Z",
+      "taskCount": 1,
+      "completedCount": 1,
+      "tags": [
+        "BD-64-create-performance-ui"
       ]
     }
   }

--- a/src/app/(main)/performances/new/PerformanceCreateWizard.client.tsx
+++ b/src/app/(main)/performances/new/PerformanceCreateWizard.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarDays, Plus, X } from 'lucide-react';
+import { CalendarDays, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -9,14 +9,14 @@ import { DateTimePicker } from '@/components/ui/date-time-picker';
 import { Input } from '@/components/ui/input';
 import { StepIndicator } from '@/components/ui/step-indicator';
 import { WizardSummaryCard } from '@/components/ui/wizard-summary-card';
-import { BandPickerModal } from '@/domain/band/components/BandPickerModal.client';
-import type { BandInfoResponse } from '@/domain/band/types';
+import { SetlistPickerModal } from '@/domain/setlist-meeting/components/SetlistPickerModal.client';
+import type { Meeting } from '@/domain/setlist-meeting/types';
 import { useCreatePerformance } from '@/domain/performance/hooks/useCreatePerformance';
 import { ROUTES } from '@/global/config/routes';
 import { useRegisterDirtyForm } from '@/global/navigation/dirty-form-context';
 import { useToast } from '@/hooks/useToast';
 
-const STEPS = ['기본 정보', '참여 밴드', '검토'] as const;
+const STEPS = ['기본 정보', '셋리스트', '검토'] as const;
 
 export function PerformanceCreateWizard() {
   const router = useRouter();
@@ -31,10 +31,10 @@ export function PerformanceCreateWizard() {
 
   // Step 2
   const [pickerOpen, setPickerOpen] = useState(false);
-  const [selectedBands, setSelectedBands] = useState<BandInfoResponse[]>([]);
+  const [selectedMeetings, setSelectedMeetings] = useState<Meeting[]>([]);
 
   const dirty =
-    step > 0 || title.length > 0 || venue.length > 0 || !!startAt || selectedBands.length > 0;
+    step > 0 || title.length > 0 || venue.length > 0 || !!startAt || selectedMeetings.length > 0;
   useRegisterDirtyForm('performance-create-wizard', dirty);
 
   const mutation = useCreatePerformance({
@@ -62,8 +62,7 @@ export function PerformanceCreateWizard() {
     if (!title || !startAt) return;
     mutation.mutate({
       title,
-      // 백엔드는 bandIds null/missing 시 400 (mvp-1-fix-v3 Task 8 검증). 항상 배열 전송.
-      bandIds: selectedBands.map((b) => b.bandId),
+      setlistMeetingIds: selectedMeetings.map((m) => m.id),
       startAt,
       durationMinutes,
       venue: venue || undefined,
@@ -124,27 +123,25 @@ export function PerformanceCreateWizard() {
 
       {/* Step 2 */}
       {step === 1 && (
-        <section data-slot="wizard-step-bands" className="space-y-s-4">
-          <h2 className="text-subtitle font-semibold">참여 밴드를 추가하세요 (선택)</h2>
-          {selectedBands.length === 0 ? (
+        <section data-slot="wizard-step-setlists" className="space-y-s-4">
+          <h2 className="text-subtitle font-semibold">셋리스트를 추가하세요 (선택)</h2>
+          {selectedMeetings.length === 0 ? (
             <p className="text-foreground-muted text-caption">
-              추가하지 않으면 빈 배열로 전송됩니다. 공연 생성 후 상세 화면에서 추가할 수 있습니다.
+              추가하지 않으면 셋리스트 없이 공연이 생성됩니다.
             </p>
           ) : (
             <ul className="gap-s-2 flex flex-wrap">
-              {selectedBands.map((b) => (
+              {selectedMeetings.map((m) => (
                 <li
-                  key={b.bandId}
+                  key={m.id}
                   className="bg-card border-border gap-s-2 px-s-3 py-s-1 inline-flex items-center rounded-full border"
                 >
-                  <span className="text-caption">{b.bandName}</span>
+                  <span className="text-caption">{m.title}</span>
                   <button
                     type="button"
-                    aria-label={`${b.bandName} 제거`}
+                    aria-label={`${m.title} 제거`}
                     className="text-foreground-muted hover:text-foreground"
-                    onClick={() =>
-                      setSelectedBands((prev) => prev.filter((x) => x.bandId !== b.bandId))
-                    }
+                    onClick={() => setSelectedMeetings((prev) => prev.filter((x) => x.id !== m.id))}
                   >
                     <X className="h-3 w-3" />
                   </button>
@@ -158,7 +155,7 @@ export function PerformanceCreateWizard() {
             onClick={() => setPickerOpen(true)}
             className="w-full"
           >
-            <Plus className="h-4 w-4" /> 밴드 검색해서 추가
+            셋리스트 검색해서 추가
           </Button>
         </section>
       )}
@@ -189,11 +186,11 @@ export function PerformanceCreateWizard() {
                 onEdit: () => setStep(0),
               },
               {
-                label: '참여 밴드',
+                label: '셋리스트',
                 value:
-                  selectedBands.length === 0
+                  selectedMeetings.length === 0
                     ? '없음'
-                    : selectedBands.map((b) => b.bandName).join(', '),
+                    : selectedMeetings.map((m) => m.title).join(', '),
                 onEdit: () => setStep(1),
               },
             ]}
@@ -217,13 +214,11 @@ export function PerformanceCreateWizard() {
         )}
       </footer>
 
-      <BandPickerModal
+      <SetlistPickerModal
         open={pickerOpen}
         onOpenChange={setPickerOpen}
-        multiple
-        initialSelection={selectedBands}
-        onConfirm={(bands) => setSelectedBands(bands)}
-        title="참여 밴드 추가"
+        initialSelection={selectedMeetings}
+        onConfirm={(meetings) => setSelectedMeetings(meetings)}
       />
     </div>
   );

--- a/src/domain/performance/types/req.ts
+++ b/src/domain/performance/types/req.ts
@@ -1,6 +1,7 @@
 export interface CreatePerformanceRequest {
   title: string;
   bandIds?: string[];
+  setlistMeetingIds?: string[];
   startAt: string;
   durationMinutes: number;
   venue?: string;

--- a/src/domain/setlist-meeting/components/SetlistPickerModal.client.tsx
+++ b/src/domain/setlist-meeting/components/SetlistPickerModal.client.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { ListMusic, Search } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetContent,
+  ResponsiveSheetFooter,
+  ResponsiveSheetHeader,
+  ResponsiveSheetTitle,
+} from '@/components/ui/responsive-sheet';
+
+import { useSetlistStore } from '../store/setlistStore';
+import type { Meeting } from '../types';
+
+export interface SetlistPickerModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialSelection?: Meeting[];
+  onConfirm: (meetings: Meeting[]) => void;
+}
+
+export function SetlistPickerModal({
+  open,
+  onOpenChange,
+  initialSelection = [],
+  onConfirm,
+}: SetlistPickerModalProps) {
+  const meetings = useSetlistStore((s) => s.meetings);
+  const songs = useSetlistStore((s) => s.songs);
+
+  const [query, setQuery] = useState('');
+  const [selection, setSelection] = useState<Meeting[]>(initialSelection);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setSelection(initialSelection);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const filtered =
+    query.trim() === ''
+      ? meetings
+      : meetings.filter((m) => m.title.includes(query.trim()) || m.bandName.includes(query.trim()));
+
+  function songCount(meetingId: string) {
+    return songs.filter((s) => s.meetingId === meetingId).length;
+  }
+
+  function confirmedCount(meetingId: string) {
+    const meetingSongs = songs.filter((s) => s.meetingId === meetingId);
+    return meetingSongs.filter((song) =>
+      song.sessions.every((sess) => (song.confirmed[sess.id]?.length ?? 0) >= sess.need),
+    ).length;
+  }
+
+  function toggle(m: Meeting) {
+    setSelection((prev) =>
+      prev.some((p) => p.id === m.id) ? prev.filter((p) => p.id !== m.id) : [...prev, m],
+    );
+  }
+
+  function confirm() {
+    onConfirm(selection);
+    onOpenChange(false);
+  }
+
+  return (
+    <ResponsiveSheet open={open} onOpenChange={onOpenChange}>
+      <ResponsiveSheetContent>
+        <ResponsiveSheetHeader>
+          <ResponsiveSheetTitle>셋리스트 추가</ResponsiveSheetTitle>
+        </ResponsiveSheetHeader>
+
+        <ResponsiveSheetBody>
+          <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 mb-s-3 flex items-center rounded-md border">
+            <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
+            <input
+              autoFocus
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="셋리스트 또는 밴드명으로 검색…"
+              className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+              aria-label="셋리스트 검색"
+            />
+          </div>
+
+          <ul className="gap-s-2 flex max-h-[420px] flex-col overflow-y-auto">
+            {filtered.length === 0 ? (
+              <li className="text-foreground-muted p-s-4 text-caption">검색 결과가 없습니다.</li>
+            ) : (
+              filtered.map((m) => {
+                const total = songCount(m.id);
+                const confirmed = confirmedCount(m.id);
+                const sel = selection.some((p) => p.id === m.id);
+                const progress = total > 0 ? confirmed / total : 0;
+                const date = (m.updatedAt ?? m.createdAt).slice(0, 10);
+
+                return (
+                  <li key={m.id}>
+                    <button
+                      type="button"
+                      onClick={() => toggle(m)}
+                      aria-pressed={sel}
+                      className="w-full text-left"
+                    >
+                      <div
+                        className={
+                          'border-border bg-card hover:bg-card-hover gap-s-3 px-s-4 py-s-3 flex items-start rounded-md border transition-colors ' +
+                          (sel ? 'border-accent bg-accent-dim' : '')
+                        }
+                      >
+                        <span className="bg-accent-dim text-accent mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md">
+                          <ListMusic className="h-4 w-4" aria-hidden="true" />
+                        </span>
+
+                        <div className="min-w-0 flex-1 space-y-1">
+                          <p className="text-foreground-muted text-caption truncate font-medium">
+                            {m.bandName}
+                          </p>
+                          <p className="text-body truncate font-semibold">{m.title}</p>
+
+                          <div className="gap-s-2 flex items-center">
+                            <div
+                              className="bg-surface flex-1 overflow-hidden rounded-full"
+                              style={{ height: 4 }}
+                            >
+                              <div
+                                className="bg-accent h-full rounded-full transition-all"
+                                style={{ width: `${progress * 100}%` }}
+                              />
+                            </div>
+                            <span
+                              className="text-foreground-muted shrink-0 tabular-nums"
+                              style={{ fontSize: 11 }}
+                            >
+                              {confirmed}/{total}
+                            </span>
+                          </div>
+
+                          <p className="text-foreground-muted" style={{ fontSize: 11 }}>
+                            {date}
+                          </p>
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </ResponsiveSheetBody>
+
+        <ResponsiveSheetFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button onClick={confirm} disabled={selection.length === 0}>
+            선택 ({selection.length})
+          </Button>
+        </ResponsiveSheetFooter>
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-64](https://sunwoo1137.atlassian.net/browse/BD-64)

📌 **작업 내용 및 특이사항**

- **`CreatePerformanceRequest`에 `setlistMeetingIds?: string[]` 필드 추가**
  - 기존 `bandIds` 는 유지, `setlistMeetingIds` 를 별도 필드로 분리
- **`SetlistPickerModal` 신규 구현** (`src/domain/setlist-meeting/components/SetlistPickerModal.client.tsx`)
  - Zustand `setlistStore` 기반 클라이언트 사이드 필터 (API 호출 없음)
  - 카드 UI: 밴드명 · 셋리스트 제목 · 확정곡/전체 진행 바 · 날짜
  - 모달 오픈 시 전체 목록 즉시 표시, 제목/밴드명 타이핑으로 실시간 필터
  - 다중 선택 지원, 선택 수 실시간 표시
- **`PerformanceCreateWizard` Step2 교체**
  - `참여 밴드` → `셋리스트` 단계로 변경
  - 선택된 미팅 ID를 `setlistMeetingIds`로 submit
  - Step3 검토 섹션 레이블 업데이트 (`참여 밴드` → `셋리스트`)

📚 **참고사항**

- 셋리스트 데이터는 현재 Zustand mock(sessionStorage persist) 기반 — 백엔드 API 연동 시 `fetcher` 교체 필요
- 진행 바 기준: 모든 세션이 `need` 수 이상 확정된 곡 수 / 전체 곡 수

[BD-64]: https://sunwoo1137.atlassian.net/browse/BD-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ