### PR TITLE
[BD-133] fix: GIS login_uri 환경변수 고정 및 커서·버튼 너비 보정

### DIFF
--- a/.github/workflows/develop_ci_test.yml
+++ b/.github/workflows/develop_ci_test.yml
@@ -21,6 +21,7 @@ jobs:
       # 운영/스테이지 배포 환경에서는 배포 플랫폼(예: Vercel)의 환경 변수로 주입되어야 함.
       NEXT_PUBLIC_API_BASE_URL: http://localhost:8080
       NEXT_PUBLIC_APP_ENV: dev
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
 
     steps:
       - name: Checkout source code

--- a/src/app/(auth)/login/OAuthSection.client.tsx
+++ b/src/app/(auth)/login/OAuthSection.client.tsx
@@ -67,7 +67,7 @@ export function OAuthSection() {
         redirect 모드에서는 GIS iframe이 직접 사용자 클릭을 받아야 리다이렉트가 트리거된다.
         programmatic .click()은 cross-origin iframe에 전달되지 않으므로 overlay 방식을 사용.
       */}
-      <div className="relative">
+      <div className="relative cursor-pointer">
         <OAuthButton provider="google" className="pointer-events-none rounded-[5px]" />
         <div
           ref={googleButtonRef}

--- a/src/domain/auth/oauth/google.ts
+++ b/src/domain/auth/oauth/google.ts
@@ -49,16 +49,19 @@ export async function renderGoogleButton(element: HTMLElement): Promise<void> {
       cancel_on_tap_outside: true,
       context: 'signin',
       ux_mode: 'redirect',
-      login_uri: `${window.location.origin}/api/oauth/google/callback`,
+      login_uri: `${env.NEXT_PUBLIC_APP_URL}/api/oauth/google/callback`,
     });
     isInitialized = true;
   }
 
+  // GIS iframe이 버튼 전체 너비를 채우도록 컨테이너 width를 전달 (최대 400px)
+  const width = Math.min(element.offsetWidth || 400, 400);
   google.accounts.id.renderButton(element, {
     type: 'standard',
     size: 'large',
     theme: 'outline',
     text: 'signin_with',
     shape: 'rectangular',
+    width,
   });
 }

--- a/src/global/config/env.ts
+++ b/src/global/config/env.ts
@@ -12,6 +12,8 @@ const optionalNonEmpty = z
 const envSchema = z.object({
   NEXT_PUBLIC_API_BASE_URL: z.string().url(),
   NEXT_PUBLIC_APP_ENV: z.enum(['local', 'dev', 'prod']),
+  /** 프론트엔드 앱의 퍼블릭 URL. GIS login_uri 등 절대 경로 생성에 사용. */
+  NEXT_PUBLIC_APP_URL: z.string().url(),
   /** Kakao JavaScript SDK 키 (REST API/Admin 키 아님). 미설정 시 카카오 로그인 비활성화. */
   NEXT_PUBLIC_KAKAO_JS_KEY: optionalNonEmpty,
   /** Google OAuth Web Client ID. BE GOOGLE_OAUTH_CLIENT_ID 와 동일 값이어야 audience 검증 통과. */
@@ -21,6 +23,7 @@ const envSchema = z.object({
 const parsed = envSchema.safeParse({
   NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
   NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   NEXT_PUBLIC_KAKAO_JS_KEY: process.env.NEXT_PUBLIC_KAKAO_JS_KEY,
   NEXT_PUBLIC_GOOGLE_CLIENT_ID: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
 });


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-133](https://sunwoo1137.atlassian.net/browse/BD-133)

📌 **작업 내용 및 특이사항**

- `NEXT_PUBLIC_APP_URL` 환경변수 추가 — GIS `login_uri` 생성 시 `window.location.origin` 대신 고정 URL 사용
  - 모바일 / 시크릿 모드에서 `0.0.0.0:3000` origin이 그대로 `login_uri`로 전달돼 Google Console 미등록 에러가 발생하던 문제 해소
- 구글 버튼 wrapper에 `cursor-pointer` 추가 — overlay 방식 전환(BD-132) 이후 `OAuthButton`이 `pointer-events-none`이 되어 커서가 사라지던 문제 해소
- `renderGoogleButton`에 `width` 옵션 추가 — GIS iframe이 컨테이너 너비 전체를 채우도록 해 버튼 우측 빈 영역 클릭 미동작 방지

📚 **참고사항**
- BD-132(overlay 전환) 이후 이어지는 보완 패치

[BD-133]: https://sunwoo1137.atlassian.net/browse/BD-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ