### PR TITLE
[BD-108] chore: GitHub Actions Git LFS 활성화

### DIFF
--- a/.github/workflows/develop_ci_test.yml
+++ b/.github/workflows/develop_ci_test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup pnpm
         # 버전은 package.json 의 "packageManager" 필드(해시 pin) 를 단일 소스로 사용.

--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Configure AWS Credentials
         # ECR 한정 권한을 가진 IAM 사용자 키 — S3 / 기타 권한과 분리되어 있다.


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-108](https://sunwoo1137.atlassian.net/browse/BD-108)

📌 **작업 내용 및 특이사항**

- `develop_deploy.yml`, `develop_ci_test.yml` 의 `actions/checkout` 스텝에 `lfs: true` 추가
- 배포 시 `.glb` 3D 모델 파일이 Git LFS에서 정상적으로 fetch되어 Docker 빌드 컨텍스트에 포함됨
- 미적용 시 LFS 포인터 파일만 복사되어 모델 로드 실패 → `ModelErrorBoundary` fallback(플레이스홀더) 표시되는 문제 해결

📚 **참고사항**

- BD-89 보딩 페이지에서 추가된 `guitarist.glb`, `pianist.glb`, `drummer.glb`, `vocal.glb` (총 312MB) 가 대상
- CI 테스트 워크플로우도 동일하게 적용 (빌드 검증 일관성)

[BD-108]: https://sunwoo1137.atlassian.net/browse/BD-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ