### PR TITLE
[BD-132] fix: GIS overlay 방식으로 전환 — cross-origin iframe click 전달 문제 해소

### DIFF
--- a/src/app/(auth)/login/OAuthSection.client.tsx
+++ b/src/app/(auth)/login/OAuthSection.client.tsx
@@ -35,15 +35,6 @@ export function OAuthSection() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [googleEnabled]);
 
-  function handleGoogle() {
-    if (!googleEnabled) {
-      toast.error('구글 로그인이 설정되지 않았습니다.');
-      return;
-    }
-    const btn = googleButtonRef.current?.querySelector<HTMLElement>('div[role=button]');
-    btn?.click();
-  }
-
   return (
     <section aria-label="OAuth 로그인" className="space-y-s-3" data-slot="oauth-section">
       {/*
@@ -71,14 +62,19 @@ export function OAuthSection() {
         <OAuthButton provider="apple" onClick={notReady} />
       */}
 
-      {/* GIS renderButton 마운트 대상 — 화면 밖에 숨겨 시각적으로 노출하지 않음 */}
-      <div
-        ref={googleButtonRef}
-        aria-hidden="true"
-        style={{ position: 'fixed', top: -9999, left: -9999 }}
-      />
-
-      <OAuthButton provider="google" onClick={handleGoogle} className="rounded-[5px]" />
+      {/*
+        GIS iframe을 커스텀 버튼 위에 투명 overlay로 마운트.
+        redirect 모드에서는 GIS iframe이 직접 사용자 클릭을 받아야 리다이렉트가 트리거된다.
+        programmatic .click()은 cross-origin iframe에 전달되지 않으므로 overlay 방식을 사용.
+      */}
+      <div className="relative">
+        <OAuthButton provider="google" className="pointer-events-none rounded-[5px]" />
+        <div
+          ref={googleButtonRef}
+          aria-hidden="true"
+          className="absolute inset-0 overflow-hidden opacity-0"
+        />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-132](https://sunwoo1137.atlassian.net/browse/BD-132)

📌 **작업 내용 및 특이사항**

**문제**
GIS `ux_mode:'redirect'`에서 구글 로그인 버튼 클릭 시 Google 인증 페이지로 이동하지 않는 문제.

GIS `renderButton`은 내부적으로 cross-origin iframe을 생성하는데, 기존 방식(`div[role=button]` 을 찾아 programmatic `.click()` 호출)으로는 클릭 이벤트가 iframe 내부까지 전달되지 않아 redirect가 트리거되지 않음.

**변경 내용**
- GIS renderButton 마운트 대상을 화면 밖 숨김 div에서 커스텀 버튼 위 `opacity-0` overlay div로 변경
- 사용자 클릭이 GIS iframe에 직접 전달되어 redirect 정상 동작
- 커스텀 `OAuthButton`은 `pointer-events-none`으로 시각적 역할만 유지

📚 **참고사항**

팝업/FedCM 모드에서는 overlay가 효과 없지만, redirect 모드에서는 이 방식이 올바른 접근.

[BD-132]: https://sunwoo1137.atlassian.net/browse/BD-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ