### PR TITLE
[BD-134] fix: Route Handler 리다이렉트 URL을 NEXT_PUBLIC_APP_URL로 고정

### DIFF
--- a/src/app/api/oauth/google/callback/route.ts
+++ b/src/app/api/oauth/google/callback/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+import { env } from '@/global/config/env';
+
 /**
  * GIS ux_mode:'redirect' 의 login_uri 엔드포인트.
  *
@@ -7,17 +9,21 @@ import { NextResponse } from 'next/server';
  * credential 을 단명(60초) 쿠키에 저장하고 GoogleCallback 클라이언트 페이지로 리다이렉트.
  * 클라이언트 페이지에서 쿠키를 읽어 Spring 백엔드를 직접 호출하므로
  * refreshToken 쿠키가 브라우저에 직접 설정된다.
+ *
+ * request.url 은 EC2 내부 주소(0.0.0.0:3000)를 반환하므로 NEXT_PUBLIC_APP_URL 로 고정.
  */
 export async function POST(request: Request) {
   const formData = await request.formData();
   const credential = formData.get('credential');
 
+  const appUrl = env.NEXT_PUBLIC_APP_URL;
+
   if (!credential || typeof credential !== 'string') {
-    return NextResponse.redirect(new URL('/?error=google_auth_failed', request.url));
+    return NextResponse.redirect(new URL('/?error=google_auth_failed', appUrl));
   }
 
   // 303 See Other: POST → GET 전환 (307 유지 시 브라우저가 POST로 페이지를 요청해 라우터 혼선)
-  const response = NextResponse.redirect(new URL('/oauth/callback/google', request.url), {
+  const response = NextResponse.redirect(new URL('/oauth/callback/google', appUrl), {
     status: 303,
   });
   response.cookies.set('_g_credential', credential, {


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-134](https://sunwoo1137.atlassian.net/browse/BD-134)

📌 **작업 내용 및 특이사항**

- `/api/oauth/google/callback` Route Handler의 리다이렉트 URL 생성 시 `request.url` 대신 `env.NEXT_PUBLIC_APP_URL` 사용
  - EC2 Docker 환경에서 `request.url`이 내부 주소(`http://0.0.0.0:3000/...`)를 반환해 브라우저가 내부 주소로 리다이렉트되던 문제 해소
  - nginx/CloudFront를 통해 프록시되면 `request.url`의 호스트가 외부 도메인이 아닌 컨테이너 내부 주소로 채워짐

📚 **참고사항**

-

[BD-134]: https://sunwoo1137.atlassian.net/browse/BD-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ