### PR TITLE
[BD-130] fix: One Tap 닫은 후 구글 로그인 재시도 불가 — FedCM 쿨다운 우회

### DIFF
--- a/src/app/(auth)/login/OAuthSection.client.tsx
+++ b/src/app/(auth)/login/OAuthSection.client.tsx
@@ -63,11 +63,10 @@ export function OAuthSection() {
       toast.error('구글 로그인이 설정되지 않았습니다.');
       return;
     }
-    // renderButton 클릭 방식은 데스크톱 Chrome에서 팝업 창을 열려 할 때 팝업 차단에 걸린다.
-    // prompt()는 팝업 창 없이 페이지 내 오버레이 UI를 사용하므로 차단되지 않는다.
-    // (BD-110 억제 이슈는 페이지 로드 시 자동 호출에서 발생한 것이며,
-    //  사용자 클릭 핸들러에서 호출하면 브라우저가 억제하지 않는다.)
-    window.google?.accounts?.id?.prompt();
+    // use_fedcm_for_prompt: false 로 FedCM을 비활성화했으므로
+    // renderButton 클릭이 전통적인 OAuth 팝업으로 열린다 (FedCM 쿨다운 무관).
+    const btn = googleButtonRef.current?.querySelector<HTMLElement>('div[role=button]');
+    btn?.click();
   }
 
   return (

--- a/src/domain/auth/oauth/google.ts
+++ b/src/domain/auth/oauth/google.ts
@@ -56,6 +56,9 @@ export async function renderGoogleButton(
       auto_select: false,
       cancel_on_tap_outside: true,
       context: 'signin',
+      // FedCM 비활성화: Chrome의 FedCM 쿨다운(One Tap 닫기 후 지수적 억제)을 우회해
+      // 전통적인 OAuth 팝업 방식으로 항상 계정 선택창을 열 수 있게 한다.
+      use_fedcm_for_prompt: false,
     });
     isInitialized = true;
   }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-130](https://sunwoo1137.atlassian.net/browse/BD-130)

📌 **작업 내용 및 특이사항**

- `initialize()`에 `use_fedcm_for_prompt: false` 추가
- Chrome 120+에서 GIS가 FedCM API를 기본 사용하는데, 사용자가 One Tap을 닫으면 지수적 쿨다운이 걸려 이후 재시도 시 아무것도 표시되지 않는 문제
- `use_fedcm_for_prompt: false`로 FedCM을 우회해 전통적인 OAuth 팝업 방식으로 강제 → 쿨다운 영향 없음
- `renderButton` 클릭 방식 복원 (BD-128-1의 `prompt()` 방식 철회)

📚 **참고사항**

- 모바일은 FedCM을 다르게 처리해 기존에도 정상 동작했으나, 이번 변경으로 PC와 동일한 코드 경로를 타게 됨
- 배포 후 PC 운영에서 One Tap 닫기 → 재시도 시 계정 선택창이 정상 노출되는지 확인 필요

[BD-130]: https://sunwoo1137.atlassian.net/browse/BD-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ