### PR TITLE
[BD-106] feat: 멤버 가용성 등록/수정 UI 구현

### DIFF
--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -31,6 +31,7 @@ import { useUpdateMe } from '@/domain/member/hooks/useUpdateMe';
 import { useWithdraw } from '@/domain/member/hooks/useWithdraw';
 import {
   updateMeSchema,
+  type AvailabilityExceptionRequest,
   type MemberInfoResponse,
   type UpdateMeSchema,
   type WeeklyRuleRequest,
@@ -64,8 +65,12 @@ export function MeContent() {
     onError: (err) => toast.error(err.message || '스케줄 저장에 실패했습니다.'),
   });
 
-  const handleSaveSchedule = (weeklyRules: WeeklyRuleRequest[], note: string) => {
-    updateAvailabilityMutation.mutate({ weeklyRules, note });
+  const handleSaveSchedule = (
+    weeklyRules: WeeklyRuleRequest[],
+    note: string,
+    exceptions: AvailabilityExceptionRequest[],
+  ) => {
+    updateAvailabilityMutation.mutate({ weeklyRules, exceptions, note });
   };
 
   const logoutMutation = useLogout({

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { cn } from '@/lib/cn';
+
+const DOW = ['일', '월', '화', '수', '목', '금', '토'];
+
+function pad(n: number) {
+  return String(n).padStart(2, '0');
+}
+
+function parseDate(s: string): { y: number; mo: number; d: number } | null {
+  if (!s) return null;
+  const m = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!m) return null;
+  return { y: Number(m[1]), mo: Number(m[2]), d: Number(m[3]) };
+}
+
+function fmtDate(y: number, mo: number, d: number): string {
+  return `${y}-${pad(mo)}-${pad(d)}`;
+}
+
+type Props = {
+  value: string;
+  onChange: (v: string) => void;
+  min?: string;
+  max?: string;
+  placeholder?: string;
+  className?: string;
+};
+
+export function DatePicker({
+  value,
+  onChange,
+  min,
+  max,
+  placeholder = '날짜 선택',
+  className,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const parsed = parseDate(value);
+  const today = new Date();
+  const todayStr = fmtDate(today.getFullYear(), today.getMonth() + 1, today.getDate());
+
+  const [viewYear, setViewYear] = useState(parsed?.y ?? today.getFullYear());
+  const [viewMonth, setViewMonth] = useState(parsed?.mo ?? today.getMonth() + 1);
+
+  useEffect(() => {
+    if (open) {
+      const p = parseDate(value);
+      const t = new Date();
+      setViewYear(p?.y ?? t.getFullYear());
+      setViewMonth(p?.mo ?? t.getMonth() + 1);
+    }
+  }, [open, value]);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      const popup = document.getElementById('date-picker-popup');
+      if (popup?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [open]);
+
+  const handleOpen = () => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPos({ top: rect.bottom + 4, left: rect.left });
+    }
+    setOpen((v) => !v);
+  };
+
+  const navMonth = (dir: number) => {
+    let mo = viewMonth + dir;
+    let y = viewYear;
+    if (mo > 12) {
+      mo = 1;
+      y += 1;
+    }
+    if (mo < 1) {
+      mo = 12;
+      y -= 1;
+    }
+    setViewYear(y);
+    setViewMonth(mo);
+  };
+
+  const pick = (y: number, mo: number, d: number) => {
+    onChange(fmtDate(y, mo, d));
+    setOpen(false);
+  };
+
+  const firstDow = new Date(viewYear, viewMonth - 1, 1).getDay();
+  const daysInMonth = new Date(viewYear, viewMonth, 0).getDate();
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < firstDow; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const displayLabel = parsed ? `${parsed.y}.${pad(parsed.mo)}.${pad(parsed.d)}` : placeholder;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={handleOpen}
+        className={cn(
+          'border-border bg-surface flex w-full items-center justify-between rounded-md border px-2 py-1.5 text-[12px]',
+          parsed ? 'text-[#d1d5db]' : 'text-foreground-muted',
+          className,
+        )}
+      >
+        <span>{displayLabel}</span>
+        <CalendarDays className="text-foreground-muted h-3.5 w-3.5 shrink-0" />
+      </button>
+
+      {open && pos && (
+        <div
+          id="date-picker-popup"
+          className="bg-card border-border fixed z-[200] w-60 rounded-lg border p-3 shadow-2xl"
+          style={{ top: pos.top, left: pos.left }}
+        >
+          <div className="mb-2 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => navMonth(-1)}
+              className="text-foreground-sub hover:text-foreground p-1"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <span className="text-foreground text-[12px] font-semibold">
+              {viewYear}년 {viewMonth}월
+            </span>
+            <button
+              type="button"
+              onClick={() => navMonth(1)}
+              className="text-foreground-sub hover:text-foreground p-1"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="mb-1 grid grid-cols-7">
+            {DOW.map((label, i) => (
+              <div
+                key={label}
+                className={cn(
+                  'py-0.5 text-center text-[10px] font-medium',
+                  i === 0 ? 'text-red-400' : i === 6 ? 'text-blue-400' : 'text-foreground-muted',
+                )}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7">
+            {cells.map((d, idx) => {
+              if (d === null) return <div key={`p-${idx}`} className="aspect-square" />;
+              const dateStr = fmtDate(viewYear, viewMonth, d);
+              const isSelected = dateStr === value;
+              const isToday = dateStr === todayStr;
+              const isDisabled = (min && dateStr < min) || (max && dateStr > max);
+              const dow = (firstDow + d - 1) % 7;
+
+              return (
+                <button
+                  key={d}
+                  type="button"
+                  disabled={!!isDisabled}
+                  onClick={() => pick(viewYear, viewMonth, d)}
+                  className={cn(
+                    'flex aspect-square items-center justify-center rounded-md text-[11px] transition-colors',
+                    isSelected && 'bg-[#d1d5db] font-bold text-black',
+                    !isSelected && isToday && 'font-bold text-[#d1d5db]',
+                    !isSelected &&
+                      !isToday &&
+                      (dow === 0
+                        ? 'text-red-400'
+                        : dow === 6
+                          ? 'text-blue-400'
+                          : 'text-foreground'),
+                    !isSelected && !isDisabled && 'hover:bg-white/10',
+                    isDisabled && 'cursor-not-allowed opacity-30',
+                  )}
+                >
+                  {d}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/domain/member/components/ScheduleManagerModal.client.tsx
+++ b/src/domain/member/components/ScheduleManagerModal.client.tsx
@@ -1,16 +1,22 @@
 'use client';
 
-import { addDays, format, startOfWeek } from 'date-fns';
-import { X } from 'lucide-react';
+import { format } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
+import { Plus, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { KST } from '@/lib/date';
 import { cn } from '@/lib/cn';
-import { toZonedTime } from 'date-fns-tz';
 
-import type { DayOfWeek, MemberAvailabilityResponse, WeeklyRuleRequest } from '../types';
+import type {
+  AvailabilityExceptionRequest,
+  AvailabilityKind,
+  DayOfWeek,
+  MemberAvailabilityResponse,
+  WeeklyRuleRequest,
+} from '../types';
 
 const DAY_OF_WEEK_KEYS: DayOfWeek[] = [
   'MONDAY',
@@ -23,12 +29,10 @@ const DAY_OF_WEEK_KEYS: DayOfWeek[] = [
 ];
 const DAY_SHORT = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 
-// 모달 표시 범위: 9:00(slot 18) ~ 22:00(slot 44)
 const START_SLOT = 18;
 const END_SLOT = 44;
-const SLOT_COUNT = END_SLOT - START_SLOT; // 26슬롯
-
-const CELL_HEIGHT = 22; // px
+const SLOT_COUNT = END_SLOT - START_SLOT;
+const CELL_HEIGHT = 22;
 
 function slotToTimeLabel(slot: number): string {
   const h = Math.floor(slot / 2);
@@ -36,7 +40,19 @@ function slotToTimeLabel(slot: number): string {
   return `${h}:${m}`;
 }
 
-/** [dayIdx][slotIdx] = selected? */
+function timeToSlot(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return (h ?? 0) * 2 + ((m ?? 0) >= 30 ? 1 : 0);
+}
+
+function slotToTime(slot: number): string {
+  const h = Math.floor(slot / 2)
+    .toString()
+    .padStart(2, '0');
+  const m = slot % 2 === 0 ? '00' : '30';
+  return `${h}:${m}`;
+}
+
 type GridState = boolean[][];
 
 function emptyGrid(): GridState {
@@ -47,19 +63,9 @@ function availabilityToGrid(availability: MemberAvailabilityResponse | undefined
   const grid = emptyGrid();
   if (!availability) return grid;
 
-  const now = toZonedTime(new Date(), KST);
-  const monday = startOfWeek(now, { weekStartsOn: 1 });
-  const weekDates = Array.from({ length: 7 }, (_, i) => addDays(monday, i));
-  const weekDateStrs = weekDates.map((d) => format(d, 'yyyy-MM-dd'));
-
   for (const rule of availability.weeklyRules) {
     const dayIdx = DAY_OF_WEEK_KEYS.indexOf(rule.dayOfWeek);
     if (dayIdx === -1) continue;
-    const dateStr = weekDateStrs[dayIdx];
-    if (!dateStr) continue;
-    if (rule.effectiveTo && dateStr > rule.effectiveTo) continue;
-    if (dateStr < rule.effectiveFrom) continue;
-
     for (let s = rule.startSlot; s < rule.endSlot; s++) {
       const idx = s - START_SLOT;
       if (idx >= 0 && idx < SLOT_COUNT) grid[dayIdx]![idx] = true;
@@ -68,18 +74,16 @@ function availabilityToGrid(availability: MemberAvailabilityResponse | undefined
   return grid;
 }
 
-function gridToWeeklyRules(grid: GridState): WeeklyRuleRequest[] {
+function gridToWeeklyRules(
+  grid: GridState,
+  effectiveFrom: string,
+  effectiveTo: string,
+): WeeklyRuleRequest[] {
   const rules: WeeklyRuleRequest[] = [];
-  const now = toZonedTime(new Date(), KST);
-  const monday = startOfWeek(now, { weekStartsOn: 1 });
-
   for (let d = 0; d < 7; d++) {
     const dayOfWeek = DAY_OF_WEEK_KEYS[d];
     if (!dayOfWeek) continue;
-    const dayDate = addDays(monday, d);
-    const effectiveFrom = format(dayDate, 'yyyy-MM-dd');
     const daySlots = grid[d]!;
-
     let i = 0;
     while (i < SLOT_COUNT) {
       if (daySlots[i]) {
@@ -90,6 +94,7 @@ function gridToWeeklyRules(grid: GridState): WeeklyRuleRequest[] {
           startSlot: start + START_SLOT,
           endSlot: i + START_SLOT,
           effectiveFrom,
+          effectiveTo: effectiveTo || undefined,
         });
       } else {
         i++;
@@ -107,30 +112,52 @@ type Props = {
   open: boolean;
   onClose: () => void;
   availability: MemberAvailabilityResponse | undefined;
-  onSave: (weeklyRules: WeeklyRuleRequest[], note: string) => void;
+  onSave: (
+    weeklyRules: WeeklyRuleRequest[],
+    note: string,
+    exceptions: AvailabilityExceptionRequest[],
+  ) => void;
   isSaving?: boolean;
 };
 
 export function ScheduleManagerModal({ open, onClose, availability, onSave, isSaving }: Props) {
-  const [step, setStep] = useState<1 | 2>(1);
+  const today = format(toZonedTime(new Date(), KST), 'yyyy-MM-dd');
+
+  const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
+  const [effectiveFrom, setEffectiveFrom] = useState(today);
+  const [effectiveTo, setEffectiveTo] = useState('');
   const [grid, setGrid] = useState<GridState>(emptyGrid);
+  const [exceptions, setExceptions] = useState<AvailabilityExceptionRequest[]>([]);
   const [note, setNote] = useState('');
 
-  // 드래그 상태
+  const [newExcDate, setNewExcDate] = useState('');
+  const [newExcKind, setNewExcKind] = useState<AvailabilityKind>('BLOCKED');
+  const [newExcAllDay, setNewExcAllDay] = useState(true);
+  const [newExcStartTime, setNewExcStartTime] = useState('09:00');
+  const [newExcEndTime, setNewExcEndTime] = useState('18:00');
+
   const dragState = useRef<{
     active: boolean;
     dayIdx: number;
-    painting: boolean; // true=선택, false=해제
-    startSlot: number;
+    painting: boolean;
   } | null>(null);
 
   useEffect(() => {
     if (open) {
       setStep(1);
+      const firstRule = availability?.weeklyRules[0];
+      setEffectiveFrom(firstRule?.effectiveFrom ?? today);
+      setEffectiveTo(firstRule?.effectiveTo ?? '');
       setGrid(availabilityToGrid(availability));
+      setExceptions(availability?.exceptions ?? []);
       setNote(availability?.note ?? '');
+      setNewExcDate('');
+      setNewExcKind('BLOCKED');
+      setNewExcAllDay(true);
+      setNewExcStartTime('09:00');
+      setNewExcEndTime('18:00');
     }
-  }, [open, availability]);
+  }, [open, availability, today]);
 
   const toggleSlot = useCallback((dayIdx: number, slotIdx: number, paint: boolean) => {
     setGrid((prev) => {
@@ -142,7 +169,7 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
 
   const handlePointerDown = (dayIdx: number, slotIdx: number) => {
     const painting = !grid[dayIdx]![slotIdx];
-    dragState.current = { active: true, dayIdx, painting, startSlot: slotIdx };
+    dragState.current = { active: true, dayIdx, painting };
     toggleSlot(dayIdx, slotIdx, painting);
   };
 
@@ -155,13 +182,21 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
     if (dragState.current) dragState.current.active = false;
   };
 
-  const handleReset = () => setGrid(emptyGrid());
-
-  const handleNext = () => setStep(2);
+  const handleAddException = () => {
+    if (!newExcDate) return;
+    const exc: AvailabilityExceptionRequest = {
+      date: newExcDate,
+      kind: newExcKind,
+      ...(newExcAllDay
+        ? {}
+        : { startSlot: timeToSlot(newExcStartTime), endSlot: timeToSlot(newExcEndTime) }),
+    };
+    setExceptions((prev) => [...prev.filter((e) => e.date !== newExcDate), exc]);
+    setNewExcDate('');
+  };
 
   const handleSave = () => {
-    const rules = gridToWeeklyRules(grid);
-    onSave(rules, note);
+    onSave(gridToWeeklyRules(grid, effectiveFrom, effectiveTo), note, exceptions);
   };
 
   if (!open) return null;
@@ -179,9 +214,8 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
         className="bg-card relative mx-4 flex w-full max-w-lg flex-col overflow-hidden rounded-xl shadow-xl"
         style={{ maxHeight: '90vh' }}
       >
-        {/* 헤더 — 고정 */}
+        {/* 헤더 */}
         <div className="shrink-0 px-5 pt-5">
-          {/* 닫기 버튼 */}
           <button
             type="button"
             onClick={onClose}
@@ -190,17 +224,64 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
           >
             <X className="h-5 w-5" />
           </button>
-
-          {/* 제목 */}
           <h3 className="text-foreground mb-1 text-[17px] font-bold">
             나의 스케줄 관리{' '}
-            <span className="text-foreground-muted text-[13px] font-normal">({step}/2)</span>
+            <span className="text-foreground-muted text-caption font-normal">({step}/4)</span>
           </h3>
         </div>
 
-        {step === 1 ? (
+        {/* Step 1: 기간 선택 */}
+        {step === 1 && (
           <>
-            {/* 설명 + 초기화 — 고정 */}
+            <div className="flex-1 overflow-y-auto px-5 pt-1 pb-2">
+              <p className="text-foreground-sub mb-4 text-[12px]">
+                이 스케줄이 적용될 기간을 선택해주세요
+              </p>
+              <div className="space-y-3">
+                <div className="grid grid-cols-[64px_1fr] items-center gap-3">
+                  <span className="text-foreground-sub text-[13px]">시작일</span>
+                  <input
+                    type="date"
+                    value={effectiveFrom}
+                    min={today}
+                    onChange={(e) => setEffectiveFrom(e.target.value)}
+                    className="border-border bg-surface text-foreground rounded-md border px-3 py-2 text-[13px]"
+                  />
+                </div>
+                <div className="grid grid-cols-[64px_1fr] items-center gap-3">
+                  <span className="text-foreground-sub text-[13px]">종료일</span>
+                  <input
+                    type="date"
+                    value={effectiveTo}
+                    min={effectiveFrom || today}
+                    onChange={(e) => setEffectiveTo(e.target.value)}
+                    className="border-border bg-surface text-foreground rounded-md border px-3 py-2 text-[13px]"
+                  />
+                </div>
+                <p className="text-foreground-muted text-micro">
+                  {effectiveTo
+                    ? `* ${effectiveFrom} ~ ${effectiveTo} 기간에 적용됩니다`
+                    : '* 종료일 미입력 시 무기한 적용됩니다'}
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 justify-end px-5 pt-3 pb-5">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setStep(2)}
+                disabled={!effectiveFrom}
+                className="rounded-[5px]"
+              >
+                다음
+              </Button>
+            </div>
+          </>
+        )}
+
+        {/* Step 2: 주간 타임테이블 */}
+        {step === 2 && (
+          <>
             <div className="shrink-0 px-5 pt-1">
               <p className="text-foreground-sub mb-3 text-[12px]">
                 주간 가능 시간대를 모두 채워주세요
@@ -208,19 +289,17 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               <div className="mb-2 flex justify-end">
                 <button
                   type="button"
-                  onClick={handleReset}
-                  className="text-foreground-sub border-border rounded border px-2 py-0.5 text-[11px]"
+                  onClick={() => setGrid(emptyGrid())}
+                  className="text-foreground-sub border-border text-micro rounded border px-2 py-0.5"
                 >
                   스케줄 초기화
                 </button>
               </div>
             </div>
 
-            {/* 선택 그리드 — 내부 스크롤 */}
             <div className="min-h-0 flex-1 overflow-y-auto px-5">
               <div className="overflow-x-auto select-none" onPointerLeave={handlePointerUp}>
                 <div className="min-w-[320px]">
-                  {/* 요일 헤더 */}
                   <div className="grid" style={{ gridTemplateColumns: '36px repeat(7, 1fr)' }}>
                     <div />
                     {DAY_SHORT.map((day, i) => (
@@ -230,12 +309,10 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                     ))}
                   </div>
 
-                  {/* 슬롯 그리드 */}
                   <div
                     className="relative grid"
                     style={{ gridTemplateColumns: '36px repeat(7, 1fr)' }}
                   >
-                    {/* 시간 레이블 */}
                     <div className="relative">
                       {hourSlots.map((slotIdx) => (
                         <span
@@ -258,14 +335,12 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                       <div style={{ height: SLOT_COUNT * CELL_HEIGHT }} />
                     </div>
 
-                    {/* 요일별 슬롯 */}
                     {Array.from({ length: 7 }, (_, dayIdx) => (
                       <div
                         key={dayIdx}
                         className="border-border relative border-l"
                         style={{ height: SLOT_COUNT * CELL_HEIGHT }}
                       >
-                        {/* 수평 구분선 */}
                         {hourSlots.map((slotIdx) => (
                           <div
                             key={slotIdx}
@@ -273,8 +348,6 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                             style={{ top: slotIdx * CELL_HEIGHT }}
                           />
                         ))}
-
-                        {/* 슬롯 셀 */}
                         {Array.from({ length: SLOT_COUNT }, (_, slotIdx) => (
                           <div
                             key={slotIdx}
@@ -282,10 +355,7 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                               'absolute right-0 left-0 cursor-pointer transition-colors',
                               grid[dayIdx]![slotIdx] ? 'bg-[#e8856a]' : 'hover:bg-[#e8856a]/20',
                             )}
-                            style={{
-                              top: slotIdx * CELL_HEIGHT,
-                              height: CELL_HEIGHT,
-                            }}
+                            style={{ top: slotIdx * CELL_HEIGHT, height: CELL_HEIGHT }}
                             onPointerDown={(e) => {
                               e.preventDefault();
                               handlePointerDown(dayIdx, slotIdx);
@@ -300,19 +370,24 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               </div>
             </div>
 
-            {/* 푸터 — 고정 */}
             <div className="shrink-0 px-5 pb-5">
-              <p className="text-foreground-muted mt-2.5 text-[11px]">
-                * 셀 1칸 당 30분 단위입니다
-              </p>
-              <p className="text-foreground-muted text-[11px]">
+              <p className="text-foreground-muted text-micro mt-2.5">* 셀 1칸 당 30분 단위입니다</p>
+              <p className="text-foreground-muted text-micro">
                 * 입력한 주간 가능 시간대는 향후 전 주 동일 적용됩니다
               </p>
-              <div className="mt-4 flex justify-end">
+              <div className="mt-4 flex justify-between">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setStep(1)}
+                  className="rounded-[5px]"
+                >
+                  이전
+                </Button>
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={handleNext}
+                  onClick={() => setStep(3)}
                   disabled={!hasAnySelected(grid)}
                   className="rounded-[5px]"
                 >
@@ -321,11 +396,163 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               </div>
             </div>
           </>
-        ) : (
+        )}
+
+        {/* Step 3: 예외 날짜 */}
+        {step === 3 && (
+          <>
+            <div className="flex-1 space-y-4 overflow-y-auto px-5 pt-1 pb-2">
+              <p className="text-foreground-sub text-[12px]">
+                위 규칙과 다른 날짜가 있으면 추가해주세요 (선택)
+              </p>
+
+              {/* 추가 폼 */}
+              <div className="border-border space-y-3 rounded-md border p-3">
+                <div className="grid grid-cols-[52px_1fr] items-center gap-2">
+                  <span className="text-foreground-sub text-[12px]">날짜</span>
+                  <input
+                    type="date"
+                    value={newExcDate}
+                    min={effectiveFrom}
+                    max={effectiveTo || undefined}
+                    onChange={(e) => setNewExcDate(e.target.value)}
+                    className="border-border bg-surface text-foreground rounded-md border px-2 py-1.5 text-[12px]"
+                  />
+                </div>
+                <div className="grid grid-cols-[52px_1fr] items-center gap-2">
+                  <span className="text-foreground-sub text-[12px]">종류</span>
+                  <div className="flex gap-4">
+                    {(['AVAILABLE', 'BLOCKED'] as AvailabilityKind[]).map((k) => (
+                      <label key={k} className="flex cursor-pointer items-center gap-1.5">
+                        <input
+                          type="radio"
+                          name="excKind"
+                          value={k}
+                          checked={newExcKind === k}
+                          onChange={() => setNewExcKind(k)}
+                          className="accent-[#e8856a]"
+                        />
+                        <span className="text-foreground text-[12px]">
+                          {k === 'AVAILABLE' ? '가능' : '불가'}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+                <div className="grid grid-cols-[52px_1fr] items-center gap-2">
+                  <span className="text-foreground-sub text-[12px]">시간</span>
+                  <label className="flex cursor-pointer items-center gap-1.5">
+                    <input
+                      type="checkbox"
+                      checked={newExcAllDay}
+                      onChange={(e) => setNewExcAllDay(e.target.checked)}
+                      className="accent-[#e8856a]"
+                    />
+                    <span className="text-foreground text-[12px]">하루 종일</span>
+                  </label>
+                </div>
+                {!newExcAllDay && (
+                  <div className="grid grid-cols-[52px_1fr] items-center gap-2">
+                    <div />
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="time"
+                        value={newExcStartTime}
+                        step={1800}
+                        onChange={(e) => setNewExcStartTime(e.target.value)}
+                        className="border-border bg-surface text-foreground rounded-md border px-2 py-1.5 text-[12px]"
+                      />
+                      <span className="text-foreground-muted text-[12px]">~</span>
+                      <input
+                        type="time"
+                        value={newExcEndTime}
+                        step={1800}
+                        onChange={(e) => setNewExcEndTime(e.target.value)}
+                        className="border-border bg-surface text-foreground rounded-md border px-2 py-1.5 text-[12px]"
+                      />
+                    </div>
+                  </div>
+                )}
+                <div className="flex justify-end">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleAddException}
+                    disabled={!newExcDate}
+                    className="gap-1 rounded-[5px]"
+                  >
+                    <Plus className="h-3 w-3" />
+                    추가
+                  </Button>
+                </div>
+              </div>
+
+              {/* 예외 목록 */}
+              {exceptions.length > 0 && (
+                <ul className="space-y-2">
+                  {exceptions.map((exc) => (
+                    <li
+                      key={exc.date}
+                      className="border-border flex items-center justify-between rounded-md border px-3 py-2"
+                    >
+                      <div>
+                        <span className="text-foreground text-[13px] font-medium">{exc.date}</span>
+                        <span
+                          className={cn(
+                            'ml-2 text-[11px]',
+                            exc.kind === 'AVAILABLE' ? 'text-[#e8856a]' : 'text-foreground-muted',
+                          )}
+                        >
+                          {exc.kind === 'AVAILABLE' ? '가능' : '불가'}
+                        </span>
+                        {exc.startSlot != null && exc.endSlot != null && (
+                          <span className="text-foreground-muted ml-1 text-[11px]">
+                            {slotToTime(exc.startSlot)}~{slotToTime(exc.endSlot)}
+                          </span>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setExceptions((prev) => prev.filter((e) => e.date !== exc.date))
+                        }
+                        className="text-foreground-muted hover:text-foreground"
+                        aria-label="삭제"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className="flex shrink-0 justify-between px-5 pt-3 pb-5">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setStep(2)}
+                className="rounded-[5px]"
+              >
+                이전
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setStep(4)}
+                className="rounded-[5px]"
+              >
+                다음
+              </Button>
+            </div>
+          </>
+        )}
+
+        {/* Step 4: 특이사항 */}
+        {step === 4 && (
           <>
             <div className="px-5 pb-5">
               <p className="text-foreground-sub mb-3 text-[12px]">특이사항을 적어주세요</p>
-
               <Textarea
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
@@ -333,8 +560,15 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                 className="h-40 resize-none"
                 maxLength={500}
               />
-
-              <div className="mt-4 flex justify-end">
+              <div className="mt-4 flex justify-between">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setStep(3)}
+                  className="rounded-[5px]"
+                >
+                  이전
+                </Button>
                 <Button
                   variant="secondary"
                   size="sm"

--- a/src/domain/member/components/ScheduleManagerModal.client.tsx
+++ b/src/domain/member/components/ScheduleManagerModal.client.tsx
@@ -6,6 +6,7 @@ import { Check, Plus, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { DatePicker } from '@/components/ui/date-picker';
 import { Textarea } from '@/components/ui/textarea';
 import { KST } from '@/lib/date';
 import { cn } from '@/lib/cn';
@@ -240,22 +241,20 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               <div className="space-y-3">
                 <div className="grid grid-cols-[64px_1fr] items-center gap-3">
                   <span className="text-foreground-sub text-[13px]">시작일</span>
-                  <input
-                    type="date"
+                  <DatePicker
                     value={effectiveFrom}
                     min={today}
-                    onChange={(e) => setEffectiveFrom(e.target.value)}
-                    className="border-border bg-surface rounded-md border px-3 py-2 text-[13px] text-[#d1d5db]"
+                    onChange={setEffectiveFrom}
+                    placeholder="시작일 선택"
                   />
                 </div>
                 <div className="grid grid-cols-[64px_1fr] items-center gap-3">
                   <span className="text-foreground-sub text-[13px]">종료일</span>
-                  <input
-                    type="date"
+                  <DatePicker
                     value={effectiveTo}
                     min={effectiveFrom || today}
-                    onChange={(e) => setEffectiveTo(e.target.value)}
-                    className="border-border bg-surface rounded-md border px-3 py-2 text-[13px] text-[#d1d5db]"
+                    onChange={setEffectiveTo}
+                    placeholder="종료일 선택 (선택)"
                   />
                 </div>
                 <p className="text-foreground-muted text-micro">
@@ -410,13 +409,12 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               <div className="border-border space-y-3 rounded-md border p-3">
                 <div className="grid grid-cols-[52px_1fr] items-center gap-2">
                   <span className="text-foreground-sub text-[12px]">날짜</span>
-                  <input
-                    type="date"
+                  <DatePicker
                     value={newExcDate}
                     min={effectiveFrom}
                     max={effectiveTo || undefined}
-                    onChange={(e) => setNewExcDate(e.target.value)}
-                    className="border-border bg-surface rounded-md border px-2 py-1.5 text-[12px] text-[#d1d5db]"
+                    onChange={setNewExcDate}
+                    placeholder="날짜 선택"
                   />
                 </div>
                 <div className="grid grid-cols-[52px_1fr] items-center gap-2">

--- a/src/domain/member/components/ScheduleManagerModal.client.tsx
+++ b/src/domain/member/components/ScheduleManagerModal.client.tsx
@@ -2,7 +2,7 @@
 
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
-import { Plus, Trash2, X } from 'lucide-react';
+import { Check, Plus, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -245,7 +245,7 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                     value={effectiveFrom}
                     min={today}
                     onChange={(e) => setEffectiveFrom(e.target.value)}
-                    className="border-border bg-surface text-foreground rounded-md border px-3 py-2 text-[13px]"
+                    className="border-border bg-surface rounded-md border px-3 py-2 text-[13px] text-[#d1d5db]"
                   />
                 </div>
                 <div className="grid grid-cols-[64px_1fr] items-center gap-3">
@@ -255,7 +255,7 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                     value={effectiveTo}
                     min={effectiveFrom || today}
                     onChange={(e) => setEffectiveTo(e.target.value)}
-                    className="border-border bg-surface text-foreground rounded-md border px-3 py-2 text-[13px]"
+                    className="border-border bg-surface rounded-md border px-3 py-2 text-[13px] text-[#d1d5db]"
                   />
                 </div>
                 <p className="text-foreground-muted text-micro">
@@ -416,7 +416,7 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                     min={effectiveFrom}
                     max={effectiveTo || undefined}
                     onChange={(e) => setNewExcDate(e.target.value)}
-                    className="border-border bg-surface text-foreground rounded-md border px-2 py-1.5 text-[12px]"
+                    className="border-border bg-surface rounded-md border px-2 py-1.5 text-[12px] text-[#d1d5db]"
                   />
                 </div>
                 <div className="grid grid-cols-[52px_1fr] items-center gap-2">
@@ -430,9 +430,24 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                           value={k}
                           checked={newExcKind === k}
                           onChange={() => setNewExcKind(k)}
-                          className="accent-[#e8856a]"
+                          className="sr-only"
                         />
-                        <span className="text-foreground text-[12px]">
+                        <span
+                          className={cn(
+                            'flex h-4 w-4 items-center justify-center rounded-full border-2',
+                            newExcKind === k ? 'border-[#d1d5db]' : 'border-[#6b7280]',
+                          )}
+                        >
+                          {newExcKind === k && (
+                            <span className="h-2 w-2 rounded-full bg-[#d1d5db]" />
+                          )}
+                        </span>
+                        <span
+                          className={cn(
+                            'text-[12px]',
+                            newExcKind === k ? 'text-[#d1d5db]' : 'text-[#6b7280]',
+                          )}
+                        >
                           {k === 'AVAILABLE' ? '가능' : '불가'}
                         </span>
                       </label>
@@ -446,30 +461,63 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                       type="checkbox"
                       checked={newExcAllDay}
                       onChange={(e) => setNewExcAllDay(e.target.checked)}
-                      className="accent-[#e8856a]"
+                      className="sr-only"
                     />
-                    <span className="text-foreground text-[12px]">하루 종일</span>
+                    <span
+                      className={cn(
+                        'flex h-4 w-4 items-center justify-center rounded border-2',
+                        newExcAllDay ? 'border-[#d1d5db] bg-[#d1d5db]' : 'border-[#6b7280]',
+                      )}
+                    >
+                      {newExcAllDay && <Check className="h-3 w-3 text-black" strokeWidth={3} />}
+                    </span>
+                    <span
+                      className={cn(
+                        'text-[12px]',
+                        newExcAllDay ? 'text-[#d1d5db]' : 'text-foreground',
+                      )}
+                    >
+                      하루 종일
+                    </span>
                   </label>
                 </div>
                 {!newExcAllDay && (
                   <div className="grid grid-cols-[52px_1fr] items-center gap-2">
                     <div />
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="time"
-                        value={newExcStartTime}
-                        step={1800}
-                        onChange={(e) => setNewExcStartTime(e.target.value)}
-                        className="border-border bg-surface text-foreground rounded-md border px-2 py-1.5 text-[12px]"
-                      />
-                      <span className="text-foreground-muted text-[12px]">~</span>
-                      <input
-                        type="time"
-                        value={newExcEndTime}
-                        step={1800}
-                        onChange={(e) => setNewExcEndTime(e.target.value)}
-                        className="border-border bg-surface text-foreground rounded-md border px-2 py-1.5 text-[12px]"
-                      />
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="time"
+                          value={newExcStartTime}
+                          min="09:00"
+                          max="22:00"
+                          step={1800}
+                          onChange={(e) => setNewExcStartTime(e.target.value)}
+                          className="border-border bg-surface rounded-md border px-2 py-1.5 text-[12px] text-[#d1d5db]"
+                        />
+                        <span className="text-foreground-muted text-[12px]">~</span>
+                        <input
+                          type="time"
+                          value={newExcEndTime}
+                          min="09:00"
+                          max="22:00"
+                          step={1800}
+                          onChange={(e) => setNewExcEndTime(e.target.value)}
+                          className="border-border bg-surface rounded-md border px-2 py-1.5 text-[12px] text-[#d1d5db]"
+                        />
+                      </div>
+                      <p className="text-foreground-muted text-[10px]">
+                        * 09:00~22:00 범위 내에서만 선택 가능합니다
+                      </p>
+                      {(newExcStartTime < '09:00' ||
+                        newExcEndTime > '22:00' ||
+                        newExcStartTime >= newExcEndTime) && (
+                        <p className="text-[10px] text-red-400">
+                          {newExcStartTime >= newExcEndTime
+                            ? '* 시작 시간은 종료 시간보다 빨라야 합니다'
+                            : '* 09:00~22:00 범위를 벗어난 시간입니다'}
+                        </p>
+                      )}
                     </div>
                   </div>
                 )}
@@ -478,7 +526,13 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                     variant="secondary"
                     size="sm"
                     onClick={handleAddException}
-                    disabled={!newExcDate}
+                    disabled={
+                      !newExcDate ||
+                      (!newExcAllDay &&
+                        (newExcStartTime < '09:00' ||
+                          newExcEndTime > '22:00' ||
+                          newExcStartTime >= newExcEndTime))
+                    }
                     className="gap-1 rounded-[5px]"
                   >
                     <Plus className="h-3 w-3" />
@@ -500,7 +554,7 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                         <span
                           className={cn(
                             'ml-2 text-[11px]',
-                            exc.kind === 'AVAILABLE' ? 'text-[#e8856a]' : 'text-foreground-muted',
+                            exc.kind === 'AVAILABLE' ? 'text-[#d1d5db]' : 'text-foreground-muted',
                           )}
                         >
                           {exc.kind === 'AVAILABLE' ? '가능' : '불가'}
@@ -556,11 +610,12 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               <Textarea
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
-                placeholder="평일 저녁만, 주말은 1시 이후부터 가능합니다."
-                className="h-40 resize-none"
+                placeholder="ex) 평일 저녁만, 주말은 1시 이후부터 가능합니다."
+                className="placeholder:text-foreground-muted focus-visible:border-foreground-muted h-40 resize-none focus-visible:ring-0 focus-visible:ring-offset-0"
                 maxLength={500}
               />
-              <div className="mt-4 flex justify-between">
+              <p className="text-foreground-muted mt-1 text-right text-[12px]">(500자 이내)</p>
+              <div className="mt-3 flex justify-between">
                 <Button
                   variant="ghost"
                   size="sm"

--- a/src/domain/member/components/WeeklyTimetable.client.tsx
+++ b/src/domain/member/components/WeeklyTimetable.client.tsx
@@ -4,7 +4,7 @@ import { addDays, format, startOfWeek } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { toZonedTime } from 'date-fns-tz';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import type { PerformanceListItemResponse } from '@/domain/performance/types';
 import type { PracticeListItemResponse } from '@/domain/practice/types';
@@ -112,6 +112,14 @@ type TimetableEvent = {
   dayIdx: number;
 };
 
+type MockEvent = {
+  id: number;
+  type: 'practice' | 'performance';
+  dayIdx: number;
+  startSlot: number;
+  slotSpan: number;
+};
+
 function buildEvents(
   practices: PracticeListItemResponse[],
   performances: PerformanceListItemResponse[],
@@ -172,6 +180,33 @@ export function WeeklyTimetable({
   onManageSchedule,
 }: Props) {
   const [weekOffset, setWeekOffset] = useState(0);
+  const [paintPractice, setPaintPractice] = useState(false);
+  const [paintPerformance, setPaintPerformance] = useState(false);
+  const [mockEvents, setMockEvents] = useState<MockEvent[]>([]);
+  const mockIdRef = useRef(0);
+
+  const handleCellClick = (dayIdx: number, e: React.MouseEvent<HTMLDivElement>) => {
+    if (!paintPractice && !paintPerformance) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const slot = Math.floor((e.clientY - rect.top) / CELL_HEIGHT);
+    if (slot < 0 || slot >= SLOT_COUNT) return;
+    setMockEvents((prev) => {
+      let next = [...prev];
+      for (const type of (['practice', 'performance'] as const).filter(
+        (t) => (t === 'practice' && paintPractice) || (t === 'performance' && paintPerformance),
+      )) {
+        const existing = next.find(
+          (m) => m.dayIdx === dayIdx && m.startSlot === slot && m.type === type,
+        );
+        if (existing) {
+          next = next.filter((m) => m.id !== existing.id);
+        } else {
+          next = [...next, { id: mockIdRef.current++, type, dayIdx, startSlot: slot, slotSpan: 1 }];
+        }
+      }
+      return next;
+    });
+  };
 
   const now = toZonedTime(new Date(), KST);
   const monday = addDays(startOfWeek(now, { weekStartsOn: 1 }), weekOffset * 7);
@@ -275,8 +310,12 @@ export function WeeklyTimetable({
             {weekDates.map((_, dayIdx) => (
               <div
                 key={dayIdx}
-                className="border-border relative border-r last:border-r-0"
+                className={cn(
+                  'border-border relative border-r last:border-r-0',
+                  paintPractice || paintPerformance ? 'cursor-crosshair' : 'cursor-default',
+                )}
                 style={{ height: SLOT_COUNT * CELL_HEIGHT }}
+                onClick={(e) => handleCellClick(dayIdx, e)}
               >
                 {hourSlots.map((slotIdx) => (
                   <div
@@ -306,11 +345,12 @@ export function WeeklyTimetable({
                   return (
                     <div
                       key={ei}
+                      onClick={(e) => e.stopPropagation()}
                       className={cn(
                         'absolute right-0 left-0 overflow-hidden rounded-sm px-1 py-0.5',
                         ev.type === 'practice'
-                          ? 'bg-[#e8e8c0] text-[#4a4a20]'
-                          : 'bg-[#7a9e8c] text-white',
+                          ? 'bg-[#4ade80]/20 text-[#4ade80]'
+                          : 'bg-[#60a5fa]/20 text-[#60a5fa]',
                       )}
                       style={{ top: clippedStart * CELL_HEIGHT, height }}
                     >
@@ -321,10 +361,60 @@ export function WeeklyTimetable({
                     </div>
                   );
                 })}
+
+                {/* 임시 이벤트 블록 */}
+                {mockEvents
+                  .filter(
+                    (me) =>
+                      me.dayIdx === dayIdx &&
+                      ((me.type === 'practice' && paintPractice) ||
+                        (me.type === 'performance' && paintPerformance)),
+                  )
+                  .map((me) => (
+                    <div
+                      key={me.id}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setMockEvents((prev) => prev.filter((m) => m.id !== me.id));
+                      }}
+                      className={cn(
+                        'absolute right-0 left-0 cursor-pointer overflow-hidden',
+                        me.type === 'practice' ? 'bg-[#4ade80]/60' : 'bg-[#60a5fa]/60',
+                      )}
+                      style={{ top: me.startSlot * CELL_HEIGHT, height: me.slotSpan * CELL_HEIGHT }}
+                    />
+                  ))}
               </div>
             ))}
           </div>
         </div>
+      </div>
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setPaintPractice((v) => !v)}
+          className={cn(
+            'rounded-full border px-3.5 py-1 text-sm font-medium transition-colors',
+            paintPractice
+              ? 'border-[#4ade80] bg-[#4ade80]/10 text-[#4ade80]'
+              : 'border-border text-foreground-muted',
+          )}
+        >
+          합주 표시
+        </button>
+        <button
+          type="button"
+          onClick={() => setPaintPerformance((v) => !v)}
+          className={cn(
+            'rounded-full border px-3.5 py-1 text-sm font-medium transition-colors',
+            paintPerformance
+              ? 'border-[#60a5fa] bg-[#60a5fa]/10 text-[#60a5fa]'
+              : 'border-border text-foreground-muted',
+          )}
+        >
+          공연 표시
+        </button>
       </div>
     </section>
   );

--- a/src/domain/member/components/WeeklyTimetable.client.tsx
+++ b/src/domain/member/components/WeeklyTimetable.client.tsx
@@ -3,6 +3,8 @@
 import { addDays, format, startOfWeek } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { toZonedTime } from 'date-fns-tz';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
 
 import type { PerformanceListItemResponse } from '@/domain/performance/types';
 import type { PracticeListItemResponse } from '@/domain/practice/types';
@@ -42,20 +44,36 @@ function startAtToSlot(startAt: string): number {
 
 function buildAvailabilityMatrix(
   rules: MemberAvailabilityResponse['weeklyRules'],
+  exceptions: MemberAvailabilityResponse['exceptions'],
   weekDates: Date[],
 ): boolean[][] {
   const matrix: boolean[][] = Array.from({ length: 7 }, () =>
     new Array<boolean>(SLOT_COUNT).fill(false),
   );
 
+  const weekDateStrs = weekDates.map((d) => format(d, 'yyyy-MM-dd'));
+
+  // effectiveFrom 이전 날짜는 빈 셀(가능/미설정)로 표시
+  const earliestFrom = rules.reduce<string | null>(
+    (min, r) =>
+      r.effectiveFrom && (min === null || r.effectiveFrom < min) ? r.effectiveFrom : min,
+    null,
+  );
+  if (earliestFrom) {
+    for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
+      const dateStr = weekDateStrs[dayIdx];
+      if (dateStr && dateStr < earliestFrom) matrix[dayIdx]!.fill(true);
+    }
+  }
+
+  // weeklyRules 적용
   for (const rule of rules) {
     const dayIdx = DAY_OF_WEEK_KEYS.indexOf(rule.dayOfWeek);
     if (dayIdx === -1) continue;
-    const weekDate = weekDates[dayIdx];
-    if (!weekDate) continue;
-    const dateStr = format(weekDate, 'yyyy-MM-dd');
+    const dateStr = weekDateStrs[dayIdx];
+    if (!dateStr) continue;
+    if (!rule.effectiveFrom || dateStr < rule.effectiveFrom) continue;
     if (rule.effectiveTo && dateStr > rule.effectiveTo) continue;
-    if (dateStr < rule.effectiveFrom) continue;
 
     const row = matrix[dayIdx]!;
     for (let s = rule.startSlot; s < rule.endSlot; s++) {
@@ -63,6 +81,26 @@ function buildAvailabilityMatrix(
       if (idx >= 0 && idx < SLOT_COUNT) row[idx] = true;
     }
   }
+
+  // exceptions 적용 (weeklyRules 위에 덮어쓰기)
+  for (const exc of exceptions) {
+    const dayIdx = weekDateStrs.indexOf(exc.date);
+    if (dayIdx === -1) continue;
+
+    const row = matrix[dayIdx]!;
+    const isAvailable = exc.kind === 'AVAILABLE';
+    const isAllDay = exc.startSlot == null || exc.endSlot == null || exc.startSlot >= exc.endSlot;
+
+    if (isAllDay) {
+      row.fill(isAvailable);
+    } else {
+      for (let s = exc.startSlot!; s < exc.endSlot!; s++) {
+        const idx = s - START_SLOT;
+        if (idx >= 0 && idx < SLOT_COUNT) row[idx] = isAvailable;
+      }
+    }
+  }
+
   return matrix;
 }
 
@@ -133,8 +171,10 @@ export function WeeklyTimetable({
   performances,
   onManageSchedule,
 }: Props) {
+  const [weekOffset, setWeekOffset] = useState(0);
+
   const now = toZonedTime(new Date(), KST);
-  const monday = startOfWeek(now, { weekStartsOn: 1 });
+  const monday = addDays(startOfWeek(now, { weekStartsOn: 1 }), weekOffset * 7);
   const weekDates: Date[] = Array.from({ length: 7 }, (_, i) => addDays(monday, i));
 
   const weekLabel =
@@ -142,7 +182,11 @@ export function WeeklyTimetable({
     ' ~ ' +
     format(weekDates[6]!, 'MM-dd (EEE)', { locale: ko });
 
-  const availMatrix = buildAvailabilityMatrix(availability?.weeklyRules ?? [], weekDates);
+  const availMatrix = buildAvailabilityMatrix(
+    availability?.weeklyRules ?? [],
+    availability?.exceptions ?? [],
+    weekDates,
+  );
   const events = buildEvents(practices, performances, weekDates);
 
   const eventsByDay: TimetableEvent[][] = Array.from({ length: 7 }, () => []);
@@ -154,12 +198,30 @@ export function WeeklyTimetable({
 
   return (
     <section className="mt-15">
-      <div className="mb-s-3 flex items-center justify-between">
-        <p className="text-foreground-sub text-[13px]">{weekLabel}</p>
+      <div className="mb-s-3 relative flex items-center justify-center">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setWeekOffset((o) => o - 1)}
+            className="text-foreground-sub hover:text-foreground"
+            aria-label="이전 주"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <p className="text-foreground-sub text-sm">{weekLabel}</p>
+          <button
+            type="button"
+            onClick={() => setWeekOffset((o) => o + 1)}
+            className="text-foreground-sub hover:text-foreground"
+            aria-label="다음 주"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
         <button
           type="button"
           onClick={onManageSchedule}
-          className="text-foreground border-border shrink-0 rounded-[5px] border px-3 py-1 text-sm font-medium"
+          className="text-foreground border-border absolute right-0 shrink-0 rounded-[5px] border px-3 py-1 text-sm font-medium"
         >
           나의 스케줄 관리
         </button>
@@ -228,7 +290,7 @@ export function WeeklyTimetable({
                 {buildUnavailableBlocks(availMatrix[dayIdx]!).map((block, bi) => (
                   <div
                     key={bi}
-                    className="bg-surface/70 absolute right-0 left-0"
+                    className="bg-foreground-sub/80 absolute right-0 left-0"
                     style={{
                       top: block.start * CELL_HEIGHT,
                       height: block.length * CELL_HEIGHT,

--- a/src/domain/member/types/req.ts
+++ b/src/domain/member/types/req.ts
@@ -29,7 +29,7 @@ export interface AvailabilityExceptionRequest {
 
 /** API_SPEC §2-8 — 가용성 등록/수정. weeklyRules·exceptions 전체 교체 방식. */
 export interface UpdateMyAvailabilityRequest {
-  weeklyRules?: WeeklyRuleRequest[];
-  exceptions?: AvailabilityExceptionRequest[];
+  weeklyRules: WeeklyRuleRequest[];
+  exceptions: AvailabilityExceptionRequest[];
   note?: string | null;
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-106](https://sunwoo1137.atlassian.net/browse/BD-106)

📌 작업 내용 및 특이사항

- `ScheduleManagerModal`을 4단계 플로우로 재구성
  - **1단계** 기간 선택: `effectiveFrom` (필수) / `effectiveTo` (선택, 미입력 시 무기한)
  - **2단계** 주간 타임테이블: 드래그로 요일별 가능 시간대 선택 (기간이 `weeklyRules`에 반영)
  - **3단계** 예외 날짜: 날짜·종류(가능/불가)·시간(하루종일 or 특정 시간대) 추가/삭제
  - **4단계** 특이사항: 메모 입력
- `UpdateMyAvailabilityRequest`의 `weeklyRules` / `exceptions` 를 스펙 기준 `required`로 수정 (기존 optional → 400 에러 방지)
- 모달 재오픈 시 기존 저장값(기간·예외·메모)을 `weeklyRules[0]` 기반으로 복원
- 각 단계에 이전 버튼 추가

**UI 개선 (추가 커밋)**
- 라디오·체크박스 커스텀 스타일 교체: 선택 시 `#d1d5db`, 미선택 시 `#6b7280`
- date/time 입력 텍스트 색상 `#d1d5db` 통일
- 시간 선택 범위 09:00~22:00 제한 및 범위 이탈 시 빨간 에러 메시지 표시, 추가 버튼 비활성화
- 예외 목록 가능/불가 텍스트 색상 조정
- 특이사항 textarea focus 링 제거 및 placeholder 형식 개선 (`ex) ...`, `(500자 이내)` 안내)
- `DatePicker` 컴포넌트 신규 구현: 날짜 클릭 시 작은 캘린더 팝업으로 선택 (fixed 팝업, min/max 지원)

**시간표 개선 (추가 커밋)**
- 가용성 매트릭스 로직 개선: `effectiveFrom` 이전 날짜 빈 셀 표시, exceptions 적용
- 주간 이동 화살표 추가 및 날짜 레이블 중앙 정렬
- 합주 표시 / 공연 표시 토글 버튼 추가 (독립 on/off)
  - 버튼 활성 시 셀 클릭으로 해당 타입 임시 블록 칠하기 / 다시 클릭 시 제거
  - 버튼 비활성 시 칠한 셀 숨김
  - ⚠️ 합주/공연 표시 버튼 API 연동 예정

📚 참고사항

- `middleware.ts` 변경분은 별도 커밋으로 분리 예정
- 예외 날짜 시간 입력은 30분 단위 (`step={1800}`)

[BD-106]: https://sunwoo1137.atlassian.net/browse/BD-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ