### PR TITLE
[BD-128] fix: 구글 로그인 renderButton 재마운트 미호출 버그

### DIFF
--- a/src/domain/auth/oauth/google.ts
+++ b/src/domain/auth/oauth/google.ts
@@ -58,12 +58,13 @@ export async function renderGoogleButton(
       context: 'signin',
     });
     isInitialized = true;
-    google.accounts.id.renderButton(element, {
-      type: 'standard',
-      size: 'large',
-      theme: 'outline',
-      text: 'signin_with',
-      shape: 'rectangular',
-    });
   }
+
+  google.accounts.id.renderButton(element, {
+    type: 'standard',
+    size: 'large',
+    theme: 'outline',
+    text: 'signin_with',
+    shape: 'rectangular',
+  });
 }


### PR DESCRIPTION
🛠️ Issue Number
### closes [BD-128](https://sunwoo1137.atlassian.net/browse/BD-128)

📌 **작업 내용 및 특이사항**

- `renderButton()`을 `isInitialized` 블록 밖으로 분리해 컴포넌트 재마운트 시에도 새 DOM 요소에 버튼 렌더링 보장
- `initialize()`는 `isInitialized` 플래그로 세션당 1회만 호출 유지 (GIS 중복 초기화 방어)

**원인**: BD-127 수정에서 `renderButton()`을 `isInitialized` 블록 안에 포함시켜, 로그인 페이지 재방문 시 컴포넌트가 재마운트돼도 새 DOM 요소에 버튼이 렌더링되지 않았음. `handleGoogle()`이 빈 요소에서 `div[role=button]`을 찾지 못해 클릭이 no-op으로 처리됨.

📚 **참고사항**

- 모바일 운영은 영향 없었으나 PC 운영·개발 환경에서 구글 로그인 팝업 미노출 재현
- 배포 후 PC 운영 환경에서 팝업 정상 동작 여부 확인 필요

[BD-128]: https://sunwoo1137.atlassian.net/browse/BD-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ