### PR TITLE
[BD-128] fix: 데스크톱 구글 로그인 팝업 차단 문제 해결

### DIFF
--- a/src/app/(auth)/login/OAuthSection.client.tsx
+++ b/src/app/(auth)/login/OAuthSection.client.tsx
@@ -63,10 +63,11 @@ export function OAuthSection() {
       toast.error('구글 로그인이 설정되지 않았습니다.');
       return;
     }
-    // 화면 밖에 숨겨진 Google renderButton 을 프로그래밍적으로 클릭.
-    // 사용자 클릭 이벤트 핸들러 내부이므로 팝업 차단 없이 동작.
-    const btn = googleButtonRef.current?.querySelector<HTMLElement>('div[role=button]');
-    btn?.click();
+    // renderButton 클릭 방식은 데스크톱 Chrome에서 팝업 창을 열려 할 때 팝업 차단에 걸린다.
+    // prompt()는 팝업 창 없이 페이지 내 오버레이 UI를 사용하므로 차단되지 않는다.
+    // (BD-110 억제 이슈는 페이지 로드 시 자동 호출에서 발생한 것이며,
+    //  사용자 클릭 핸들러에서 호출하면 브라우저가 억제하지 않는다.)
+    window.google?.accounts?.id?.prompt();
   }
 
   return (


### PR DESCRIPTION
🛠️ Issue Number
### closes [BD-128](https://sunwoo1137.atlassian.net/browse/BD-128)

📌 **작업 내용 및 특이사항**

- `renderButton` 클릭 방식 → `prompt()` 직접 호출로 변경
- `renderButton`은 팝업 창(`window.open`)을 열어 데스크톱 Chrome 팝업 차단에 걸림
- `prompt()`는 팝업 창 없이 페이지 내 오버레이 UI를 사용해 차단되지 않음
- BD-110 억제 이슈는 페이지 로드 시 자동 호출에서 발생한 것이며, 사용자 클릭 핸들러에서 직접 호출하면 브라우저가 억제하지 않음

📚 **참고사항**

- 배포 후 PC 운영 환경에서 구글 로그인 버튼 클릭 시 우측 상단 계정 선택 오버레이가 뜨는지 확인 필요
- 모바일 운영 환경은 기존과 동일하게 동작

[BD-128]: https://sunwoo1137.atlassian.net/browse/BD-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ