### PR TITLE
fix: 운영 환경 구글 로그인 팝업 미노출 버그

### DIFF
--- a/src/domain/auth/oauth/google.ts
+++ b/src/domain/auth/oauth/google.ts
@@ -3,6 +3,8 @@ import { env } from '@/global/config/env';
 const SDK_URL = 'https://accounts.google.com/gsi/client';
 
 let loadPromise: Promise<NonNullable<Window['google']>> | null = null;
+let currentCallback: ((idToken: string) => void) | null = null;
+let isInitialized = false;
 
 export async function loadGoogleGis(): Promise<NonNullable<Window['google']>> {
   if (typeof window === 'undefined') {
@@ -32,26 +34,36 @@ export async function loadGoogleGis(): Promise<NonNullable<Window['google']>> {
 /**
  * GIS renderButton 을 사용해 element 에 Google 로그인 버튼을 렌더링한다.
  * prompt()(One Tap)와 달리 브라우저 억제(suppression)가 없어 항상 계정 선택 팝업을 연다.
+ *
+ * initialize()는 페이지 세션당 한 번만 호출한다 — 복수 호출 시 GIS 내부 상태가 꼬여
+ * renderButton으로 그린 버튼 클릭 시 팝업이 열리지 않는 버그가 발생한다.
+ * callback은 모듈 수준 currentCallback 포인터로 위임해 컴포넌트 재마운트 시에도 최신 핸들러를 유지한다.
  */
 export async function renderGoogleButton(
   element: HTMLElement,
   onIdToken: (idToken: string) => void,
 ): Promise<void> {
+  currentCallback = onIdToken;
+
   const google = await loadGoogleGis();
-  google.accounts.id.initialize({
-    client_id: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
-    callback: (response) => {
-      if (response.credential) onIdToken(response.credential);
-    },
-    auto_select: false,
-    cancel_on_tap_outside: true,
-    context: 'signin',
-  });
-  google.accounts.id.renderButton(element, {
-    type: 'standard',
-    size: 'large',
-    theme: 'outline',
-    text: 'signin_with',
-    shape: 'rectangular',
-  });
+
+  if (!isInitialized) {
+    google.accounts.id.initialize({
+      client_id: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
+      callback: (response) => {
+        if (response.credential) currentCallback?.(response.credential);
+      },
+      auto_select: false,
+      cancel_on_tap_outside: true,
+      context: 'signin',
+    });
+    isInitialized = true;
+    google.accounts.id.renderButton(element, {
+      type: 'standard',
+      size: 'large',
+      theme: 'outline',
+      text: 'signin_with',
+      shape: 'rectangular',
+    });
+  }
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-127](https://sunwoo1137.atlassian.net/browse/BD-127)

📌 **작업 내용 및 특이사항**

- GIS `initialize()` 중복 호출 방어 (`isInitialized` 플래그 추가)
- 모듈 수준 `currentCallback` 포인터로 콜백 위임 — 컴포넌트 재마운트 시에도 최신 핸들러 유지

**원인**: Next.js App Router에서 로그인 페이지 컴포넌트가 재마운트될 때 `renderGoogleButton()`이 중복 호출되어 `initialize()`가 여러 번 실행됨. GIS는 마지막 초기화 인스턴스만 유효하게 처리하므로, 먼저 렌더링된 버튼이 깨진 인스턴스를 참조해 클릭 시 팝업이 열리지 않음.

📚 **참고사항**

- 로컬(localhost)에서는 GIS가 개발 환경 origin에 더 관대하게 동작해 재현되지 않았음
- 운영 배포 후 브라우저 콘솔에서 `[GSI_LOGGER]: initialize() is called multiple times` 경고 소멸 여부 확인 필요


[BD-127]: https://sunwoo1137.atlassian.net/browse/BD-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ