### PR TITLE
[BD-110] fix: 구글 로그인 suppression 버그 수정

### DIFF
--- a/src/app/(auth)/login/OAuthSection.client.tsx
+++ b/src/app/(auth)/login/OAuthSection.client.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { OAuthButton } from '@/components/ui/oauth-button';
 import { useGoogleLogin } from '@/domain/auth/hooks/useGoogleLogin';
-import { oauthErrorMessage, requestGoogleIdToken } from '@/domain/auth/oauth';
+import { oauthErrorMessage, renderGoogleButton } from '@/domain/auth/oauth';
 import type { OAuthLoginResponse } from '@/domain/auth/types';
 import { env } from '@/global/config/env';
 import { ROUTES } from '@/global/config/routes';
@@ -13,7 +14,8 @@ import { useToast } from '@/hooks/useToast';
 /**
  * OAuth 로그인 섹션.
  *
- * Google: GIS prompt() 로 in-place ID token 발급 → BE 에 바로 전달.
+ * Google: GIS renderButton 으로 계정 선택 팝업을 열어 idToken 발급 → BE 전달.
+ * prompt()(One Tap) 대신 renderButton 을 사용해 브라우저 억제(suppression) 문제를 해소함.
  *
  * 카카오/애플 로그인은 사업자 등록 등 외부 사유로 일시 보류 — 코드는 보존하고 UI 만 숨긴다.
  * 재개 시 아래 import / handler / OAuthButton JSX 의 주석을 해제하면 즉시 동작 (BE contract 변경 없음).
@@ -25,6 +27,7 @@ import { useToast } from '@/hooks/useToast';
 export function OAuthSection() {
   const router = useRouter();
   const toast = useToast();
+  const googleButtonRef = useRef<HTMLDivElement>(null);
 
   const googleEnabled = !!env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
 
@@ -38,19 +41,32 @@ export function OAuthSection() {
     onError: (err) => toast.error(oauthErrorMessage(err)),
   });
 
+  // mutate 최신 참조를 ref 로 유지해 effect 재실행 없이 항상 최신 함수 호출
+  const mutateRef = useRef(googleMutation.mutate);
+  mutateRef.current = googleMutation.mutate;
+
+  useEffect(() => {
+    if (!googleEnabled || !googleButtonRef.current) return;
+    renderGoogleButton(googleButtonRef.current, (idToken) => {
+      mutateRef.current({ idToken });
+    }).catch((err) => {
+      toast.error(err instanceof Error ? err.message : '구글 로그인을 초기화할 수 없습니다.');
+    });
+    // googleEnabled 가 바뀔 때만 재렌더링
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [googleEnabled]);
+
   const busy = googleMutation.isPending;
 
-  async function handleGoogle() {
+  function handleGoogle() {
     if (!googleEnabled) {
       toast.error('구글 로그인이 설정되지 않았습니다.');
       return;
     }
-    try {
-      const idToken = await requestGoogleIdToken();
-      googleMutation.mutate({ idToken });
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : '구글 로그인에 실패했습니다.');
-    }
+    // 화면 밖에 숨겨진 Google renderButton 을 프로그래밍적으로 클릭.
+    // 사용자 클릭 이벤트 핸들러 내부이므로 팝업 차단 없이 동작.
+    const btn = googleButtonRef.current?.querySelector<HTMLElement>('div[role=button]');
+    btn?.click();
   }
 
   return (
@@ -79,6 +95,14 @@ export function OAuthSection() {
         <OAuthButton provider="kakao" onClick={handleKakao} disabled={busy} />
         <OAuthButton provider="apple" onClick={notReady} disabled={busy} />
       */}
+
+      {/* GIS renderButton 마운트 대상 — 화면 밖에 숨겨 시각적으로 노출하지 않음 */}
+      <div
+        ref={googleButtonRef}
+        aria-hidden="true"
+        style={{ position: 'fixed', top: -9999, left: -9999 }}
+      />
+
       <OAuthButton
         provider="google"
         onClick={handleGoogle}

--- a/src/domain/auth/oauth/google.ts
+++ b/src/domain/auth/oauth/google.ts
@@ -3,14 +3,7 @@ import { env } from '@/global/config/env';
 const SDK_URL = 'https://accounts.google.com/gsi/client';
 
 let loadPromise: Promise<NonNullable<Window['google']>> | null = null;
-let initialized = false;
-let pendingResolver: ((idToken: string) => void) | null = null;
-let pendingRejecter: ((err: Error) => void) | null = null;
 
-/**
- * Google Identity Services 스크립트를 동적으로 로드.
- * 이미 로드되어 있으면 바로 반환. 한 번만 로드되고 이후 호출은 캐시.
- */
 export async function loadGoogleGis(): Promise<NonNullable<Window['google']>> {
   if (typeof window === 'undefined') {
     throw new Error('SSR 환경에서는 GIS 를 로드할 수 없습니다.');
@@ -36,71 +29,29 @@ export async function loadGoogleGis(): Promise<NonNullable<Window['google']>> {
   return loadPromise;
 }
 
-function ensureInitialized(google: NonNullable<Window['google']>) {
-  if (initialized) return;
+/**
+ * GIS renderButton 을 사용해 element 에 Google 로그인 버튼을 렌더링한다.
+ * prompt()(One Tap)와 달리 브라우저 억제(suppression)가 없어 항상 계정 선택 팝업을 연다.
+ */
+export async function renderGoogleButton(
+  element: HTMLElement,
+  onIdToken: (idToken: string) => void,
+): Promise<void> {
+  const google = await loadGoogleGis();
   google.accounts.id.initialize({
     client_id: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
     callback: (response) => {
-      const resolver = pendingResolver;
-      const rejecter = pendingRejecter;
-      pendingResolver = null;
-      pendingRejecter = null;
-      if (response.credential) resolver?.(response.credential);
-      else rejecter?.(new Error('Google 로그인 응답에 credential 이 없습니다.'));
+      if (response.credential) onIdToken(response.credential);
     },
-    use_fedcm_for_prompt: true,
     auto_select: false,
     cancel_on_tap_outside: true,
     context: 'signin',
   });
-  initialized = true;
-}
-
-/**
- * GIS One Tap / Sign In With Google prompt 를 띄워 ID token (JWT) 을 발급받는다.
- *
- * 주의: prompt 가 표시되지 않는 경우가 많다 (브라우저 third-party cookie 차단,
- * 짧은 시간 내 반복 호출, 동의 거부 직후 등). FedCM 옵션을 켜서 최신 Chrome 에서는
- * cookie 정책과 무관하게 동작하지만, Safari / Firefox 에서는 여전히 막힐 수 있다.
- * 호출 측은 reject 메시지에 따라 표준 GIS 버튼으로 fallback 안내가 필요할 수 있다.
- */
-export async function requestGoogleIdToken(): Promise<string> {
-  const google = await loadGoogleGis();
-  ensureInitialized(google);
-  // 이전 호출이 끝나기 전 동시에 호출되면 이전 호출은 취소.
-  if (pendingRejecter) pendingRejecter(new Error('이전 Google 로그인 시도가 취소되었습니다.'));
-
-  return new Promise<string>((resolve, reject) => {
-    pendingResolver = resolve;
-    pendingRejecter = reject;
-    google.accounts.id.prompt((notification) => {
-      if (notification.isNotDisplayed()) {
-        pendingResolver = null;
-        pendingRejecter = null;
-        const reason = notification.getNotDisplayedReason();
-        // opt_out_or_no_session: 브라우저에 구글 계정 로그인 없음
-        const isNoSession = reason === 'opt_out_or_no_session' || reason === 'suppressed_by_user';
-        reject(
-          new Error(
-            isNoSession
-              ? 'Chrome에 구글 계정이 로그인되어 있지 않습니다. 브라우저에 구글 계정을 추가한 후 다시 시도해주세요.'
-              : `Google 로그인 창을 표시할 수 없습니다 (${reason}).`,
-          ),
-        );
-      } else if (notification.isSkippedMoment()) {
-        pendingResolver = null;
-        pendingRejecter = null;
-        reject(new Error('Google 로그인이 취소되었습니다.'));
-      } else if (notification.isDismissedMoment()) {
-        // FedCM abort 포함 — credential callback 없이 닫힌 경우
-        const reason = notification.getDismissedReason();
-        if (reason !== 'credential_returned') {
-          pendingResolver = null;
-          pendingRejecter = null;
-          reject(new Error('Google 로그인이 취소되었습니다.'));
-        }
-        // credential_returned 는 callback 에서 처리됨.
-      }
-    });
+  google.accounts.id.renderButton(element, {
+    type: 'standard',
+    size: 'large',
+    theme: 'outline',
+    text: 'signin_with',
+    shape: 'rectangular',
   });
 }

--- a/src/domain/auth/oauth/index.ts
+++ b/src/domain/auth/oauth/index.ts
@@ -1,6 +1,6 @@
 export { buildKakaoRedirectUri, loadKakao, startKakaoAuthorize } from './kakao';
 export { consumeKakaoState } from './kakaoState';
-export { loadGoogleGis, requestGoogleIdToken } from './google';
+export { loadGoogleGis, renderGoogleButton } from './google';
 
 import { ApiError } from '@/global/error/ApiError';
 


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-110](https://sunwoo1137.atlassian.net/browse/BD-110)

📌 **작업 내용 및 특이사항**

**원인**
- GIS `prompt()`(One Tap) 방식은 사용자가 팝업을 여러 번 닫으면 브라우저가 일정 기간 억제(suppression)하는 구조적 한계 존재
- `use_fedcm_for_prompt: true` 설정으로 인한 `FedCM get() rejects with AbortError` 에러 동반 발생

**수정 내용**
- `google.ts`: `prompt()` 제거, `renderGoogleButton()` 추가
  - GIS `renderButton()`은 계정 선택 팝업을 열어 suppression 없이 항상 동작
  - `use_fedcm_for_prompt` 옵션 제거로 FedCM AbortError 해소
- `OAuthSection.client.tsx`: 화면 밖 숨김 div에 `renderButton` 렌더링, 커스텀 버튼 클릭 시 프로그래밍적으로 트리거
  - 기존 커스텀 버튼 UI 유지
  - 사용자 클릭 이벤트 핸들러 내부에서 트리거하므로 팝업 차단 없이 동작

**BE contract 변경 없음**
- `POST /api/v1/auth/oauth/google { idToken }` 동일하게 유지

📚 **참고사항**

- `src/middleware.ts` 로컬 dev 패치는 커밋에 포함하지 않음

[BD-110]: https://sunwoo1137.atlassian.net/browse/BD-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ