### PR TITLE
fix: Server Actions 암호화 키 고정으로 배포 시 "Failed to find Server Action" 해소

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -74,6 +74,7 @@ jobs:
             NEXT_PUBLIC_APP_ENV=dev
             NEXT_PUBLIC_KAKAO_JS_KEY=${{ secrets.DEV_KAKAO_JS_KEY }}
             NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.DEV_GOOGLE_CLIENT_ID }}
+            NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,17 @@ ARG NEXT_PUBLIC_API_BASE_URL
 ARG NEXT_PUBLIC_APP_ENV
 ARG NEXT_PUBLIC_KAKAO_JS_KEY
 ARG NEXT_PUBLIC_GOOGLE_CLIENT_ID
+# Server Actions 암호화 키 — 빌드마다 랜덤 생성되는 기본 동작을 막고 고정한다.
+# 미고정 시: 새 빌드로 무중단 교체될 때 구버전 페이지를 열어둔 클라이언트가
+# "Failed to find Server Action" 에러를 겪는다 (action ID 복호화 불일치).
+# NEXT_PUBLIC_* 가 아니므로 클라이언트 번들에 노출되지 않는 서버 전용 비밀값이다.
+# 빌드(manifest 암호화) 와 런타임(복호화) 양쪽에 동일 값이 있어야 한다.
+ARG NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
 ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL \
     NEXT_PUBLIC_APP_ENV=$NEXT_PUBLIC_APP_ENV \
     NEXT_PUBLIC_KAKAO_JS_KEY=$NEXT_PUBLIC_KAKAO_JS_KEY \
     NEXT_PUBLIC_GOOGLE_CLIENT_ID=$NEXT_PUBLIC_GOOGLE_CLIENT_ID \
+    NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=$NEXT_SERVER_ACTIONS_ENCRYPTION_KEY \
     NEXT_TELEMETRY_DISABLED=1
 
 RUN --mount=type=cache,id=next,target=/app/.next/cache \
@@ -57,10 +64,15 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
+# Server Actions 복호화 키 — 빌드 시 manifest 암호화에 쓴 값과 반드시 동일해야 한다.
+# 멀티스테이지라 builder 의 ENV 가 상속되지 않으므로 runner 에서 다시 받는다.
+ARG NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
+
 ENV NODE_ENV=production \
     PORT=3000 \
     HOSTNAME=0.0.0.0 \
     TZ=Asia/Seoul \
+    NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=$NEXT_SERVER_ACTIONS_ENCRYPTION_KEY \
     NEXT_TELEMETRY_DISABLED=1
 
 EXPOSE 3000


### PR DESCRIPTION
## 문제

배포 환경(dev)에서 `Failed to find Server Action "x"` 에러가 재발.

코드에 `"use server"` 디렉티브는 없지만, App Router 는 폼 제출·RSC payload 재요청 등을 내부적으로 Server Action 메커니즘으로 처리하므로 프레임워크가 생성한 action ID 가 클라이언트 번들에 박힌다.

`next build` 는 Server Actions 암호화 키를 **빌드마다 랜덤 생성**한다(키 미지정 시 기본 동작). 배포 흐름은 `develop` push 마다 새 이미지를 빌드(`dev-<sha>`)하고 EC2 에서 단일 컨테이너를 무중단 교체(`docker compose up -d --no-deps fe-web`)한다. 이때:

- 구버전 페이지를 열어둔 클라이언트가 들고 있는 action ID/키
- 신버전 서버의 새 랜덤 키

가 불일치 → 서버가 action ID 를 복호화하지 못해 에러 발생.

## 해결

`NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` 환경변수로 키를 고정한다. 설치된 next `15.5.15` 는 런타임에 이 env 를 우선 사용한다(`encryption-utils.js:160`):

```js
const rawKey = process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
            || serverActionsManifestSingleton.serverActionsManifest.encryptionKey;
```

config 스키마에는 `encryptionKey` 가 노출되지 않아 env 주입이 유일한 안정적 경로다.

### 변경

- **Dockerfile** — builder(manifest 암호화) + runner(런타임 복호화) 양쪽 스테이지에 `ARG -> ENV` 주입. 멀티스테이지라 builder 의 ENV 가 상속되지 않으므로 runner 에서 재선언. `NEXT_PUBLIC_*` 가 아니므로 클라이언트 번들에 노출되지 않는 서버 전용 비밀값.
- **develop_deploy.yml** — `build-args` 에 secret 전달.

CI 워크플로우(`develop_ci_test.yml`)는 Docker 빌드가 아닌 검증용 `pnpm build` 라 키 고정 불필요(산출물 폐기).

## ⚠️ 머지 전 필수 — GitHub Secret 등록

**이 secret 을 먼저 등록하지 않고 머지하면**, build-arg 가 빈 값으로 들어가 next 가 다시 랜덤 키로 fallback 하여 **수정이 무효화**된다.

```
Settings → Secrets and variables → Actions → New repository secret
  Name:   NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
  Secret: <node -e "console.log(require('crypto').randomBytes(32).toString('base64'))" 결과>
```

- 32바이트 base64 (AES-256) 값.
- **한 번 정하면 고정 유지.** 키를 바꾸면 그 순간 열려 있던 모든 페이지에서 같은 에러가 재발한다.
- 향후 prod 배포 워크플로우 추가 시 동일 키 주입 필요(현재는 dev 워크플로우만 존재).

## 검증

- next 런타임의 키 우선순위 로직은 설치된 `node_modules` 실제 소스(`encryption-utils.js:160`)로 확인.
- secret 등록 후 머지 → develop 배포 파이프라인에서 키 주입 빌드 실제 검증 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)