### PR TITLE
[BD-131] fix: 구글 로그인 FedCM 우회 — GIS redirect 모드 전환

### DIFF
--- a/src/app/(auth)/login/OAuthSection.client.tsx
+++ b/src/app/(auth)/login/OAuthSection.client.tsx
@@ -1,21 +1,18 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { useRouter } from 'next/navigation';
 
 import { OAuthButton } from '@/components/ui/oauth-button';
-import { useGoogleLogin } from '@/domain/auth/hooks/useGoogleLogin';
-import { oauthErrorMessage, renderGoogleButton } from '@/domain/auth/oauth';
-import type { OAuthLoginResponse } from '@/domain/auth/types';
+import { renderGoogleButton } from '@/domain/auth/oauth';
 import { env } from '@/global/config/env';
-import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
 
 /**
  * OAuth 로그인 섹션.
  *
- * Google: GIS renderButton 으로 계정 선택 팝업을 열어 idToken 발급 → BE 전달.
- * prompt()(One Tap) 대신 renderButton 을 사용해 브라우저 억제(suppression) 문제를 해소함.
+ * Google: GIS ux_mode:'redirect' — 버튼 클릭 시 Google 인증 페이지로 리다이렉트.
+ * 인증 완료 후 Google 이 /api/oauth/google/callback(Route Handler)으로 POST → /oauth/callback/google 로 이동.
+ * FedCM / 쿨다운 / Chrome 팝업 차단 등 브라우저 정책의 영향을 받지 않는다.
  *
  * 카카오/애플 로그인은 사업자 등록 등 외부 사유로 일시 보류 — 코드는 보존하고 UI 만 숨긴다.
  * 재개 시 아래 import / handler / OAuthButton JSX 의 주석을 해제하면 즉시 동작 (BE contract 변경 없음).
@@ -25,46 +22,24 @@ import { useToast } from '@/hooks/useToast';
  * - 응답 { accessToken, isNewMember } + Set-Cookie refreshToken
  */
 export function OAuthSection() {
-  const router = useRouter();
   const toast = useToast();
   const googleButtonRef = useRef<HTMLDivElement>(null);
 
   const googleEnabled = !!env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
 
-  const onLoginSuccess = (data: OAuthLoginResponse) => {
-    toast.success(data.isNewMember ? '환영합니다. 가입이 완료되었습니다.' : '로그인되었습니다.');
-    router.replace(ROUTES.HOME);
-  };
-
-  const googleMutation = useGoogleLogin({
-    onSuccess: onLoginSuccess,
-    onError: (err) => toast.error(oauthErrorMessage(err)),
-  });
-
-  // mutate 최신 참조를 ref 로 유지해 effect 재실행 없이 항상 최신 함수 호출
-  const mutateRef = useRef(googleMutation.mutate);
-  mutateRef.current = googleMutation.mutate;
-
   useEffect(() => {
     if (!googleEnabled || !googleButtonRef.current) return;
-    renderGoogleButton(googleButtonRef.current, (idToken) => {
-      mutateRef.current({ idToken });
-    }).catch((err) => {
+    renderGoogleButton(googleButtonRef.current).catch((err) => {
       toast.error(err instanceof Error ? err.message : '구글 로그인을 초기화할 수 없습니다.');
     });
-    // googleEnabled 가 바뀔 때만 재렌더링
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [googleEnabled]);
-
-  const busy = googleMutation.isPending;
 
   function handleGoogle() {
     if (!googleEnabled) {
       toast.error('구글 로그인이 설정되지 않았습니다.');
       return;
     }
-    // use_fedcm_for_prompt: false 로 FedCM을 비활성화했으므로
-    // renderButton 클릭이 전통적인 OAuth 팝업으로 열린다 (FedCM 쿨다운 무관).
     const btn = googleButtonRef.current?.querySelector<HTMLElement>('div[role=button]');
     btn?.click();
   }
@@ -92,8 +67,8 @@ export function OAuthSection() {
 
         const notReady = () => toast.info('준비 중입니다.');
 
-        <OAuthButton provider="kakao" onClick={handleKakao} disabled={busy} />
-        <OAuthButton provider="apple" onClick={notReady} disabled={busy} />
+        <OAuthButton provider="kakao" onClick={handleKakao} />
+        <OAuthButton provider="apple" onClick={notReady} />
       */}
 
       {/* GIS renderButton 마운트 대상 — 화면 밖에 숨겨 시각적으로 노출하지 않음 */}
@@ -103,12 +78,7 @@ export function OAuthSection() {
         style={{ position: 'fixed', top: -9999, left: -9999 }}
       />
 
-      <OAuthButton
-        provider="google"
-        onClick={handleGoogle}
-        disabled={busy}
-        className="rounded-[5px]"
-      />
+      <OAuthButton provider="google" onClick={handleGoogle} className="rounded-[5px]" />
     </section>
   );
 }

--- a/src/app/api/oauth/google/callback/route.ts
+++ b/src/app/api/oauth/google/callback/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * GIS ux_mode:'redirect' 의 login_uri 엔드포인트.
+ *
+ * Google 이 인증 완료 후 브라우저를 통해 credential(idToken) 을 form-POST 로 전달한다.
+ * credential 을 단명(60초) 쿠키에 저장하고 GoogleCallback 클라이언트 페이지로 리다이렉트.
+ * 클라이언트 페이지에서 쿠키를 읽어 Spring 백엔드를 직접 호출하므로
+ * refreshToken 쿠키가 브라우저에 직접 설정된다.
+ */
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const credential = formData.get('credential');
+
+  if (!credential || typeof credential !== 'string') {
+    return NextResponse.redirect(new URL('/?error=google_auth_failed', request.url));
+  }
+
+  // 303 See Other: POST → GET 전환 (307 유지 시 브라우저가 POST로 페이지를 요청해 라우터 혼선)
+  const response = NextResponse.redirect(new URL('/oauth/callback/google', request.url), {
+    status: 303,
+  });
+  response.cookies.set('_g_credential', credential, {
+    httpOnly: false,
+    maxAge: 60,
+    sameSite: 'lax',
+    path: '/',
+    secure: process.env.NODE_ENV === 'production',
+  });
+
+  return response;
+}

--- a/src/app/oauth/callback/google/GoogleCallback.client.tsx
+++ b/src/app/oauth/callback/google/GoogleCallback.client.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { Spinner } from '@/components/ui/spinner';
+import { useGoogleLogin } from '@/domain/auth/hooks/useGoogleLogin';
+import { oauthErrorMessage } from '@/domain/auth/oauth';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+
+export function GoogleCallback() {
+  const router = useRouter();
+  const toast = useToast();
+  const ran = useRef(false);
+
+  const mutation = useGoogleLogin({
+    onSuccess: (data) => {
+      toast.success(data.isNewMember ? '환영합니다. 가입이 완료되었습니다.' : '로그인되었습니다.');
+      router.replace(ROUTES.HOME);
+    },
+    onError: (err) => {
+      toast.error(oauthErrorMessage(err));
+      router.replace(ROUTES.LOGIN);
+    },
+  });
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+
+    const credential = document.cookie
+      .split('; ')
+      .find((row) => row.startsWith('_g_credential='))
+      ?.split('=')[1];
+
+    document.cookie = '_g_credential=; Max-Age=0; Path=/';
+
+    if (!credential) {
+      toast.error('구글 인증 정보를 받지 못했습니다.');
+      router.replace(ROUTES.LOGIN);
+      return;
+    }
+
+    mutation.mutate({ idToken: credential });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="text-foreground-sub flex items-center gap-3 text-sm">
+        <Spinner size="md" />
+        <span>구글 로그인 처리 중...</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/oauth/callback/google/page.tsx
+++ b/src/app/oauth/callback/google/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+
+import { GoogleCallback } from './GoogleCallback.client';
+
+export const metadata: Metadata = {
+  title: '구글 로그인 처리 중 | Bandage',
+};
+
+export default function GoogleCallbackPage() {
+  return (
+    <Suspense fallback={null}>
+      <GoogleCallback />
+    </Suspense>
+  );
+}

--- a/src/domain/auth/oauth/google.ts
+++ b/src/domain/auth/oauth/google.ts
@@ -3,7 +3,6 @@ import { env } from '@/global/config/env';
 const SDK_URL = 'https://accounts.google.com/gsi/client';
 
 let loadPromise: Promise<NonNullable<Window['google']>> | null = null;
-let currentCallback: ((idToken: string) => void) | null = null;
 let isInitialized = false;
 
 export async function loadGoogleGis(): Promise<NonNullable<Window['google']>> {
@@ -32,33 +31,25 @@ export async function loadGoogleGis(): Promise<NonNullable<Window['google']>> {
 }
 
 /**
- * GIS renderButton 을 사용해 element 에 Google 로그인 버튼을 렌더링한다.
- * prompt()(One Tap)와 달리 브라우저 억제(suppression)가 없어 항상 계정 선택 팝업을 연다.
+ * GIS renderButton 을 ux_mode:'redirect' 로 초기화한다.
  *
- * initialize()는 페이지 세션당 한 번만 호출한다 — 복수 호출 시 GIS 내부 상태가 꼬여
- * renderButton으로 그린 버튼 클릭 시 팝업이 열리지 않는 버그가 발생한다.
- * callback은 모듈 수준 currentCallback 포인터로 위임해 컴포넌트 재마운트 시에도 최신 핸들러를 유지한다.
+ * 버튼 클릭 시 Google 인증 페이지로 리다이렉트되며, 인증 완료 후 Google 이
+ * login_uri(Route Handler)로 credential 을 POST 한다.
+ * FedCM / 쿨다운 / Chrome 팝업 차단 등 브라우저 정책의 영향을 받지 않는다.
+ *
+ * initialize()는 페이지 세션당 한 번만 호출한다.
  */
-export async function renderGoogleButton(
-  element: HTMLElement,
-  onIdToken: (idToken: string) => void,
-): Promise<void> {
-  currentCallback = onIdToken;
-
+export async function renderGoogleButton(element: HTMLElement): Promise<void> {
   const google = await loadGoogleGis();
 
   if (!isInitialized) {
     google.accounts.id.initialize({
       client_id: env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
-      callback: (response) => {
-        if (response.credential) currentCallback?.(response.credential);
-      },
       auto_select: false,
       cancel_on_tap_outside: true,
       context: 'signin',
-      // FedCM 비활성화: Chrome의 FedCM 쿨다운(One Tap 닫기 후 지수적 억제)을 우회해
-      // 전통적인 OAuth 팝업 방식으로 항상 계정 선택창을 열 수 있게 한다.
-      use_fedcm_for_prompt: false,
+      ux_mode: 'redirect',
+      login_uri: `${window.location.origin}/api/oauth/google/callback`,
     });
     isInitialized = true;
   }

--- a/src/global/config/routes.ts
+++ b/src/global/config/routes.ts
@@ -3,6 +3,7 @@ export const ROUTES = {
   JOIN: '/join',
   PASSWORD_CHANGE: '/password-change',
   OAUTH_CALLBACK_KAKAO: '/oauth/callback/kakao',
+  OAUTH_CALLBACK_GOOGLE: '/oauth/callback/google',
 
   HOME: '/home',
 

--- a/src/global/types/google-gsi.d.ts
+++ b/src/global/types/google-gsi.d.ts
@@ -4,13 +4,15 @@
  */
 interface GoogleIdConfiguration {
   client_id: string;
-  callback: (response: GoogleCredentialResponse) => void;
+  /** popup 모드에서 credential 수신 콜백. redirect 모드에서는 사용되지 않음. */
+  callback?: (response: GoogleCredentialResponse) => void;
   auto_select?: boolean;
   cancel_on_tap_outside?: boolean;
-  /** FedCM 사용 (Chrome third-party cookie 정책 회피). default true (권장). */
   use_fedcm_for_prompt?: boolean;
   context?: 'signin' | 'signup' | 'use';
   ux_mode?: 'popup' | 'redirect';
+  /** redirect 모드에서 Google 이 credential 을 POST 할 URI. */
+  login_uri?: string;
 }
 
 interface GoogleCredentialResponse {


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-131](https://sunwoo1137.atlassian.net/browse/BD-131)

📌 **작업 내용 및 특이사항**

**문제**
Chrome PC에서 구글 로그인이 FedCM(Federated Credential Management) 브라우저 정책으로 차단됨. `use_fedcm_for_prompt: false` 등 옵션으로는 브라우저 레벨 이슈를 완전 우회 불가.

추가로, 콜백 페이지가 `(auth)` 라우트 그룹에 있어 `AuthSplit` → `ResponsiveSheet`(Radix Dialog)로 감싸지는 구조 문제. Dialog `open = false` 상태에서 Content가 마운트되지 않아 `GoogleCallback` 컴포넌트가 실행되지 않는 버그 존재.

**변경 내용**
- GIS `initialize()`에 `ux_mode: 'redirect'` + `login_uri` 적용 — FedCM/팝업 차단 완전 우회
- `OAuthSection`에서 mutation 제거, 버튼 클릭 시 GIS 버튼 click() 위임으로 단순화
- Route Handler `POST /api/oauth/google/callback` 추가: Google이 전달하는 credential을 단명 쿠키(60초)에 저장 후 303 리다이렉트
- `/oauth/callback/google` 처리 페이지 신규 추가: 쿠키에서 idToken 읽어 Spring `POST /api/v1/auth/oauth/google` 호출 → 성공 시 `/home` 이동
- 콜백 페이지를 `(auth)` 그룹 밖(`src/app/oauth/callback/google/`)으로 이동 — Dialog 미마운트 버그 해소

📚 **참고사항**

`middleware.ts` 변경분(dev 환경 cross-domain 쿠키 우회)은 별도 이슈로 분리 예정.

[BD-131]: https://sunwoo1137.atlassian.net/browse/BD-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ