### PR TITLE
[BD-107] fix: 로그인·회원가입 UI 개선

### DIFF
--- a/src/app/(auth)/join/JoinForm.client.tsx
+++ b/src/app/(auth)/join/JoinForm.client.tsx
@@ -54,7 +54,7 @@ export function JoinForm() {
       <Input
         label="이름"
         autoComplete="name"
-        placeholder="홍길동"
+        placeholder="이름을 입력하세요"
         required
         error={form.formState.errors.name?.message}
         className={INPUT_CLASS}

--- a/src/app/(auth)/join/JoinForm.client.tsx
+++ b/src/app/(auth)/join/JoinForm.client.tsx
@@ -2,26 +2,23 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { PasswordStrength } from '@/components/ui/password-strength';
-import { StepIndicator } from '@/components/ui/step-indicator';
 import { useLogin } from '@/domain/auth/hooks/useLogin';
 import { useJoin } from '@/domain/member/hooks/useJoin';
 import { joinSchema, type JoinSchema } from '@/domain/member/types';
 import { ROUTES } from '@/global/config/routes';
-import { formatPhone } from '@/lib/phone';
 import { useToast } from '@/hooks/useToast';
 
-const STEPS = ['기본 정보', '계정 설정'] as const;
+const INPUT_CLASS =
+  'rounded-[5px] border-white/20 hover:border-white/35 focus-visible:ring-0 focus-visible:border-white/70 not-placeholder-shown:border-white/70';
 
 export function JoinForm() {
   const router = useRouter();
   const toast = useToast();
-  const [step, setStep] = useState<0 | 1>(0);
 
   const loginMutation = useLogin({
     onSuccess: () => router.replace(ROUTES.HOME),
@@ -33,8 +30,8 @@ export function JoinForm() {
 
   const form = useForm<JoinSchema>({
     resolver: zodResolver(joinSchema),
-    defaultValues: { email: '', password: '', name: '', contact: '' },
-    mode: 'onTouched',
+    defaultValues: { email: '', password: '', confirmPassword: '', name: '' },
+    mode: 'onChange',
   });
 
   const joinMutation = useJoin({
@@ -48,85 +45,57 @@ export function JoinForm() {
 
   const isPending = joinMutation.isPending || loginMutation.isPending;
 
-  async function goNext() {
-    const valid = await form.trigger(['name', 'contact']);
-    if (valid) setStep(1);
-  }
-
   return (
     <form
       className="space-y-s-4"
       onSubmit={form.handleSubmit((values) => joinMutation.mutate(values))}
       noValidate
     >
-      <StepIndicator steps={STEPS} current={step} />
-
-      {step === 0 && (
-        <>
-          <Input
-            label="이름"
-            autoComplete="name"
-            placeholder="홍길동"
-            required
-            error={form.formState.errors.name?.message}
-            {...form.register('name')}
-          />
-          <Input
-            label="연락처"
-            autoComplete="tel"
-            placeholder="010-1234-5678"
-            required
-            error={form.formState.errors.contact?.message}
-            {...form.register('contact')}
-            onChange={(e) => {
-              const formatted = formatPhone(e.target.value);
-              e.target.value = formatted;
-              void form.register('contact').onChange(e);
-            }}
-          />
-          <Button type="button" className="w-full" onClick={goNext} disabled={isPending}>
-            다음
-          </Button>
-        </>
-      )}
-
-      {step === 1 && (
-        <>
-          <Input
-            label="이메일"
-            type="email"
-            autoComplete="email"
-            placeholder="you@bandage.com"
-            required
-            error={form.formState.errors.email?.message}
-            {...form.register('email')}
-          />
-          <Input
-            label="비밀번호"
-            type="password"
-            autoComplete="new-password"
-            placeholder="8자 이상"
-            required
-            error={form.formState.errors.password?.message}
-            {...form.register('password')}
-          />
-          <PasswordStrength password={form.watch('password')} />
-          <div className="gap-s-2 flex">
-            <Button
-              type="button"
-              variant="ghost"
-              className="flex-1"
-              onClick={() => setStep(0)}
-              disabled={isPending}
-            >
-              이전
-            </Button>
-            <Button type="submit" className="flex-1" loading={isPending}>
-              가입하기
-            </Button>
-          </div>
-        </>
-      )}
+      <Input
+        label="이름"
+        autoComplete="name"
+        placeholder="홍길동"
+        required
+        error={form.formState.errors.name?.message}
+        className={INPUT_CLASS}
+        {...form.register('name')}
+      />
+      <Input
+        label="이메일"
+        type="email"
+        autoComplete="email"
+        placeholder="you@bandage.com"
+        required
+        error={form.formState.errors.email?.message}
+        className={INPUT_CLASS}
+        {...form.register('email')}
+      />
+      <div className="space-y-2">
+        <Input
+          label="비밀번호"
+          type="password"
+          autoComplete="new-password"
+          placeholder="비밀번호를 입력하세요"
+          required
+          error={form.formState.errors.password?.message}
+          className={INPUT_CLASS}
+          {...form.register('password')}
+        />
+        <PasswordStrength password={form.watch('password')} />
+      </div>
+      <Input
+        label="비밀번호 확인"
+        type="password"
+        autoComplete="new-password"
+        placeholder="비밀번호를 재입력해주세요"
+        required
+        error={form.formState.errors.confirmPassword?.message}
+        className={INPUT_CLASS}
+        {...form.register('confirmPassword')}
+      />
+      <Button type="submit" className="w-full rounded-[5px] font-bold" loading={isPending}>
+        가입하기
+      </Button>
     </form>
   );
 }

--- a/src/app/(auth)/join/page.tsx
+++ b/src/app/(auth)/join/page.tsx
@@ -14,12 +14,15 @@ export default function JoinPage() {
     <div className="space-y-8">
       <header className="space-y-1 text-center">
         <h1 className="text-foreground text-2xl font-bold">회원가입</h1>
-        <p className="text-foreground-sub text-sm">이메일과 기본 정보로 Bandage 계정을 만듭니다.</p>
+        <p className="text-foreground-muted text-sm">Bandage 계정을 생성합니다</p>
       </header>
       <JoinForm />
       <p className="text-foreground-sub text-center text-sm">
         이미 계정이 있으신가요?{' '}
-        <Link href={ROUTES.LOGIN} className="text-accent-hi font-medium hover:underline">
+        <Link
+          href={ROUTES.LOGIN}
+          className="cursor-pointer font-medium text-white hover:no-underline"
+        >
           로그인
         </Link>
       </p>

--- a/src/app/(auth)/login/LoginForm.client.tsx
+++ b/src/app/(auth)/login/LoginForm.client.tsx
@@ -18,6 +18,8 @@ export function LoginForm() {
   const form = useForm<LoginSchema>({
     resolver: zodResolver(loginSchema),
     defaultValues: { email: '', password: '' },
+    mode: 'onTouched',
+    reValidateMode: 'onChange',
   });
 
   const mutation = useLogin({
@@ -40,6 +42,7 @@ export function LoginForm() {
         autoComplete="email"
         placeholder="you@bandage.com"
         error={form.formState.errors.email?.message}
+        className="rounded-[5px] border-white/20 not-placeholder-shown:border-white/70 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
         {...form.register('email')}
       />
       <Input
@@ -48,9 +51,10 @@ export function LoginForm() {
         autoComplete="current-password"
         placeholder="8자 이상"
         error={form.formState.errors.password?.message}
+        className="rounded-[5px] border-white/20 not-placeholder-shown:border-white/70 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
         {...form.register('password')}
       />
-      <Button type="submit" className="w-full" loading={mutation.isPending}>
+      <Button type="submit" className="w-full rounded-[5px] font-bold" loading={mutation.isPending}>
         로그인
       </Button>
     </form>

--- a/src/app/(auth)/login/OAuthSection.client.tsx
+++ b/src/app/(auth)/login/OAuthSection.client.tsx
@@ -79,7 +79,12 @@ export function OAuthSection() {
         <OAuthButton provider="kakao" onClick={handleKakao} disabled={busy} />
         <OAuthButton provider="apple" onClick={notReady} disabled={busy} />
       */}
-      <OAuthButton provider="google" onClick={handleGoogle} disabled={busy} />
+      <OAuthButton
+        provider="google"
+        onClick={handleGoogle}
+        disabled={busy}
+        className="rounded-[5px]"
+      />
     </section>
   );
 }

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -15,7 +15,7 @@ export default function RootPage() {
     <div className="space-y-s-6">
       <header className="space-y-1 text-center">
         <h1 className="text-foreground text-2xl font-bold">로그인</h1>
-        <p className="text-foreground-sub text-sm">Bandage 계정으로 로그인하세요.</p>
+        <p className="text-foreground-muted text-sm">밴드 합주 관리를 간편하게 시작하세요</p>
       </header>
       <LoginForm />
       <div className="gap-s-3 flex items-center" aria-hidden="true">
@@ -26,7 +26,10 @@ export default function RootPage() {
       <OAuthSection />
       <p className="text-foreground-sub text-center text-sm">
         아직 계정이 없으신가요?{' '}
-        <Link href={ROUTES.JOIN} className="text-accent-hi font-medium hover:underline">
+        <Link
+          href={ROUTES.JOIN}
+          className="cursor-pointer font-medium text-white hover:no-underline"
+        >
           회원가입
         </Link>
       </p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,11 +19,12 @@
   /* Nav active */
   --color-nav-active: #ceced6;
 
-  /* Accent - Blue */
-  --color-accent: oklch(0.62 0.22 250);
-  --color-accent-dim: oklch(0.62 0.22 250 / 0.14);
-  --color-accent-soft: oklch(0.62 0.22 250 / 0.08);
-  --color-accent-hi: oklch(0.72 0.2 250);
+  /* Accent — 브랜드 컬러 #e27363 (oklch 변환) */
+  --color-brand: #e27363;
+  --color-accent: oklch(0.68 0.15 29);
+  --color-accent-dim: oklch(0.68 0.15 29 / 0.14);
+  --color-accent-soft: oklch(0.68 0.15 29 / 0.08);
+  --color-accent-hi: oklch(0.74 0.13 29);
 
   /* Semantic */
   --color-success: oklch(0.7 0.18 155);
@@ -136,6 +137,15 @@
     }
   }
 
+  @keyframes sheet-in {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+
   @keyframes shimmer {
     0% {
       background-position: -400px 0;
@@ -167,6 +177,14 @@
 
   a:hover {
     text-decoration: underline;
+  }
+
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus {
+    -webkit-box-shadow: 0 0 0px 1000px #161620 inset !important;
+    -webkit-text-fill-color: #f4f4f8 !important;
+    transition: background-color 5000s ease-in-out 0s;
   }
 
   button {

--- a/src/components/layout/auth-split.tsx
+++ b/src/components/layout/auth-split.tsx
@@ -41,7 +41,7 @@ export function AuthSplit({ children }: { children: ReactNode }) {
 
       <ResponsiveSheet open={open} onOpenChange={setOpen}>
         <ResponsiveSheetContent
-          className="max-h-[92vh] border-white/20"
+          className="max-h-[92vh] border-white/20 lg:max-h-none"
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <ResponsiveSheetTitle className="sr-only">로그인</ResponsiveSheetTitle>

--- a/src/components/layout/auth-split.tsx
+++ b/src/components/layout/auth-split.tsx
@@ -2,27 +2,27 @@
 
 import { useState, type ReactNode } from 'react';
 
+import { useRouter } from 'next/navigation';
+
 import { Button } from '@/components/ui/button';
 import {
-  BottomSheet,
-  BottomSheetBody,
-  BottomSheetContent,
-  BottomSheetTitle,
-} from '@/components/ui/bottom-sheet';
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetContent,
+  ResponsiveSheetTitle,
+} from '@/components/ui/responsive-sheet';
+import { ROUTES } from '@/global/config/routes';
 
 import { HeroCinematic } from './HeroCinematic.client';
 
-/**
- * Auth 전체 shell: 3D 씬 전체화면 + 상단 로그인 버튼 오버레이 + BottomSheet 폼.
- */
 export function AuthSplit({ children }: { children: ReactNode }) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
+  const router = useRouter();
 
   return (
     <div className="relative h-screen w-full overflow-hidden" data-slot="auth-split">
       <HeroCinematic />
 
-      {/* Top bar: logo left, login button right */}
       <div className="pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center justify-between px-6 py-5">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src="/brand/bandage_wave_text_white.png" alt="Bandage" className="h-7 w-auto" />
@@ -30,18 +30,26 @@ export function AuthSplit({ children }: { children: ReactNode }) {
           variant="secondary"
           size="sm"
           className="pointer-events-auto border border-white/20 bg-white/10 text-white/90 backdrop-blur-sm hover:bg-white/20"
-          onClick={() => setOpen(true)}
+          onClick={() => {
+            router.push(ROUTES.LOGIN);
+            setOpen(true);
+          }}
         >
           로그인
         </Button>
       </div>
 
-      <BottomSheet open={open} onOpenChange={setOpen}>
-        <BottomSheetContent className="max-h-[92vh]">
-          <BottomSheetTitle className="sr-only">로그인</BottomSheetTitle>
-          <BottomSheetBody className="overflow-y-auto px-5 py-6">{children}</BottomSheetBody>
-        </BottomSheetContent>
-      </BottomSheet>
+      <ResponsiveSheet open={open} onOpenChange={setOpen}>
+        <ResponsiveSheetContent
+          className="max-h-[92vh] border-white/20"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <ResponsiveSheetTitle className="sr-only">로그인</ResponsiveSheetTitle>
+          <ResponsiveSheetBody className="overflow-y-auto px-5 py-6">
+            {children}
+          </ResponsiveSheetBody>
+        </ResponsiveSheetContent>
+      </ResponsiveSheet>
     </div>
   );
 }

--- a/src/components/layout/auth-split.tsx
+++ b/src/components/layout/auth-split.tsx
@@ -16,7 +16,7 @@ import { ROUTES } from '@/global/config/routes';
 import { HeroCinematic } from './HeroCinematic.client';
 
 export function AuthSplit({ children }: { children: ReactNode }) {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   const router = useRouter();
 
   return (

--- a/src/components/ui/__snapshots__/password-strength.test.tsx.snap
+++ b/src/components/ui/__snapshots__/password-strength.test.tsx.snap
@@ -2,36 +2,11 @@
 
 exports[`PasswordStrength > strong 레벨 렌더 스냅샷 1`] = `
 <DocumentFragment>
-  <div
-    class="-mt-s-2 mb-s-3"
+  <p
+    class="text-xs text-success"
     data-slot="password-strength"
   >
-    <div
-      aria-label="비밀번호 강도"
-      aria-valuemax="4"
-      aria-valuemin="0"
-      aria-valuenow="4"
-      class="flex gap-[3px]"
-      role="progressbar"
-    >
-      <span
-        class="h-1 flex-1 rounded-sm transition-colors duration-200 bg-success"
-      />
-      <span
-        class="h-1 flex-1 rounded-sm transition-colors duration-200 bg-success"
-      />
-      <span
-        class="h-1 flex-1 rounded-sm transition-colors duration-200 bg-success"
-      />
-      <span
-        class="h-1 flex-1 rounded-sm transition-colors duration-200 bg-success"
-      />
-    </div>
-    <p
-      class="mt-s-1 text-success"
-    >
-      강함
-    </p>
-  </div>
+    보안 강함
+  </p>
 </DocumentFragment>
 `;

--- a/src/components/ui/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet.tsx
@@ -38,7 +38,7 @@ export const BottomSheetContent = forwardRef<ElementRef<typeof Content>, BottomS
           ref={ref}
           className={cn(
             'bg-card text-foreground border-border fixed inset-x-0 bottom-0 z-50 flex max-h-[85vh] flex-col rounded-t-xl border border-b-0 shadow-lg outline-none',
-            'animate-[toast-in_var(--duration-normal)_var(--ease-default)]',
+            'animate-[sheet-in_var(--duration-normal)_var(--ease-default)]',
             className,
           )}
           {...props}

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -20,7 +20,7 @@ export function Field({ label, hint, error, required, htmlFor, className, childr
   const describedBy = error ? errorId : hint ? hintId : undefined;
 
   return (
-    <div className={cn('flex flex-col gap-1.5', className)}>
+    <div className={cn('flex flex-col gap-2.5', className)}>
       {label && (
         <label htmlFor={inputId} className="text-foreground text-sm font-medium">
           {label}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -30,8 +30,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
           aria-required={required || undefined}
           className={cn(
             baseInputClasses,
-            error ? 'border-danger' : 'border-border hover:border-border-hi',
+            'border-border hover:border-border-hi',
             className,
+            error &&
+              'border-danger hover:border-danger focus-visible:border-danger [&:not(:placeholder-shown)]:border-danger',
           )}
           {...props}
         />

--- a/src/components/ui/password-strength.test.tsx
+++ b/src/components/ui/password-strength.test.tsx
@@ -9,7 +9,6 @@ describe('evaluatePassword', () => {
   });
 
   it('짧은 영문만은 weak (1점: 대소문자만 부분 충족)', () => {
-    // 'ab' 는 8자 미만, 대문자 없음, 숫자 없음, 특수 없음 → 0점
     expect(evaluatePassword('ab')).toEqual({ score: 0, level: 'weak' });
   });
 
@@ -28,24 +27,30 @@ describe('PasswordStrength', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('빈 비밀번호는 모든 세그먼트 bg-border', () => {
+  it('빈 비밀번호는 아무것도 렌더하지 않음', () => {
     const { container } = render(<PasswordStrength password="" />);
-    const segs = container.querySelectorAll('span.h-1');
-    expect(segs.length).toBe(4);
-    segs.forEach((s) => expect(s.className).toContain('bg-border'));
+    expect(container.firstChild).toBeNull();
   });
 
-  it('strong 는 4 segments 모두 bg-success', () => {
+  it('strong 는 text-success 텍스트로 렌더', () => {
     const { container } = render(<PasswordStrength password="Abcdefg1!" />);
-    const segs = container.querySelectorAll('span.h-1');
-    expect(segs.length).toBe(4);
-    segs.forEach((s) => expect(s.className).toContain('bg-success'));
+    const el = container.querySelector('[data-slot="password-strength"]');
+    expect(el).not.toBeNull();
+    expect(el?.className).toContain('text-success');
+    expect(el?.textContent).toBe('보안 강함');
   });
 
-  it('progressbar aria 값이 score 와 일치', () => {
+  it('medium 는 text-warn 텍스트로 렌더', () => {
     const { container } = render(<PasswordStrength password="Abcdefg1" />);
-    const bar = container.querySelector('[role="progressbar"]');
-    expect(bar?.getAttribute('aria-valuenow')).toBe('3');
-    expect(bar?.getAttribute('aria-valuemax')).toBe('4');
+    const el = container.querySelector('[data-slot="password-strength"]');
+    expect(el?.className).toContain('text-warn');
+    expect(el?.textContent).toBe('보안 보통');
+  });
+
+  it('weak 는 text-danger 텍스트로 렌더', () => {
+    const { container } = render(<PasswordStrength password="abc" />);
+    const el = container.querySelector('[data-slot="password-strength"]');
+    expect(el?.className).toContain('text-danger');
+    expect(el?.textContent).toBe('보안 약함');
   });
 });

--- a/src/components/ui/password-strength.tsx
+++ b/src/components/ui/password-strength.tsx
@@ -22,56 +22,28 @@ export function evaluatePassword(pw: string): { score: number; level: PasswordSt
 }
 
 const LABEL_MAP: Record<PasswordStrengthLevel, string> = {
-  empty: '비밀번호를 입력하세요',
-  weak: '약함',
-  medium: '보통',
-  strong: '강함',
-};
-
-const SEG_COLOR: Record<PasswordStrengthLevel, string> = {
-  empty: 'bg-border',
-  weak: 'bg-danger',
-  medium: 'bg-warn',
-  strong: 'bg-success',
+  empty: '',
+  weak: '보안 약함',
+  medium: '보안 보통',
+  strong: '보안 강함',
 };
 
 const LABEL_COLOR: Record<PasswordStrengthLevel, string> = {
-  empty: 'text-foreground-muted',
+  empty: '',
   weak: 'text-danger',
   medium: 'text-warn',
   strong: 'text-success',
 };
 
-/**
- * 비밀번호 강도 4-segment 바 + 하단 힌트.
- * design/dist/css/components.css .pw-strength 규칙 미러링.
- */
 export function PasswordStrength({ password, className, onLevelChange }: PasswordStrengthProps) {
   const { score, level } = evaluatePassword(password);
   onLevelChange?.(level, score);
-  const filled = level === 'empty' ? 0 : score;
+
+  if (level === 'empty') return null;
 
   return (
-    <div className={cn('-mt-s-2 mb-s-3', className)} data-slot="password-strength">
-      <div
-        className="flex gap-[3px]"
-        role="progressbar"
-        aria-label="비밀번호 강도"
-        aria-valuemin={0}
-        aria-valuemax={4}
-        aria-valuenow={score}
-      >
-        {[0, 1, 2, 3].map((i) => (
-          <span
-            key={i}
-            className={cn(
-              'h-1 flex-1 rounded-sm transition-colors duration-200',
-              i < filled ? SEG_COLOR[level] : 'bg-border',
-            )}
-          />
-        ))}
-      </div>
-      <p className={cn('text-micro mt-s-1', LABEL_COLOR[level])}>{LABEL_MAP[level]}</p>
-    </div>
+    <p className={cn('text-xs', LABEL_COLOR[level], className)} data-slot="password-strength">
+      {LABEL_MAP[level]}
+    </p>
   );
 }

--- a/src/domain/auth/types/schema.ts
+++ b/src/domain/auth/types/schema.ts
@@ -1,23 +1,23 @@
 import { z } from 'zod';
 
 export const loginSchema = z.object({
-  email: z.string().min(1, '이메일을 입력해 주세요.').email('올바른 이메일 형식이 아닙니다.'),
-  password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.'),
+  email: z.string().min(1, '이메일을 입력해 주세요').email('올바른 이메일 형식이 아닙니다'),
+  password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다'),
 });
 export type LoginSchema = z.infer<typeof loginSchema>;
 
 export const passwordChangeSchema = z
   .object({
-    originalPassword: z.string().min(1, '현재 비밀번호를 입력해 주세요.'),
-    newPassword: z.string().min(8, '새 비밀번호는 8자 이상이어야 합니다.'),
-    confirmPassword: z.string().min(1, '새 비밀번호를 다시 입력해 주세요.'),
+    originalPassword: z.string().min(1, '현재 비밀번호를 입력해 주세요'),
+    newPassword: z.string().min(8, '새 비밀번호는 8자 이상이어야 합니다'),
+    confirmPassword: z.string().min(1, '새 비밀번호를 다시 입력해 주세요'),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {
     path: ['confirmPassword'],
-    message: '새 비밀번호가 일치하지 않습니다.',
+    message: '새 비밀번호가 일치하지 않습니다',
   })
   .refine((data) => data.originalPassword !== data.newPassword, {
     path: ['newPassword'],
-    message: '현재 비밀번호와 다른 값을 사용해 주세요.',
+    message: '현재 비밀번호와 다른 값을 사용해 주세요',
   });
 export type PasswordChangeSchema = z.infer<typeof passwordChangeSchema>;

--- a/src/domain/member/types/req.ts
+++ b/src/domain/member/types/req.ts
@@ -2,7 +2,7 @@ export interface JoinRequest {
   email: string;
   password: string;
   name: string;
-  contact: string;
+  contact?: string;
 }
 
 export interface UpdateMeRequest {

--- a/src/domain/member/types/schema.ts
+++ b/src/domain/member/types/schema.ts
@@ -2,23 +2,25 @@ import { z } from 'zod';
 
 const CONTACT_REGEX = /^01\d-\d{3,4}-\d{4}$/;
 
-export const joinSchema = z.object({
-  email: z.string().min(1, '이메일을 입력해 주세요.').email('올바른 이메일 형식이 아닙니다.'),
-  password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.'),
-  name: z.string().min(2, '이름은 2자 이상이어야 합니다.'),
-  contact: z
-    .string()
-    .min(1, '연락처를 입력해 주세요.')
-    .regex(CONTACT_REGEX, '올바른 전화번호 형식이 아닙니다.'),
-});
+export const joinSchema = z
+  .object({
+    email: z.string().min(1, '이메일을 입력해 주세요').email('올바른 이메일 형식이 아닙니다'),
+    password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다'),
+    confirmPassword: z.string().min(1, '비밀번호 확인을 입력해 주세요'),
+    name: z.string().min(2, '이름은 2자 이상이어야 합니다'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다',
+    path: ['confirmPassword'],
+  });
 export type JoinSchema = z.infer<typeof joinSchema>;
 
 export const updateMeSchema = z
   .object({
-    name: z.string().min(2, '이름은 2자 이상이어야 합니다.').optional(),
-    contact: z.string().regex(CONTACT_REGEX, '올바른 전화번호 형식이 아닙니다.').optional(),
+    name: z.string().min(2, '이름은 2자 이상이어야 합니다').optional(),
+    contact: z.string().regex(CONTACT_REGEX, '올바른 전화번호 형식이 아닙니다').optional(),
   })
   .refine((data) => data.name !== undefined || data.contact !== undefined, {
-    message: '수정할 항목을 하나 이상 입력해 주세요.',
+    message: '수정할 항목을 하나 이상 입력해 주세요',
   });
 export type UpdateMeSchema = z.infer<typeof updateMeSchema>;


### PR DESCRIPTION
🛠️ Issue Number
### closes [BD-107](https://sunwoo1137.atlassian.net/browse/BD-107)

📌 **작업 내용 및 특이사항**

- **auth-split**: 모바일 BottomSheet / PC Dialog 분기 처리 (`ResponsiveSheet` 교체)
- **auth-split**: 초기 진입 시 모달 닫힌 상태, 로그인 버튼 클릭 시에만 오픈 (`/` 이동 + `setOpen(true)`)
- **auth-split**: PC(`lg+`)에서 `max-h` 제한 해제 → 콘텐츠 높이에 맞게 자연스럽게 렌더
- **로그인 폼**: 입력창 흰색 테두리 및 포커스 스타일, 로그인 버튼 서비스 컬러 유지·볼드 처리
- **로그인 폼**: `mode: 'onTouched'` + `reValidateMode: 'onChange'` 적용
- **회원가입**: 2단계 → 단일 폼 통합, 연락처 제거, 비밀번호 확인 필드 추가
- **회원가입**: `mode: 'onChange'`, 에러 메시지 마침표 제거, 이름 placeholder 수정
- **PasswordStrength**: 4단계 바 제거 → 텍스트 레벨 표시(`보안 약함/보통/강함`)로 교체
- **globals.css**: 브랜드 컬러 `#e27363` 등록, webkit autofill 다크 테마 스타일, `sheet-in` 키프레임 추가
- **BottomSheet**: 애니메이션 좌→우 → 아래→위 슬라이드 수정
- **테스트**: `PasswordStrength` 테스트를 텍스트 방식으로 업데이트

📚 **참고사항**

- `input.tsx` cn() 순서 재배치: 에러 상태가 `className` 오버라이드보다 항상 우선하도록 수정
- `middleware.ts` 는 커밋에서 제외 (CLAUDE.md 규칙)
- 회원가입 창 닫고 로그인 버튼 재클릭 시 항상 로그인 폼이 먼저 뜨도록 처리 (`router.push(ROUTES.LOGIN)` 선행)

[BD-107]: https://sunwoo1137.atlassian.net/browse/BD-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ