### PR TITLE
[BD-92] feat: 밴드 페이지 UI 개선

### DIFF
--- a/.github/workflows/develop_ci_test.yml
+++ b/.github/workflows/develop_ci_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
 
       - name: Setup pnpm
         # 버전은 package.json 의 "packageManager" 필드(해시 pin) 를 단일 소스로 사용.

--- a/.taskmaster/state.json
+++ b/.taskmaster/state.json
@@ -1,6 +1,6 @@
 {
-  "currentTag": "BD-64-create-performance-ui",
-  "lastSwitched": "2026-06-09T21:24:45.500Z",
+  "currentTag": "BD-92-band-detail-ui",
+  "lastSwitched": "2026-06-12T17:22:40.653Z",
   "branchTagMapping": {},
   "migrationNoticeShown": true
 }

--- a/.taskmaster/tasks/task_001_BD-92-band-detail-ui.md
+++ b/.taskmaster/tasks/task_001_BD-92-band-detail-ui.md
@@ -1,0 +1,21 @@
+# Task ID: 1
+
+**Title:** 밴드 목록 풀스크린 + 상세 카드/바텀시트 전환
+
+**Status:** pending
+
+**Dependencies:** None
+
+**Priority:** high
+
+**Description:** 1. 모바일: BandsListPane 탭 목록을 풀스크린으로 노출 (BandsMobileShell). 밴드 클릭 시 바텀시트로 BandDetailContent 표시.
+2. 데스크탑: 기존 좌측 BandsListPane + 우측 BandDetailContent 카드 유지.
+3. BandsListPane 탐색탭: 기본 useBandList(전체), 검색어 입력 시 useBandSearch(API 검색)로 전환.
+
+**Details:**
+
+No details provided.
+
+**Test Strategy:**
+
+No test strategy provided.

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -5522,7 +5522,7 @@
   "BD-64-create-performance-ui": {
     "tasks": [
       {
-        "id": "1",
+        "id": 1,
         "title": "공연 생성 위저드 Step2 셋리스트 피커 교체",
         "description": "PerformanceCreateWizard의 Step2 '참여 밴드'를 '셋리스트' 단계로 교체. SetlistPickerModal 신규 구현, CreatePerformanceRequest에 setlistMeetingIds 필드 추가, 위저드 submit 로직 업데이트.",
         "details": "",
@@ -5593,6 +5593,34 @@
       "completedCount": 1,
       "tags": [
         "BD-64-create-performance-ui"
+      ],
+      "created": "2026-06-12T17:21:53.211Z",
+      "description": "Tasks for BD-64-create-performance-ui context",
+      "updated": "2026-06-12T17:21:53.211Z"
+    }
+  },
+  "BD-92-band-detail-ui": {
+    "tasks": [
+      {
+        "id": "1",
+        "title": "밴드 목록 풀스크린 + 상세 카드/바텀시트 전환",
+        "description": "1. 모바일: BandsListPane 탭 목록을 풀스크린으로 노출 (BandsMobileShell). 밴드 클릭 시 바텀시트로 BandDetailContent 표시.\n2. 데스크탑: 기존 좌측 BandsListPane + 우측 BandDetailContent 카드 유지.\n3. BandsListPane 탐색탭: 기본 useBandList(전체), 검색어 입력 시 useBandSearch(API 검색)로 전환.",
+        "details": "",
+        "testStrategy": "",
+        "status": "done",
+        "dependencies": [],
+        "priority": "high",
+        "subtasks": [],
+        "updatedAt": "2026-06-12T17:32:03.858Z"
+      }
+    ],
+    "metadata": {
+      "version": "1.0.0",
+      "lastModified": "2026-06-12T17:32:03.858Z",
+      "taskCount": 1,
+      "completedCount": 1,
+      "tags": [
+        "BD-92-band-detail-ui"
       ]
     }
   }

--- a/src/app/(main)/bands/BandsList.client.tsx
+++ b/src/app/(main)/bands/BandsList.client.tsx
@@ -49,7 +49,7 @@ export function BandsList() {
           icon={Users}
           title="아직 밴드가 없습니다"
           description="첫 번째 밴드를 만들어 보세요."
-          action={{ label: '밴드 만들기', onClick: () => undefined }}
+          action={{ label: '밴드 생성', onClick: () => undefined }}
         />
       ) : (
         <>
@@ -65,7 +65,7 @@ export function BandsList() {
 
       <Link
         href={ROUTES.BAND_NEW}
-        aria-label="밴드 만들기"
+        aria-label="밴드 생성"
         className="bg-accent text-foreground hover:bg-accent-hi focus-visible:ring-accent focus-visible:ring-offset-bg rounded-pill fixed right-4 bottom-20 z-10 flex h-14 w-14 items-center justify-center shadow-lg transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         <Plus className="h-6 w-6" />

--- a/src/app/(main)/bands/BandsListPane.client.tsx
+++ b/src/app/(main)/bands/BandsListPane.client.tsx
@@ -3,7 +3,7 @@
 import { Plus, Search } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
@@ -12,16 +12,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BandCreateModal } from '@/domain/band/components/BandCreateModal.client';
 import { BandRoleBadge } from '@/domain/band/components/BandRoleBadge';
 import { useBandList } from '@/domain/band/hooks/useBandList';
+import { useBandSearch } from '@/domain/band/hooks/useBandSearch';
 import { useMyBands } from '@/domain/band/hooks/useMyBands';
 import type { BandInfoResponse, MyBandInfoResponse } from '@/domain/band/types';
 import { ROUTES } from '@/global/config/routes';
-import { useDiscoverySearch } from '@/hooks/useDiscoverySearch';
 import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
 import { listItemClasses } from '@/lib/list-item-styles';
 
 const BandIcon = DOMAIN_ICONS.band;
-
-const accessor = (b: BandInfoResponse) => `${b.bandName} ${b.description ?? ''}`;
 
 type Tab = 'mine' | 'discover';
 
@@ -76,19 +74,25 @@ export function BandsListPane() {
   const searchParams = useSearchParams();
   const initialTab = (searchParams?.get('tab') === 'discover' ? 'discover' : 'mine') as Tab;
   const [tab, setTab] = useState<Tab>(initialTab);
-
-  // Discover (전체 목록)
-  const { data: discoverData, isLoading: discoverLoading } = useBandList();
-  const discoverBands = discoverData?.pages.flatMap((p) => p.content) ?? [];
-  const accessorRef = useCallback(accessor, []);
-  const { query, setQuery, filtered, isFiltering } = useDiscoverySearch(discoverBands, accessorRef);
+  const [query, setQuery] = useState('');
 
   // Mine (내 소속) — API_SPEC §3-3-1 /bands/me (myRole 포함)
   const { data: myBands, isLoading: myLoading } = useMyBands(20);
 
+  // Discover: 기본 전체 목록 / 검색어 있으면 API 검색으로 전환
+  const hasQuery = query.trim().length > 0;
+  const { data: allBandsData, isLoading: allLoading } = useBandList(20);
+  const allBands = allBandsData?.pages.flatMap((p) => p.content) ?? [];
+  const { data: searchData, isLoading: searchLoading } = useBandSearch(query, 20);
+  const searchResults = searchData?.pages.flatMap((p) => p.content) ?? [];
+
+  const discoverBands = hasQuery ? searchResults : allBands;
+  const discoverLoading = hasQuery ? searchLoading : allLoading;
+
   const onTabChange = (next: string) => {
     const t = next === 'discover' ? 'discover' : 'mine';
     setTab(t);
+    setQuery('');
     const params = new URLSearchParams(searchParams?.toString() ?? '');
     params.set('tab', t);
     router.replace(`${pathname.startsWith('/bands') ? pathname : '/bands'}?${params.toString()}`, {
@@ -161,13 +165,13 @@ export function BandsListPane() {
           <div className="px-s-2 py-s-2 flex-1 overflow-y-auto">
             {discoverLoading ? (
               <p className="text-foreground-muted p-s-3 text-caption">불러오는 중…</p>
-            ) : filtered.length === 0 ? (
+            ) : discoverBands.length === 0 ? (
               <p className="text-foreground-muted p-s-3 text-caption">
-                {isFiltering ? '검색 결과가 없습니다.' : '등록된 밴드가 없습니다.'}
+                {hasQuery ? '검색 결과가 없습니다.' : '등록된 밴드가 없습니다.'}
               </p>
             ) : (
               <ul className="gap-s-1 flex flex-col">
-                {filtered.map((b) => {
+                {discoverBands.map((b) => {
                   const myEntry = myBands?.find((mb) => mb.bandId === b.bandId);
                   return (
                     <BandRow

--- a/src/app/(main)/bands/BandsListPane.client.tsx
+++ b/src/app/(main)/bands/BandsListPane.client.tsx
@@ -111,8 +111,8 @@ export function BandsListPane() {
         <h2 className="text-body font-bold">밴드 탐색</h2>
         <BandCreateModal
           trigger={
-            <Button size="sm" variant="accent-outline" aria-label="새 밴드 만들기">
-              <Plus className="h-4 w-4" /> 밴드 만들기
+            <Button size="sm" variant="accent-outline" aria-label="밴드 생성">
+              <Plus className="h-4 w-4" /> 밴드 생성
             </Button>
           }
         />

--- a/src/app/(main)/bands/BandsMobileShell.client.tsx
+++ b/src/app/(main)/bands/BandsMobileShell.client.tsx
@@ -83,8 +83,8 @@ export function BandsMobileShell() {
         <h2 className="text-body font-bold">밴드 탐색</h2>
         <BandCreateModal
           trigger={
-            <Button size="sm" variant="accent-outline" aria-label="새 밴드 만들기">
-              <Plus className="h-4 w-4" /> 밴드 만들기
+            <Button size="sm" variant="accent-outline" aria-label="밴드 생성">
+              <Plus className="h-4 w-4" /> 밴드 생성
             </Button>
           }
         />

--- a/src/app/(main)/bands/BandsMobileShell.client.tsx
+++ b/src/app/(main)/bands/BandsMobileShell.client.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Plus, Search } from 'lucide-react';
+import { Root, Portal, Overlay, Content, Title, Close } from '@radix-ui/react-dialog';
+import { Plus, Search, Users, X } from 'lucide-react';
 import { useState } from 'react';
 
 import { BottomSheet, BottomSheetContent, BottomSheetTitle } from '@/components/ui/bottom-sheet';
 import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
-import { MyItemMarker, myItemBorder } from '@/components/ui/my-item-marker';
+import { MyItemMarker } from '@/components/ui/my-item-marker';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BandCreateModal } from '@/domain/band/components/BandCreateModal.client';
@@ -15,22 +16,23 @@ import { useBandList } from '@/domain/band/hooks/useBandList';
 import { useBandSearch } from '@/domain/band/hooks/useBandSearch';
 import { useMyBands } from '@/domain/band/hooks/useMyBands';
 import type { BandInfoResponse, MyBandInfoResponse } from '@/domain/band/types';
+import { useIsDesktop } from '@/hooks/use-media-query';
 import { cn } from '@/lib/cn';
-import { DOMAIN_ICONS, DOMAIN_TONES } from '@/lib/domain-icons';
+import { DOMAIN_TONES } from '@/lib/domain-icons';
 
 import { BandDetailContent } from './[bandId]/BandDetailContent.client';
-
-const BandIcon = DOMAIN_ICONS.band;
 
 function BandSelectRow({
   band,
   myRole,
   showMineMarker = false,
+  isSelected = false,
   onClick,
 }: {
   band: BandInfoResponse;
   myRole?: MyBandInfoResponse['myRole'];
   showMineMarker?: boolean;
+  isSelected?: boolean;
   onClick: () => void;
 }) {
   return (
@@ -39,22 +41,33 @@ function BandSelectRow({
         type="button"
         onClick={onClick}
         className={cn(
-          'gap-s-3 px-s-3 py-s-3 flex w-full items-center rounded-md text-left transition-colors',
+          'gap-s-3 px-s-3 py-s-3 flex w-full items-center rounded-[5px] text-left transition-colors',
           'hover:bg-surface-hi focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-          myItemBorder(showMineMarker),
+          isSelected ? 'border-l-[3px] border-l-white/60' : '',
         )}
       >
-        <IconTile icon={<BandIcon />} size="sm" tone={DOMAIN_TONES.band} />
+        {band.profileImg ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={band.profileImg}
+            alt={band.bandName}
+            className="h-10 w-10 shrink-0 rounded-md object-cover"
+          />
+        ) : (
+          <IconTile icon={<Users />} size="sm" tone={DOMAIN_TONES.band} />
+        )}
         <div className="min-w-0 flex-1">
           <div className="gap-s-2 flex items-center">
             <span className="text-caption truncate font-semibold">{band.bandName}</span>
-            {myRole && <BandRoleBadge role={myRole} />}
+            {myRole && <BandRoleBadge role={myRole} className="bg-white/10 text-white" />}
           </div>
           {band.description && (
             <p className="text-foreground-muted text-caption mt-0.5 truncate">{band.description}</p>
           )}
         </div>
-        {showMineMarker && <MyItemMarker label="내 밴드" />}
+        {showMineMarker && (
+          <MyItemMarker label="내 밴드" className="text-micro bg-white/10 text-white" />
+        )}
       </button>
     </li>
   );
@@ -63,11 +76,11 @@ function BandSelectRow({
 export function BandsMobileShell() {
   const [query, setQuery] = useState('');
   const [selectedBandId, setSelectedBandId] = useState<string | null>(null);
+  const isDesktop = useIsDesktop();
 
   const { data: myBandsData, isLoading: myLoading } = useMyBands(50);
   const myBands = myBandsData ?? [];
 
-  // 탐색 탭: 기본 전체 목록 / 검색어 있으면 API 검색으로 전환
   const hasQuery = query.trim().length > 0;
   const { data: allBandsData, isLoading: allLoading } = useBandList(20);
   const allBands = allBandsData?.pages.flatMap((p) => p.content) ?? [];
@@ -79,24 +92,54 @@ export function BandsMobileShell() {
 
   return (
     <>
-      <div className="border-border mb-s-3 pb-s-3 flex items-center justify-between border-b">
-        <h2 className="text-body font-bold">밴드 탐색</h2>
-        <BandCreateModal
-          trigger={
-            <Button size="sm" variant="accent-outline" aria-label="밴드 생성">
-              <Plus className="h-4 w-4" /> 밴드 생성
-            </Button>
-          }
-        />
-      </div>
-
       <Tabs defaultValue="mine" onValueChange={() => setQuery('')}>
-        <div className="mb-s-3">
+        {/* 헤더 */}
+        <div className="border-border mb-s-3 pb-s-2 pt-s-1 flex items-center justify-between border-b">
+          <div className="flex items-center gap-4">
+            <h2 className="text-foreground pl-2.5 text-2xl font-bold lg:text-3xl">밴드</h2>
+            {/* PC: 헤딩 바로 옆 토글 */}
+            <TabsList className="hidden w-37.5 lg:inline-flex">
+              <TabsTrigger
+                value="mine"
+                className="text-foreground flex-1 transition-all active:scale-95 data-[state=active]:bg-neutral-100 data-[state=active]:text-neutral-900"
+              >
+                내 밴드
+              </TabsTrigger>
+              <TabsTrigger
+                value="discover"
+                className="text-foreground flex-1 transition-all active:scale-95 data-[state=active]:bg-neutral-100 data-[state=active]:text-neutral-900"
+              >
+                탐색
+              </TabsTrigger>
+            </TabsList>
+          </div>
+          <BandCreateModal
+            trigger={
+              <Button
+                size="sm"
+                variant="accent-outline"
+                aria-label="밴드 생성"
+                className="rounded-[5px] border-white text-white hover:border-transparent hover:bg-white hover:text-neutral-900 active:border-transparent active:bg-neutral-200 active:text-neutral-900"
+              >
+                <Plus className="h-4 w-4" /> 밴드 생성
+              </Button>
+            }
+          />
+        </div>
+
+        {/* 모바일: 헤더 아래 풀너비 토글 */}
+        <div className="mb-s-3 lg:hidden">
           <TabsList className="w-full">
-            <TabsTrigger value="mine" className="flex-1">
+            <TabsTrigger
+              value="mine"
+              className="text-foreground flex-1 transition-all active:scale-95 data-[state=active]:bg-neutral-100 data-[state=active]:text-neutral-900"
+            >
               내 밴드
             </TabsTrigger>
-            <TabsTrigger value="discover" className="flex-1">
+            <TabsTrigger
+              value="discover"
+              className="text-foreground flex-1 transition-all active:scale-95 data-[state=active]:bg-neutral-100 data-[state=active]:text-neutral-900"
+            >
               탐색
             </TabsTrigger>
           </TabsList>
@@ -120,6 +163,7 @@ export function BandsMobileShell() {
                   key={b.bandId}
                   band={b}
                   myRole={b.myRole}
+                  isSelected={selectedBandId === b.bandId}
                   onClick={() => setSelectedBandId(b.bandId)}
                 />
               ))}
@@ -128,13 +172,13 @@ export function BandsMobileShell() {
         </TabsContent>
 
         <TabsContent value="discover">
-          <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 mb-s-3 flex items-center rounded-md border">
+          <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 mb-s-3 flex items-center rounded-[5px] border">
             <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
             <input
               type="search"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="밴드 이름·소개 검색…"
+              placeholder="밴드명 검색"
               aria-label="밴드 검색"
               className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
             />
@@ -160,6 +204,7 @@ export function BandsMobileShell() {
                     band={b}
                     myRole={myEntry?.myRole}
                     showMineMarker={!!myEntry}
+                    isSelected={selectedBandId === b.bandId}
                     onClick={() => setSelectedBandId(b.bandId)}
                   />
                 );
@@ -169,17 +214,46 @@ export function BandsMobileShell() {
         </TabsContent>
       </Tabs>
 
-      <BottomSheet
-        open={!!selectedBandId}
-        onOpenChange={(open) => !open && setSelectedBandId(null)}
-      >
-        <BottomSheetContent>
-          <BottomSheetTitle className="sr-only">밴드 상세</BottomSheetTitle>
-          <div className="flex-1 overflow-y-auto">
-            {selectedBandId && <BandDetailContent bandId={selectedBandId} />}
-          </div>
-        </BottomSheetContent>
-      </BottomSheet>
+      {isDesktop ? (
+        <Root open={!!selectedBandId} onOpenChange={(open) => !open && setSelectedBandId(null)}>
+          <Portal>
+            <Overlay className="animate-fade-in fixed inset-0 z-40 bg-black/60 data-[state=closed]:opacity-0" />
+            <Content
+              className={cn(
+                'bg-card text-foreground border-border',
+                'fixed inset-y-0 right-0 z-50 flex w-105 flex-col border-l shadow-lg outline-none',
+                'animate-[slide-in-right_var(--duration-normal)_var(--ease-default)]',
+                'data-[state=closed]:animate-[slide-out-right_var(--duration-normal)_var(--ease-default)]',
+              )}
+            >
+              <Title className="sr-only">밴드 상세</Title>
+              <div className="flex shrink-0 items-center justify-end px-4 py-3">
+                <Close
+                  aria-label="닫기"
+                  className="text-foreground-sub hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg rounded-sm p-1 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  <X className="h-4 w-4" />
+                </Close>
+              </div>
+              <div className="flex-1 overflow-y-auto">
+                {selectedBandId && <BandDetailContent bandId={selectedBandId} />}
+              </div>
+            </Content>
+          </Portal>
+        </Root>
+      ) : (
+        <BottomSheet
+          open={!!selectedBandId}
+          onOpenChange={(open) => !open && setSelectedBandId(null)}
+        >
+          <BottomSheetContent>
+            <BottomSheetTitle className="sr-only">밴드 상세</BottomSheetTitle>
+            <div className="flex-1 overflow-y-auto">
+              {selectedBandId && <BandDetailContent bandId={selectedBandId} />}
+            </div>
+          </BottomSheetContent>
+        </BottomSheet>
+      )}
     </>
   );
 }

--- a/src/app/(main)/bands/BandsMobileShell.client.tsx
+++ b/src/app/(main)/bands/BandsMobileShell.client.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { Plus, Search } from 'lucide-react';
+import { useState } from 'react';
+
+import { BottomSheet, BottomSheetContent, BottomSheetTitle } from '@/components/ui/bottom-sheet';
+import { Button } from '@/components/ui/button';
+import { IconTile } from '@/components/ui/icon-tile';
+import { MyItemMarker, myItemBorder } from '@/components/ui/my-item-marker';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { BandCreateModal } from '@/domain/band/components/BandCreateModal.client';
+import { BandRoleBadge } from '@/domain/band/components/BandRoleBadge';
+import { useBandList } from '@/domain/band/hooks/useBandList';
+import { useBandSearch } from '@/domain/band/hooks/useBandSearch';
+import { useMyBands } from '@/domain/band/hooks/useMyBands';
+import type { BandInfoResponse, MyBandInfoResponse } from '@/domain/band/types';
+import { cn } from '@/lib/cn';
+import { DOMAIN_ICONS, DOMAIN_TONES } from '@/lib/domain-icons';
+
+import { BandDetailContent } from './[bandId]/BandDetailContent.client';
+
+const BandIcon = DOMAIN_ICONS.band;
+
+function BandSelectRow({
+  band,
+  myRole,
+  showMineMarker = false,
+  onClick,
+}: {
+  band: BandInfoResponse;
+  myRole?: MyBandInfoResponse['myRole'];
+  showMineMarker?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'gap-s-3 px-s-3 py-s-3 flex w-full items-center rounded-md text-left transition-colors',
+          'hover:bg-surface-hi focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+          myItemBorder(showMineMarker),
+        )}
+      >
+        <IconTile icon={<BandIcon />} size="sm" tone={DOMAIN_TONES.band} />
+        <div className="min-w-0 flex-1">
+          <div className="gap-s-2 flex items-center">
+            <span className="text-caption truncate font-semibold">{band.bandName}</span>
+            {myRole && <BandRoleBadge role={myRole} />}
+          </div>
+          {band.description && (
+            <p className="text-foreground-muted text-caption mt-0.5 truncate">{band.description}</p>
+          )}
+        </div>
+        {showMineMarker && <MyItemMarker label="내 밴드" />}
+      </button>
+    </li>
+  );
+}
+
+export function BandsMobileShell() {
+  const [query, setQuery] = useState('');
+  const [selectedBandId, setSelectedBandId] = useState<string | null>(null);
+
+  const { data: myBandsData, isLoading: myLoading } = useMyBands(50);
+  const myBands = myBandsData ?? [];
+
+  // 탐색 탭: 기본 전체 목록 / 검색어 있으면 API 검색으로 전환
+  const hasQuery = query.trim().length > 0;
+  const { data: allBandsData, isLoading: allLoading } = useBandList(20);
+  const allBands = allBandsData?.pages.flatMap((p) => p.content) ?? [];
+  const { data: searchData, isLoading: searchLoading } = useBandSearch(query, 20);
+  const searchResults = searchData?.pages.flatMap((p) => p.content) ?? [];
+
+  const discoverBands = hasQuery ? searchResults : allBands;
+  const discoverLoading = hasQuery ? searchLoading : allLoading;
+
+  return (
+    <>
+      <div className="border-border mb-s-3 pb-s-3 flex items-center justify-between border-b">
+        <h2 className="text-body font-bold">밴드 탐색</h2>
+        <BandCreateModal
+          trigger={
+            <Button size="sm" variant="accent-outline" aria-label="새 밴드 만들기">
+              <Plus className="h-4 w-4" /> 밴드 만들기
+            </Button>
+          }
+        />
+      </div>
+
+      <Tabs defaultValue="mine" onValueChange={() => setQuery('')}>
+        <div className="mb-s-3">
+          <TabsList className="w-full">
+            <TabsTrigger value="mine" className="flex-1">
+              내 밴드
+            </TabsTrigger>
+            <TabsTrigger value="discover" className="flex-1">
+              탐색
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        <TabsContent value="mine">
+          {myLoading ? (
+            <div className="space-y-s-2">
+              <Skeleton className="h-14 w-full" rounded="md" />
+              <Skeleton className="h-14 w-full" rounded="md" />
+              <Skeleton className="h-14 w-full" rounded="md" />
+            </div>
+          ) : myBands.length === 0 ? (
+            <p className="text-foreground-muted py-s-6 text-center text-sm">
+              참여 중인 밴드가 없습니다.
+            </p>
+          ) : (
+            <ul className="gap-s-1 flex flex-col">
+              {myBands.map((b) => (
+                <BandSelectRow
+                  key={b.bandId}
+                  band={b}
+                  myRole={b.myRole}
+                  onClick={() => setSelectedBandId(b.bandId)}
+                />
+              ))}
+            </ul>
+          )}
+        </TabsContent>
+
+        <TabsContent value="discover">
+          <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 mb-s-3 flex items-center rounded-md border">
+            <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="밴드 이름·소개 검색…"
+              aria-label="밴드 검색"
+              className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+            />
+          </div>
+
+          {discoverLoading ? (
+            <div className="space-y-s-2">
+              <Skeleton className="h-14 w-full" rounded="md" />
+              <Skeleton className="h-14 w-full" rounded="md" />
+              <Skeleton className="h-14 w-full" rounded="md" />
+            </div>
+          ) : discoverBands.length === 0 ? (
+            <p className="text-foreground-muted py-s-6 text-center text-sm">
+              {hasQuery ? '검색 결과가 없습니다.' : '등록된 밴드가 없습니다.'}
+            </p>
+          ) : (
+            <ul className="gap-s-1 flex flex-col">
+              {discoverBands.map((b) => {
+                const myEntry = myBands.find((mb) => mb.bandId === b.bandId);
+                return (
+                  <BandSelectRow
+                    key={b.bandId}
+                    band={b}
+                    myRole={myEntry?.myRole}
+                    showMineMarker={!!myEntry}
+                    onClick={() => setSelectedBandId(b.bandId)}
+                  />
+                );
+              })}
+            </ul>
+          )}
+        </TabsContent>
+      </Tabs>
+
+      <BottomSheet
+        open={!!selectedBandId}
+        onOpenChange={(open) => !open && setSelectedBandId(null)}
+      >
+        <BottomSheetContent>
+          <BottomSheetTitle className="sr-only">밴드 상세</BottomSheetTitle>
+          <div className="flex-1 overflow-y-auto">
+            {selectedBandId && <BandDetailContent bandId={selectedBandId} />}
+          </div>
+        </BottomSheetContent>
+      </BottomSheet>
+    </>
+  );
+}

--- a/src/app/(main)/bands/BandsMobileShell.client.tsx
+++ b/src/app/(main)/bands/BandsMobileShell.client.tsx
@@ -221,13 +221,13 @@ export function BandsMobileShell() {
             <Content
               className={cn(
                 'bg-card text-foreground border-border',
-                'fixed inset-y-0 right-0 z-50 flex w-105 flex-col border-l shadow-lg outline-none',
+                'fixed inset-y-0 right-0 z-50 flex w-140 flex-col border-l shadow-lg outline-none',
                 'animate-[slide-in-right_var(--duration-normal)_var(--ease-default)]',
                 'data-[state=closed]:animate-[slide-out-right_var(--duration-normal)_var(--ease-default)]',
               )}
             >
               <Title className="sr-only">밴드 상세</Title>
-              <div className="flex shrink-0 items-center justify-end px-4 py-3">
+              <div className="flex shrink-0 items-center justify-end px-4 py-5">
                 <Close
                   aria-label="닫기"
                   className="text-foreground-sub hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg rounded-sm p-1 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
@@ -246,7 +246,7 @@ export function BandsMobileShell() {
           open={!!selectedBandId}
           onOpenChange={(open) => !open && setSelectedBandId(null)}
         >
-          <BottomSheetContent>
+          <BottomSheetContent className="h-dvh">
             <BottomSheetTitle className="sr-only">밴드 상세</BottomSheetTitle>
             <div className="flex-1 overflow-y-auto">
               {selectedBandId && <BandDetailContent bandId={selectedBandId} />}

--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -29,6 +29,7 @@ import { useBandApplications } from '@/domain/band/hooks/useBandApplications';
 import { useBandDetail } from '@/domain/band/hooks/useBandDetail';
 import { useBandMembers } from '@/domain/band/hooks/useBandMembers';
 import { useDeleteBand } from '@/domain/band/hooks/useDeleteBand';
+import { useDeleteBandProfileImage } from '@/domain/band/hooks/useDeleteBandProfileImage';
 import { useLeaveBand } from '@/domain/band/hooks/useLeaveBand';
 import { useUpdateBand } from '@/domain/band/hooks/useUpdateBand';
 import { hasRole } from '@/global/auth/RoleGuard';
@@ -98,6 +99,8 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
           {!isMember && (
             <Button
               size="sm"
+              variant="secondary"
+              className="rounded-[5px] border-white text-white hover:border-transparent hover:bg-white hover:text-neutral-900 active:border-transparent active:bg-neutral-200 active:text-neutral-900"
               onClick={() => applyMutation.mutate()}
               loading={applyMutation.isPending}
             >
@@ -109,7 +112,7 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
             <Button
               size="sm"
               variant="secondary"
-              className="text-danger"
+              className="rounded-[5px] border-white text-white hover:border-transparent hover:bg-white hover:text-neutral-900 active:border-transparent active:bg-neutral-200 active:text-neutral-900"
               onClick={() => setLeaveOpen(true)}
             >
               <LogOut className="h-4 w-4" />
@@ -123,10 +126,34 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
         {/* Tab bar — 48px height, 32px horizontal padding */}
         <div className="px-s-5 lg:px-8">
           <TabsList aria-label="밴드 상세 탭">
-            <TabsTrigger value="info">정보</TabsTrigger>
-            <TabsTrigger value="members">멤버</TabsTrigger>
-            {isLeader && <TabsTrigger value="applications">신청 현황</TabsTrigger>}
-            {isLeader && <TabsTrigger value="settings">설정</TabsTrigger>}
+            <TabsTrigger
+              value="info"
+              className="data-[state=active]:text-foreground data-[state=active]:border-foreground"
+            >
+              정보
+            </TabsTrigger>
+            <TabsTrigger
+              value="members"
+              className="data-[state=active]:text-foreground data-[state=active]:border-foreground"
+            >
+              멤버
+            </TabsTrigger>
+            {isLeader && (
+              <TabsTrigger
+                value="applications"
+                className="data-[state=active]:text-foreground data-[state=active]:border-foreground"
+              >
+                신청 현황
+              </TabsTrigger>
+            )}
+            {isLeader && (
+              <TabsTrigger
+                value="settings"
+                className="data-[state=active]:text-foreground data-[state=active]:border-foreground"
+              >
+                설정
+              </TabsTrigger>
+            )}
           </TabsList>
         </div>
 
@@ -165,23 +192,30 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
 
       <Dialog open={leaveOpen} onOpenChange={setLeaveOpen}>
         <DialogContent>
-          <DialogHeader>
+          <DialogHeader className="border-b-0 pb-2">
             <DialogTitle>밴드에서 탈퇴하시겠어요?</DialogTitle>
             <DialogDescription>
               탈퇴 후에는 밴드의 합주 · 공연 · 신청 이력에 접근할 수 없습니다.
             </DialogDescription>
           </DialogHeader>
+          <div className="border-border mx-5 border-b" />
           <DialogBody>
             <p className="text-foreground-sub text-sm">
-              LEADER 인 경우 먼저 리더 권한을 다른 멤버에게 위임해야 할 수 있습니다.
+              <span className="text-nav-active font-bold">밴드 리더</span> 인 경우 먼저 리더 권한을
+              다른 멤버에게 위임해야 합니다.
             </p>
           </DialogBody>
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setLeaveOpen(false)}>
+          <DialogFooter className="border-t-0">
+            <Button
+              variant="ghost"
+              className="h-8 rounded-[5px]"
+              onClick={() => setLeaveOpen(false)}
+            >
               취소
             </Button>
             <Button
               variant="danger"
+              className="h-8 rounded-[5px] px-2"
               loading={leaveMutation.isPending}
               onClick={() => leaveMutation.mutate()}
             >
@@ -227,7 +261,6 @@ function InfoTab({
       </div>
 
       <div className="space-y-s-2 max-w-[720px]">
-        <h2 className="text-foreground text-title font-extrabold">{bandName}</h2>
         <p className="text-foreground-sub text-body leading-relaxed">
           {description ?? '소개가 등록되지 않았습니다.'}
         </p>
@@ -275,7 +308,7 @@ function MembersTab({ bandId }: { bandId: string }) {
 const STATUS_FILTERS: { value: ApplicationStatus; label: string }[] = [
   { value: 'PENDING', label: '대기중' },
   { value: 'APPROVED', label: '승인됨' },
-  { value: 'REJECTED', label: '거부됨' },
+  { value: 'REJECTED', label: '거절됨' },
 ];
 
 function ApplicationsTab({ bandId }: { bandId: string }) {
@@ -295,6 +328,7 @@ function ApplicationsTab({ bandId }: { bandId: string }) {
             interactive
             selected={status === f.value}
             onClick={() => setStatus(f.value)}
+            className={status === f.value ? 'bg-foreground text-bg border-foreground ring-0' : ''}
           >
             {f.label}
           </Chip>
@@ -305,11 +339,18 @@ function ApplicationsTab({ bandId }: { bandId: string }) {
       ) : isError ? (
         <ErrorState onRetry={() => refetch()} />
       ) : apps.length === 0 ? (
-        <EmptyState title={`${currentLabel} 상태 신청이 없습니다`} />
+        <p className="text-foreground-muted py-s-6 text-center text-sm">
+          {currentLabel} 상태 신청이 없습니다
+        </p>
       ) : (
         <div className="space-y-s-2">
           {apps.map((a) => (
-            <BandApplicationRow key={a.bandApplicationId} bandId={bandId} application={a} />
+            <BandApplicationRow
+              key={a.bandApplicationId}
+              bandId={bandId}
+              application={a}
+              onDecide={() => setStatus('PENDING')}
+            />
           ))}
           {hasNextPage && (
             <div className="flex justify-center">
@@ -352,6 +393,11 @@ function SettingsTab({
     onError: (err) => toast.error(err.message || '저장에 실패했습니다.'),
   });
 
+  const deleteImageMutation = useDeleteBandProfileImage(bandId, {
+    onSuccess: () => toast.success('이미지를 삭제했습니다.'),
+    onError: (err) => toast.error(err.message || '이미지 삭제에 실패했습니다.'),
+  });
+
   const deleteMutation = useDeleteBand(bandId, {
     onSuccess: () => {
       toast.success('밴드를 삭제했습니다.');
@@ -361,16 +407,25 @@ function SettingsTab({
   });
 
   return (
-    <div className="space-y-s-4 max-w-lg">
+    <div className="space-y-s-4 mx-auto w-full max-w-lg">
       <Tabs value={tab} onValueChange={(v) => setTab(v as 'info' | 'image' | 'delete')}>
         <TabsList className="mb-s-4 w-full">
-          <TabsTrigger value="info" className="flex-1">
+          <TabsTrigger
+            value="info"
+            className="flex-1 transition-all active:scale-95 data-[state=active]:bg-white data-[state=active]:text-neutral-900"
+          >
             정보
           </TabsTrigger>
-          <TabsTrigger value="image" className="flex-1">
-            사진
+          <TabsTrigger
+            value="image"
+            className="flex-1 transition-all active:scale-95 data-[state=active]:bg-white data-[state=active]:text-neutral-900"
+          >
+            이미지
           </TabsTrigger>
-          <TabsTrigger value="delete" className="flex-1">
+          <TabsTrigger
+            value="delete"
+            className="flex-1 transition-all active:scale-95 data-[state=active]:bg-white data-[state=active]:text-neutral-900"
+          >
             삭제
           </TabsTrigger>
         </TabsList>
@@ -380,48 +435,74 @@ function SettingsTab({
             label="밴드 이름"
             required
             value={name}
+            placeholder="밴드 이름을 입력하세요"
+            hint={<span className="block text-right">{name.length}/50자</span>}
             onChange={(e) => setName(e.target.value)}
+            className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
           />
-          <Textarea label="소개 (선택)" value={desc} onChange={(e) => setDesc(e.target.value)} />
-          <Button
-            onClick={() =>
-              updateMutation.mutate({ name: name.trim(), description: desc.trim() || undefined })
-            }
-            loading={updateMutation.isPending}
-          >
-            저장
-          </Button>
+          <Textarea
+            label="소개"
+            required
+            value={desc}
+            placeholder="밴드 소개글을 입력하세요"
+            hint={<span className="block text-right">{desc.length}/200자</span>}
+            onChange={(e) => setDesc(e.target.value)}
+            className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
+          />
+          <div className="flex justify-end">
+            <Button
+              variant="secondary"
+              className="h-8 rounded-[5px] border-white bg-white px-3 text-neutral-900 hover:border-neutral-100 hover:bg-neutral-100 active:border-neutral-200 active:bg-neutral-200"
+              disabled={!name.trim() || !desc.trim()}
+              onClick={() =>
+                updateMutation.mutate({ name: name.trim(), description: desc.trim() || undefined })
+              }
+              loading={updateMutation.isPending}
+            >
+              저장
+            </Button>
+          </div>
         </TabsContent>
 
         <TabsContent value="image" className="mt-0">
           <ProfileImageUpload
             value={profileImg ?? null}
             onChange={(objectKey) => updateMutation.mutate({ profileImg: objectKey })}
+            onDelete={() => deleteImageMutation.mutate()}
             domain="BAND"
             bandId={bandId}
-            hint="JPEG / PNG / WEBP, 5MB 이하. 리더만 변경할 수 있습니다."
+            label=""
+            imageClassName="w-full h-[220px] rounded-2xl"
+            showButton={false}
+            hint="JPEG / PNG / WEBP, 5MB 이하"
             disabled={updateMutation.isPending}
           />
         </TabsContent>
 
         <TabsContent value="delete" className="space-y-s-3 mt-0">
-          <p className="text-foreground-sub text-sm">
+          <p className="text-foreground-sub text-xs">
             밴드를 삭제하면 모든 멤버·합주·공연 연결이 함께 제거되며 복구할 수 없습니다.
           </p>
-          <Input
-            label={`밴드 이름(${bandName})을 그대로 입력해 주세요`}
-            value={confirmText}
-            onChange={(e) => setConfirmText(e.target.value)}
-            placeholder={bandName}
-          />
-          <Button
-            variant="danger"
-            onClick={() => deleteMutation.mutate()}
-            disabled={confirmText !== bandName}
-            loading={deleteMutation.isPending}
-          >
-            삭제
-          </Button>
+          <div className="mt-s-5">
+            <Input
+              label={`밴드 이름(${bandName})을 그대로 입력해 주세요`}
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={bandName}
+              className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
+            />
+          </div>
+          <div className="flex justify-end">
+            <Button
+              variant="danger"
+              className="h-8 rounded-[5px] px-3"
+              onClick={() => deleteMutation.mutate()}
+              disabled={confirmText !== bandName}
+              loading={deleteMutation.isPending}
+            >
+              삭제
+            </Button>
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Camera, LogOut, Settings, UserPlus } from 'lucide-react';
+import { Camera, LogOut, UserPlus } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -19,14 +19,18 @@ import {
 } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Input } from '@/components/ui/input';
+import { ProfileImageUpload } from '@/components/ui/profile-image-upload';
+import { Textarea } from '@/components/ui/textarea';
 import { BandApplicationRow } from '@/domain/band/components/BandApplicationRow';
 import { BandMemberRow } from '@/domain/band/components/BandMemberRow';
-import { BandSettingsModal } from '@/domain/band/components/BandSettingsModal.client';
 import { useApplyBand } from '@/domain/band/hooks/useApplyBand';
 import { useBandApplications } from '@/domain/band/hooks/useBandApplications';
 import { useBandDetail } from '@/domain/band/hooks/useBandDetail';
 import { useBandMembers } from '@/domain/band/hooks/useBandMembers';
+import { useDeleteBand } from '@/domain/band/hooks/useDeleteBand';
 import { useLeaveBand } from '@/domain/band/hooks/useLeaveBand';
+import { useUpdateBand } from '@/domain/band/hooks/useUpdateBand';
 import { hasRole } from '@/global/auth/RoleGuard';
 import { useBandRole } from '@/global/auth/useBandRole';
 import { ROUTES } from '@/global/config/routes';
@@ -40,7 +44,7 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
   const router = useRouter();
   const toast = useToast();
   const [leaveOpen, setLeaveOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState('info');
 
   const { data: band, isLoading, isError, refetch } = useBandDetail(bandId);
   const { data: myRole } = useBandRole(bandId);
@@ -82,11 +86,10 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
     <div data-slot="band-detail">
       {/* TopBar — 72px height, 32px horizontal padding, bottom 1px border */}
       <header
-        className="border-border px-s-5 flex h-[72px] items-center justify-between gap-3 border-b lg:px-8"
+        className="px-s-5 flex h-[72px] items-center justify-between gap-3 lg:px-8"
         data-slot="band-detail-topbar"
       >
         <div className="min-w-0">
-          <p className="text-foreground-muted text-caption">밴드 탐색</p>
           <h1 className="text-foreground truncate text-[22px] leading-snug font-bold">
             {band.bandName}
           </h1>
@@ -113,22 +116,17 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
               밴드 탈퇴
             </Button>
           )}
-          {isLeader && (
-            <Button size="sm" variant="secondary" onClick={() => setSettingsOpen(true)}>
-              <Settings className="h-4 w-4" />
-              밴드 설정
-            </Button>
-          )}
         </div>
       </header>
 
-      <Tabs defaultValue="info" variant="underline">
+      <Tabs value={activeTab} onValueChange={setActiveTab} variant="underline">
         {/* Tab bar — 48px height, 32px horizontal padding */}
         <div className="px-s-5 lg:px-8">
           <TabsList aria-label="밴드 상세 탭">
             <TabsTrigger value="info">정보</TabsTrigger>
             <TabsTrigger value="members">멤버</TabsTrigger>
             {isLeader && <TabsTrigger value="applications">신청 현황</TabsTrigger>}
+            {isLeader && <TabsTrigger value="settings">설정</TabsTrigger>}
           </TabsList>
         </div>
 
@@ -152,19 +150,18 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
               <ApplicationsTab bandId={bandId} />
             </TabsContent>
           )}
+          {isLeader && (
+            <TabsContent value="settings" className="mt-0">
+              <SettingsTab
+                bandId={band.bandId}
+                bandName={band.bandName}
+                description={band.description}
+                profileImg={band.profileImg}
+              />
+            </TabsContent>
+          )}
         </div>
       </Tabs>
-
-      <BandSettingsModal
-        open={settingsOpen}
-        onOpenChange={setSettingsOpen}
-        band={{
-          bandId: band.bandId,
-          bandName: band.bandName,
-          description: band.description,
-          profileImg: band.profileImg,
-        }}
-      />
 
       <Dialog open={leaveOpen} onOpenChange={setLeaveOpen}>
         <DialogContent>
@@ -328,6 +325,105 @@ function ApplicationsTab({ bandId }: { bandId: string }) {
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+function SettingsTab({
+  bandId,
+  bandName,
+  description,
+  profileImg,
+}: {
+  bandId: string;
+  bandName: string;
+  description?: string;
+  profileImg?: string;
+}) {
+  const router = useRouter();
+  const toast = useToast();
+  const [tab, setTab] = useState<'info' | 'image' | 'delete'>('info');
+  const [name, setName] = useState(bandName);
+  const [desc, setDesc] = useState(description ?? '');
+  const [confirmText, setConfirmText] = useState('');
+
+  const updateMutation = useUpdateBand(bandId, {
+    onSuccess: () => toast.success('밴드 정보를 저장했습니다.'),
+    onError: (err) => toast.error(err.message || '저장에 실패했습니다.'),
+  });
+
+  const deleteMutation = useDeleteBand(bandId, {
+    onSuccess: () => {
+      toast.success('밴드를 삭제했습니다.');
+      router.replace(ROUTES.BANDS);
+    },
+    onError: (err) => toast.error(err.message || '삭제에 실패했습니다.'),
+  });
+
+  return (
+    <div className="space-y-s-4 max-w-lg">
+      <Tabs value={tab} onValueChange={(v) => setTab(v as 'info' | 'image' | 'delete')}>
+        <TabsList className="mb-s-4 w-full">
+          <TabsTrigger value="info" className="flex-1">
+            정보
+          </TabsTrigger>
+          <TabsTrigger value="image" className="flex-1">
+            사진
+          </TabsTrigger>
+          <TabsTrigger value="delete" className="flex-1">
+            삭제
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="info" className="space-y-s-3 mt-0">
+          <Input
+            label="밴드 이름"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <Textarea label="소개 (선택)" value={desc} onChange={(e) => setDesc(e.target.value)} />
+          <Button
+            onClick={() =>
+              updateMutation.mutate({ name: name.trim(), description: desc.trim() || undefined })
+            }
+            loading={updateMutation.isPending}
+          >
+            저장
+          </Button>
+        </TabsContent>
+
+        <TabsContent value="image" className="mt-0">
+          <ProfileImageUpload
+            value={profileImg ?? null}
+            onChange={(objectKey) => updateMutation.mutate({ profileImg: objectKey })}
+            domain="BAND"
+            bandId={bandId}
+            hint="JPEG / PNG / WEBP, 5MB 이하. 리더만 변경할 수 있습니다."
+            disabled={updateMutation.isPending}
+          />
+        </TabsContent>
+
+        <TabsContent value="delete" className="space-y-s-3 mt-0">
+          <p className="text-foreground-sub text-sm">
+            밴드를 삭제하면 모든 멤버·합주·공연 연결이 함께 제거되며 복구할 수 없습니다.
+          </p>
+          <Input
+            label={`밴드 이름(${bandName})을 그대로 입력해 주세요`}
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            placeholder={bandName}
+          />
+          <Button
+            variant="danger"
+            onClick={() => deleteMutation.mutate()}
+            disabled={confirmText !== bandName}
+            loading={deleteMutation.isPending}
+          >
+            삭제
+          </Button>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/src/app/(main)/bands/layout.tsx
+++ b/src/app/(main)/bands/layout.tsx
@@ -1,22 +1,5 @@
 import type { ReactNode } from 'react';
-import { Suspense } from 'react';
 
-import { BandsListPane } from './BandsListPane.client';
-
-/**
- * Bands 라우트 레이아웃.
- * - lg 이상: 좌측 BandsListPane (360px) + 우측 children. 실질적 master-detail.
- * - lg 미만: BandsListPane 은 hidden, children 만 노출 (페이지 자체가 리스트/상세 역할 수행).
- *
- * BandsListPane 내부에서 useSearchParams() 를 사용하므로 Suspense 경계 필요.
- */
 export default function BandsLayout({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex h-full flex-col lg:h-[calc(100vh-0px)] lg:flex-row">
-      <Suspense fallback={null}>
-        <BandsListPane />
-      </Suspense>
-      <div className="min-w-0 flex-1 lg:overflow-y-auto">{children}</div>
-    </div>
-  );
+  return <div className="h-full">{children}</div>;
 }

--- a/src/app/(main)/bands/new/page.tsx
+++ b/src/app/(main)/bands/new/page.tsx
@@ -4,13 +4,13 @@ import { PageTitle } from '@/components/layout/page-title';
 import { BandCreateForm } from '@/domain/band/components/BandCreateForm.client';
 
 export const metadata: Metadata = {
-  title: '밴드 만들기 | Bandage',
+  title: '밴드 생성 | Bandage',
 };
 
 export default function BandNewPage() {
   return (
     <div className="space-y-6">
-      <PageTitle title="밴드 만들기" description="새 밴드의 기본 정보를 입력하세요." />
+      <PageTitle title="밴드 생성" description="새 밴드의 기본 정보를 입력하세요." />
       <BandCreateForm />
     </div>
   );

--- a/src/app/(main)/bands/page.tsx
+++ b/src/app/(main)/bands/page.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from 'next';
-import { Users } from 'lucide-react';
-
-import { EmptyPane } from '@/components/feedback/empty-pane';
+import { Suspense } from 'react';
 
 import { BandsMobileShell } from './BandsMobileShell.client';
 
@@ -11,19 +9,10 @@ export const metadata: Metadata = {
 
 export default function BandsPage() {
   return (
-    <>
-      {/* Mobile: 풀스크린 탭 + 바텀시트 */}
-      <div className="p-s-4 lg:hidden">
+    <Suspense fallback={null}>
+      <div className="p-s-4 lg:pt-15">
         <BandsMobileShell />
       </div>
-      {/* Desktop: 좌측 BandsListPane + EmptyPane */}
-      <div className="hidden h-full lg:block">
-        <EmptyPane
-          icon={Users}
-          title="밴드를 선택해 주세요"
-          description="왼쪽 목록에서 밴드를 선택하면 상세 정보가 이곳에 표시됩니다."
-        />
-      </div>
-    </>
+    </Suspense>
   );
 }

--- a/src/app/(main)/bands/page.tsx
+++ b/src/app/(main)/bands/page.tsx
@@ -2,9 +2,8 @@ import type { Metadata } from 'next';
 import { Users } from 'lucide-react';
 
 import { EmptyPane } from '@/components/feedback/empty-pane';
-import { PageTitle } from '@/components/layout/page-title';
 
-import { BandsList } from './BandsList.client';
+import { BandsMobileShell } from './BandsMobileShell.client';
 
 export const metadata: Metadata = {
   title: '밴드 | Bandage',
@@ -13,10 +12,9 @@ export const metadata: Metadata = {
 export default function BandsPage() {
   return (
     <>
-      {/* Mobile: 기존 리스트 페이지 */}
-      <div className="space-y-s-6 p-s-4 lg:hidden">
-        <PageTitle title="밴드" description="참여 중인 밴드를 확인하거나 새 밴드를 만드세요." />
-        <BandsList />
+      {/* Mobile: 풀스크린 탭 + 바텀시트 */}
+      <div className="p-s-4 lg:hidden">
+        <BandsMobileShell />
       </div>
       {/* Desktop: 좌측 BandsListPane + EmptyPane */}
       <div className="hidden h-full lg:block">

--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -27,6 +27,7 @@ import { WeeklyTimetable } from '@/domain/member/components/WeeklyTimetable.clie
 import { useMe } from '@/domain/member/hooks/useMe';
 import { useMyAvailability } from '@/domain/member/hooks/useMyAvailability';
 import { useUpdateMyAvailability } from '@/domain/member/hooks/useUpdateMyAvailability';
+import { useDeleteMyProfileImage } from '@/domain/member/hooks/useDeleteMyProfileImage';
 import { useUpdateMe } from '@/domain/member/hooks/useUpdateMe';
 import { useWithdraw } from '@/domain/member/hooks/useWithdraw';
 import {
@@ -262,6 +263,11 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
     onError: (err) => toast.error(err.message || '프로필 이미지 변경에 실패했습니다.'),
   });
 
+  const deleteImgMutation = useDeleteMyProfileImage({
+    onSuccess: () => toast.success('프로필 이미지가 삭제되었습니다.'),
+    onError: (err) => toast.error(err.message || '프로필 이미지 삭제에 실패했습니다.'),
+  });
+
   return (
     <Card padding="none" className="overflow-visible rounded-md border-[3px]">
       <form onSubmit={form.handleSubmit((values) => mutation.mutate(values))} noValidate>
@@ -277,7 +283,7 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
               disabled={imgMutation.isPending}
               imageClassName="rounded-[100px]"
               showButton={false}
-              onDelete={() => {}}
+              onDelete={() => deleteImgMutation.mutate()}
             />
           </div>
 

--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChevronLeft, LogOut } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { ErrorState } from '@/components/feedback/error-state';
@@ -19,9 +19,12 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { PasswordStrength } from '@/components/ui/password-strength';
 import { ProfileImageUpload } from '@/components/ui/profile-image-upload';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useChangePassword } from '@/domain/auth/hooks/useChangePassword';
 import { useLogout } from '@/domain/auth/hooks/useLogout';
+import { passwordChangeSchema, type PasswordChangeSchema } from '@/domain/auth/types/schema';
 import { ScheduleManagerModal } from '@/domain/member/components/ScheduleManagerModal.client';
 import { WeeklyTimetable } from '@/domain/member/components/WeeklyTimetable.client';
 import { useMe } from '@/domain/member/hooks/useMe';
@@ -41,7 +44,6 @@ import { useMyPerformances } from '@/domain/performance/hooks/useMyPerformances'
 import { useMyPractices } from '@/domain/practice/hooks/useMyPractices';
 import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
-import { formatPhone } from '@/lib/phone';
 
 export function MeContent() {
   const router = useRouter();
@@ -57,6 +59,15 @@ export function MeContent() {
   const [isEditing, setEditing] = useState(false);
   const [withdrawOpen, setWithdrawOpen] = useState(false);
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
+
+  const editContainerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!isEditing) return;
+    const id = requestAnimationFrame(() => {
+      (document.activeElement as HTMLElement)?.blur();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [isEditing]);
 
   const updateAvailabilityMutation = useUpdateMyAvailability({
     onSuccess: () => {
@@ -105,7 +116,7 @@ export function MeContent() {
   }
 
   return (
-    <div className="space-y-s-6">
+    <div ref={editContainerRef} tabIndex={-1} className="space-y-s-6 outline-none">
       {/* 프로필 정보 섹션 */}
       <section>
         <div className="mb-s-3 relative flex min-h-8 items-center">
@@ -147,7 +158,6 @@ export function MeContent() {
               <div className="space-y-1 pt-0.5">
                 <div className="text-foreground text-lg font-semibold">{me.name}</div>
                 <div className="text-foreground-sub text-sm">{me.email}</div>
-                {me.contact && <div className="text-foreground-muted text-xs">{me.contact}</div>}
               </div>
             </div>
           </Card>
@@ -164,13 +174,21 @@ export function MeContent() {
         />
       )}
 
+      {/* 비밀번호 변경 — 편집 모드에서만 표시 */}
+      {isEditing && (
+        <section className="mt-[60px]">
+          <h2 className="text-foreground mb-s-3 text-[16px] font-bold">비밀번호 변경</h2>
+          <PasswordChangeCard />
+        </section>
+      )}
+
       {/* 계정 탈퇴 — 편집 모드에서만 표시 */}
       {isEditing && (
         <section className="mt-[60px]">
           <h2 className="text-foreground mb-s-3 text-[16px] font-bold">계정 탈퇴</h2>
           <Card padding="lg" className="border-foreground-sub bg-bg">
             <div className="flex items-center justify-between gap-4">
-              <p className="text-foreground-sub text-[12px]">
+              <p className="text-foreground-sub text-[14px]">
                 탈퇴 후에는 참여 중인 밴드·합주·공연 데이터에 접근할 수 없습니다. 탈퇴를
                 진행하시겠습니까?
               </p>
@@ -247,7 +265,7 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
   const toast = useToast();
   const form = useForm<UpdateMeSchema>({
     resolver: zodResolver(updateMeSchema),
-    defaultValues: { name: member.name, contact: member.contact },
+    defaultValues: { name: member.name },
   });
 
   const mutation = useUpdateMe({
@@ -273,13 +291,13 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
       <form onSubmit={form.handleSubmit((values) => mutation.mutate(values))} noValidate>
         <div className="flex">
           {/* 좌측: 프로필 이미지 */}
-          <div className="py-s-6 flex w-[220px] shrink-0 items-center justify-center">
+          <div className="py-s-6 flex w-[180px] shrink-0 items-center justify-center">
             <ProfileImageUpload
               value={member.profileImg ?? null}
               onChange={(objectKey) => imgMutation.mutate({ profileImg: objectKey })}
               domain="MEMBER"
               label=""
-              size={150}
+              size={120}
               disabled={imgMutation.isPending}
               imageClassName="rounded-[100px]"
               showButton={false}
@@ -295,7 +313,7 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
               <span className="text-foreground-sub text-sm">이름</span>
               <Input
                 error={form.formState.errors.name?.message}
-                className="focus-visible:ring-white"
+                className={EDIT_INPUT_CLASS}
                 {...form.register('name')}
               />
             </div>
@@ -303,19 +321,7 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
               <span className="text-foreground-sub text-sm">이메일</span>
               <Input value={member.email} disabled readOnly className="focus-visible:ring-white" />
             </div>
-            <div className="grid grid-cols-[80px_1fr] items-center gap-4">
-              <span className="text-foreground-sub text-sm">연락처</span>
-              <Input
-                error={form.formState.errors.contact?.message}
-                className="focus-visible:ring-white"
-                {...form.register('contact')}
-                onChange={(e) => {
-                  const formatted = formatPhone(e.target.value);
-                  e.target.value = formatted;
-                  void form.register('contact').onChange(e);
-                }}
-              />
-            </div>
+
             <div className="flex justify-end">
               <Button
                 type="submit"
@@ -327,6 +333,99 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
                 수정 완료
               </Button>
             </div>
+          </div>
+        </div>
+      </form>
+    </Card>
+  );
+}
+
+const EDIT_INPUT_CLASS =
+  'rounded-[5px] border-white/20 hover:border-white/35 focus-visible:ring-0 focus-visible:border-white/70';
+
+const PASSWORD_INPUT_CLASS =
+  'rounded-[5px] border-white/20 hover:border-white/35 focus-visible:ring-0 focus-visible:border-white/70 not-placeholder-shown:border-white/70';
+
+function PasswordChangeCard() {
+  const toast = useToast();
+  const form = useForm<PasswordChangeSchema>({
+    resolver: zodResolver(passwordChangeSchema),
+    mode: 'onChange',
+    defaultValues: { originalPassword: '', newPassword: '', confirmPassword: '' },
+  });
+
+  const mutation = useChangePassword({
+    onSuccess: () => {
+      toast.success('비밀번호가 변경되었습니다.');
+      form.reset();
+    },
+    onError: (err) => toast.error(err.message || '비밀번호 변경에 실패했습니다.'),
+  });
+
+  return (
+    <Card padding="none" className="overflow-visible rounded-md border-[3px]">
+      <form onSubmit={form.handleSubmit((values) => mutation.mutate(values))} noValidate>
+        <div className="gap-s-4 p-s-6 flex flex-col">
+          <div className="flex items-start gap-6">
+            <span className="text-foreground-sub w-36 shrink-0 pt-2.5 text-sm whitespace-nowrap">
+              현재 비밀번호
+            </span>
+            <div className="min-w-0 flex-1">
+              <Input
+                type="password"
+                placeholder="현재 비밀번호 입력"
+                error={form.formState.errors.originalPassword?.message}
+                className={PASSWORD_INPUT_CLASS}
+                {...form.register('originalPassword')}
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-start gap-6">
+              <span className="text-foreground-sub w-36 shrink-0 pt-2.5 text-sm whitespace-nowrap">
+                새 비밀번호
+              </span>
+              <div className="min-w-0 flex-1">
+                <Input
+                  type="password"
+                  placeholder="새 비밀번호 입력"
+                  error={form.formState.errors.newPassword?.message}
+                  className={PASSWORD_INPUT_CLASS}
+                  {...form.register('newPassword')}
+                />
+              </div>
+            </div>
+            {form.watch('newPassword') && (
+              <div className="flex items-start gap-6">
+                <span className="w-36 shrink-0" aria-hidden="true" />
+                <PasswordStrength password={form.watch('newPassword')} className="flex-1" />
+              </div>
+            )}
+          </div>
+          <div className="flex items-start gap-6">
+            <span className="text-foreground-sub w-36 shrink-0 pt-2.5 text-sm whitespace-nowrap">
+              새 비밀번호 확인
+            </span>
+            <div className="min-w-0 flex-1">
+              <Input
+                type="password"
+                placeholder="새 비밀번호 재입력"
+                error={form.formState.errors.confirmPassword?.message}
+                className={PASSWORD_INPUT_CLASS}
+                {...form.register('confirmPassword')}
+              />
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              variant="secondary"
+              size="sm"
+              loading={mutation.isPending}
+              className="rounded-[5px]"
+            >
+              변경하기
+            </Button>
           </div>
         </div>
       </form>

--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -31,6 +31,7 @@ import { useUpdateMe } from '@/domain/member/hooks/useUpdateMe';
 import { useWithdraw } from '@/domain/member/hooks/useWithdraw';
 import {
   updateMeSchema,
+  type AvailabilityExceptionRequest,
   type MemberInfoResponse,
   type UpdateMeSchema,
   type WeeklyRuleRequest,
@@ -64,8 +65,12 @@ export function MeContent() {
     onError: (err) => toast.error(err.message || '스케줄 저장에 실패했습니다.'),
   });
 
-  const handleSaveSchedule = (weeklyRules: WeeklyRuleRequest[], note: string) => {
-    updateAvailabilityMutation.mutate({ weeklyRules, note });
+  const handleSaveSchedule = (
+    weeklyRules: WeeklyRuleRequest[],
+    note: string,
+    exceptions: AvailabilityExceptionRequest[],
+  ) => {
+    updateAvailabilityMutation.mutate({ weeklyRules, exceptions, note });
   };
 
   const logoutMutation = useLogout({

--- a/src/app/(main)/practices/PracticesListPane.client.tsx
+++ b/src/app/(main)/practices/PracticesListPane.client.tsx
@@ -82,9 +82,9 @@ export function PracticesListPane() {
     >
       <div className="border-border px-s-3 py-s-3 flex items-center justify-between border-b">
         <h2 className="text-body font-bold">합주 탐색</h2>
-        <Button asChild size="sm" variant="accent-outline" aria-label="합주 시작하기">
+        <Button asChild size="sm" variant="accent-outline" aria-label="합주 생성">
           <Link href={ROUTES.PRACTICE_NEW}>
-            <Plus className="h-4 w-4" /> 합주 시작하기
+            <Plus className="h-4 w-4" /> 합주 생성
           </Link>
         </Button>
       </div>

--- a/src/app/(main)/setlist-meetings/SetlistMeetingsListPane.client.tsx
+++ b/src/app/(main)/setlist-meetings/SetlistMeetingsListPane.client.tsx
@@ -122,8 +122,8 @@ export function SetlistMeetingsListPane({
         <div className="gap-s-1 flex items-center">
           <MeetingCreateModal
             trigger={
-              <Button size="sm" variant="accent-outline" aria-label="새 선곡 회의 만들기">
-                <Plus className="h-4 w-4" /> 회의 만들기
+              <Button size="sm" variant="accent-outline" aria-label="선곡 회의 생성">
+                <Plus className="h-4 w-4" /> 선곡 회의 생성
               </Button>
             }
           />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -148,6 +148,24 @@
     }
   }
 
+  @keyframes slide-in-right {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes slide-out-right {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(100%);
+    }
+  }
+
   @keyframes shimmer {
     0% {
       background-position: -400px 0;

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -46,7 +46,7 @@ const mainNav: NavItem[] = [
     icon: Music,
     subs: [
       { href: ROUTES.PRACTICES, label: '나의 합주' },
-      { href: ROUTES.PRACTICE_NEW, label: '합주 시작하기' },
+      { href: ROUTES.PRACTICE_NEW, label: '합주 생성' },
     ],
   },
   {
@@ -64,7 +64,7 @@ const mainNav: NavItem[] = [
     icon: ListMusic,
     subs: [
       { href: `${ROUTES.SETLIST_MEETINGS}?listOpen=1`, label: '나의 선곡 회의' },
-      { href: ROUTES.SETLIST_MEETING_NEW, label: '회의 만들기' },
+      { href: ROUTES.SETLIST_MEETING_NEW, label: '선곡 회의 생성' },
       { href: ROUTES.SETLIST_SCHEDULING, label: '합주 일정 조율' },
     ],
   },

--- a/src/components/ui/__snapshots__/common-components.test.tsx.snap
+++ b/src/components/ui/__snapshots__/common-components.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`공용 컴포넌트 신규 / 보정 > EmptyPane 1`] = `
 exports[`공용 컴포넌트 신규 / 보정 > RoleBadge(LEADER) 1`] = `
 <DocumentFragment>
   <span
-    class="rounded-pill inline-flex items-center border px-2 py-0.5 font-semibold bg-amber-dim text-amber border-transparent"
+    class="rounded-pill text-micro inline-flex items-center border px-2 py-0.5 font-semibold bg-amber-dim text-amber border-transparent"
     data-role="LEADER"
     data-slot="role-badge"
   >

--- a/src/components/ui/__snapshots__/step-indicator.test.tsx.snap
+++ b/src/components/ui/__snapshots__/step-indicator.test.tsx.snap
@@ -16,12 +16,12 @@ exports[`StepIndicator > current=0: 첫 단계 active, 두번째 pending 1`] = `
       >
         <span
           aria-label="1단계 (진행 중)"
-          class="flex h-[26px] w-[26px] items-center justify-center rounded-full border-[1.5px] font-bold transition-all duration-200 bg-accent border-accent text-foreground"
+          class="text-caption flex h-[26px] w-[26px] items-center justify-center rounded-full border-[1.5px] font-bold transition-all duration-200 bg-accent border-accent text-foreground"
         >
           1
         </span>
         <span
-          class="whitespace-nowrap text-foreground font-semibold"
+          class="text-caption whitespace-nowrap text-foreground font-semibold"
         >
           기본 정보
         </span>
@@ -39,12 +39,12 @@ exports[`StepIndicator > current=0: 첫 단계 active, 두번째 pending 1`] = `
       >
         <span
           aria-label="2단계"
-          class="flex h-[26px] w-[26px] items-center justify-center rounded-full border-[1.5px] font-bold transition-all duration-200 bg-card border-border text-foreground-muted"
+          class="text-caption flex h-[26px] w-[26px] items-center justify-center rounded-full border-[1.5px] font-bold transition-all duration-200 bg-card border-border text-foreground-muted"
         >
           2
         </span>
         <span
-          class="whitespace-nowrap text-foreground-muted"
+          class="text-caption whitespace-nowrap text-foreground-muted"
         >
           계정 설정
         </span>
@@ -69,7 +69,7 @@ exports[`StepIndicator > current=1: 첫 단계 done(체크), 두번째 active 1`
       >
         <span
           aria-label="1단계 (완료)"
-          class="flex h-[26px] w-[26px] items-center justify-center rounded-full border-[1.5px] font-bold transition-all duration-200 bg-accent-dim border-accent text-accent"
+          class="text-caption flex h-[26px] w-[26px] items-center justify-center rounded-full border-[1.5px] font-bold transition-all duration-200 bg-accent-dim border-accent text-accent"
         >
           <svg
             aria-hidden="true"
@@ -90,7 +90,7 @@ exports[`StepIndicator > current=1: 첫 단계 done(체크), 두번째 active 1`
           </svg>
         </span>
         <span
-          class="whitespace-nowrap text-foreground-muted"
+          class="text-caption whitespace-nowrap text-foreground-muted"
         >
           기본 정보
         </span>
@@ -109,12 +109,12 @@ exports[`StepIndicator > current=1: 첫 단계 done(체크), 두번째 active 1`
       >
         <span
           aria-label="2단계 (진행 중)"
-          class="flex h-[26px] w-[26px] items-center justify-center rounded-full border-[1.5px] font-bold transition-all duration-200 bg-accent border-accent text-foreground"
+          class="text-caption flex h-[26px] w-[26px] items-center justify-center rounded-full border-[1.5px] font-bold transition-all duration-200 bg-accent border-accent text-foreground"
         >
           2
         </span>
         <span
-          class="whitespace-nowrap text-foreground font-semibold"
+          class="text-caption whitespace-nowrap text-foreground font-semibold"
         >
           계정 설정
         </span>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -2,7 +2,15 @@ import { type HTMLAttributes } from 'react';
 
 import { cn } from '@/lib/cn';
 
-export type BadgeVariant = 'default' | 'accent' | 'success' | 'warn' | 'amber' | 'danger' | 'muted';
+export type BadgeVariant =
+  | 'default'
+  | 'accent'
+  | 'success'
+  | 'warn'
+  | 'amber'
+  | 'danger'
+  | 'muted'
+  | 'blue';
 
 export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   variant?: BadgeVariant;
@@ -16,6 +24,7 @@ const variantClasses: Record<BadgeVariant, string> = {
   amber: 'bg-amber-dim text-amber',
   danger: 'bg-danger-dim text-danger',
   muted: 'bg-surface text-foreground-muted border border-transparent',
+  blue: 'bg-blue-dim text-blue',
 };
 
 export function Badge({ variant = 'default', className, children, ...props }: BadgeProps) {

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { cn } from '@/lib/cn';
+
+const DOW = ['일', '월', '화', '수', '목', '금', '토'];
+
+function pad(n: number) {
+  return String(n).padStart(2, '0');
+}
+
+function parseDate(s: string): { y: number; mo: number; d: number } | null {
+  if (!s) return null;
+  const m = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!m) return null;
+  return { y: Number(m[1]), mo: Number(m[2]), d: Number(m[3]) };
+}
+
+function fmtDate(y: number, mo: number, d: number): string {
+  return `${y}-${pad(mo)}-${pad(d)}`;
+}
+
+type Props = {
+  value: string;
+  onChange: (v: string) => void;
+  min?: string;
+  max?: string;
+  placeholder?: string;
+  className?: string;
+};
+
+export function DatePicker({
+  value,
+  onChange,
+  min,
+  max,
+  placeholder = '날짜 선택',
+  className,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const parsed = parseDate(value);
+  const today = new Date();
+  const todayStr = fmtDate(today.getFullYear(), today.getMonth() + 1, today.getDate());
+
+  const [viewYear, setViewYear] = useState(parsed?.y ?? today.getFullYear());
+  const [viewMonth, setViewMonth] = useState(parsed?.mo ?? today.getMonth() + 1);
+
+  useEffect(() => {
+    if (open) {
+      const p = parseDate(value);
+      const t = new Date();
+      setViewYear(p?.y ?? t.getFullYear());
+      setViewMonth(p?.mo ?? t.getMonth() + 1);
+    }
+  }, [open, value]);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      const popup = document.getElementById('date-picker-popup');
+      if (popup?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [open]);
+
+  const handleOpen = () => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPos({ top: rect.bottom + 4, left: rect.left });
+    }
+    setOpen((v) => !v);
+  };
+
+  const navMonth = (dir: number) => {
+    let mo = viewMonth + dir;
+    let y = viewYear;
+    if (mo > 12) {
+      mo = 1;
+      y += 1;
+    }
+    if (mo < 1) {
+      mo = 12;
+      y -= 1;
+    }
+    setViewYear(y);
+    setViewMonth(mo);
+  };
+
+  const pick = (y: number, mo: number, d: number) => {
+    onChange(fmtDate(y, mo, d));
+    setOpen(false);
+  };
+
+  const firstDow = new Date(viewYear, viewMonth - 1, 1).getDay();
+  const daysInMonth = new Date(viewYear, viewMonth, 0).getDate();
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < firstDow; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const displayLabel = parsed ? `${parsed.y}.${pad(parsed.mo)}.${pad(parsed.d)}` : placeholder;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={handleOpen}
+        className={cn(
+          'border-border bg-surface flex w-full items-center justify-between rounded-md border px-2 py-1.5 text-[12px]',
+          parsed ? 'text-[#d1d5db]' : 'text-foreground-muted',
+          className,
+        )}
+      >
+        <span>{displayLabel}</span>
+        <CalendarDays className="text-foreground-muted h-3.5 w-3.5 shrink-0" />
+      </button>
+
+      {open && pos && (
+        <div
+          id="date-picker-popup"
+          className="bg-card border-border fixed z-[200] w-60 rounded-lg border p-3 shadow-2xl"
+          style={{ top: pos.top, left: pos.left }}
+        >
+          <div className="mb-2 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => navMonth(-1)}
+              className="text-foreground-sub hover:text-foreground p-1"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <span className="text-foreground text-[12px] font-semibold">
+              {viewYear}년 {viewMonth}월
+            </span>
+            <button
+              type="button"
+              onClick={() => navMonth(1)}
+              className="text-foreground-sub hover:text-foreground p-1"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="mb-1 grid grid-cols-7">
+            {DOW.map((label, i) => (
+              <div
+                key={label}
+                className={cn(
+                  'py-0.5 text-center text-[10px] font-medium',
+                  i === 0 ? 'text-red-400' : i === 6 ? 'text-blue-400' : 'text-foreground-muted',
+                )}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7">
+            {cells.map((d, idx) => {
+              if (d === null) return <div key={`p-${idx}`} className="aspect-square" />;
+              const dateStr = fmtDate(viewYear, viewMonth, d);
+              const isSelected = dateStr === value;
+              const isToday = dateStr === todayStr;
+              const isDisabled = (min && dateStr < min) || (max && dateStr > max);
+              const dow = (firstDow + d - 1) % 7;
+
+              return (
+                <button
+                  key={d}
+                  type="button"
+                  disabled={!!isDisabled}
+                  onClick={() => pick(viewYear, viewMonth, d)}
+                  className={cn(
+                    'flex aspect-square items-center justify-center rounded-md text-[11px] transition-colors',
+                    isSelected && 'bg-[#d1d5db] font-bold text-black',
+                    !isSelected && isToday && 'font-bold text-[#d1d5db]',
+                    !isSelected &&
+                      !isToday &&
+                      (dow === 0
+                        ? 'text-red-400'
+                        : dow === 6
+                          ? 'text-blue-400'
+                          : 'text-foreground'),
+                    !isSelected && !isDisabled && 'hover:bg-white/10',
+                    isDisabled && 'cursor-not-allowed opacity-30',
+                  )}
+                >
+                  {d}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ui/profile-image-upload.tsx
+++ b/src/components/ui/profile-image-upload.tsx
@@ -27,7 +27,7 @@ interface Props {
   hint?: string;
   /** 외부에서 disable. 업로드 중 자체 disable 은 별개. */
   disabled?: boolean;
-  /** 미리보기 이미지 크기. default 96px. */
+  /** 미리보기 이미지 크기(px). 미지정 시 imageClassName 의 크기를 따름. */
   size?: number;
   /** 이미지 버튼에 추가할 className (rounded-full 등 오버라이드용). */
   imageClassName?: string;
@@ -52,7 +52,7 @@ export function ProfileImageUpload({
   label = '프로필 이미지',
   hint,
   disabled,
-  size = 96,
+  size,
   imageClassName,
   showButton = true,
   onDelete,
@@ -135,8 +135,8 @@ export function ProfileImageUpload({
           {label}
         </label>
       )}
-      <div className="flex items-center gap-3">
-        <div ref={containerRef} className="relative">
+      <div className={cn('flex items-center gap-3', !showButton && 'w-full')}>
+        <div ref={containerRef} className={cn('relative', !showButton && 'w-full')}>
           <button
             type="button"
             id={id}
@@ -148,7 +148,7 @@ export function ProfileImageUpload({
               isDisabled ? 'cursor-not-allowed opacity-50' : 'group cursor-pointer',
               imageClassName,
             )}
-            style={{ width: size, height: size }}
+            style={size ? { width: size, height: size } : undefined}
           >
             {display ? (
               // eslint-disable-next-line @next/next/no-img-element -- CloudFront/Blob/외부 OAuth provider URL 모두 허용
@@ -186,7 +186,7 @@ export function ProfileImageUpload({
 
           {/* 변경/삭제 토글 메뉴 */}
           {menuOpen && (
-            <div className="bg-card border-border absolute top-full left-1/2 z-20 mt-2 min-w-30 -translate-x-1/2 overflow-hidden rounded-md border shadow-md">
+            <div className="bg-card border-border absolute top-full left-1/2 z-20 mt-2 w-[110px] -translate-x-1/2 overflow-hidden rounded-md border shadow-md">
               {display ? (
                 <>
                   <button
@@ -194,7 +194,7 @@ export function ProfileImageUpload({
                     onClick={handleMenuChange}
                     className="text-foreground hover:bg-card-hover w-full px-4 py-2.5 text-center text-sm transition-colors"
                   >
-                    이미지 변경
+                    이미지 교체
                   </button>
                   <button
                     type="button"

--- a/src/domain/band/api/deleteBandProfileImage.ts
+++ b/src/domain/band/api/deleteBandProfileImage.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function deleteBandProfileImage(bandId: string): Promise<void> {
+  await apiClient.delete(`/api/v1/bands/${bandId}/profile-image`);
+}

--- a/src/domain/band/components/BandApplicationRow.tsx
+++ b/src/domain/band/components/BandApplicationRow.tsx
@@ -12,6 +12,7 @@ import type { BandApplicationInfoResponse } from '../types';
 type Props = {
   bandId: string;
   application: BandApplicationInfoResponse;
+  onDecide?: () => void;
 };
 
 const STATUS_LABEL: Record<BandApplicationInfoResponse['status'], string> = {
@@ -22,11 +23,13 @@ const STATUS_LABEL: Record<BandApplicationInfoResponse['status'], string> = {
   LEAVED: '탈퇴',
 };
 
-export function BandApplicationRow({ bandId, application }: Props) {
+export function BandApplicationRow({ bandId, application, onDecide }: Props) {
   const toast = useToast();
   const mutation = useDecideApplication(bandId, {
-    onSuccess: (vars) =>
-      toast.success(vars.decision === 'APPROVED' ? '가입을 승인했습니다.' : '가입을 거절했습니다.'),
+    onSuccess: (vars) => {
+      toast.success(vars.decision === 'APPROVED' ? '가입을 승인했습니다.' : '가입을 거절했습니다.');
+      onDecide?.();
+    },
     onError: (err) => toast.error(err.message || '처리에 실패했습니다.'),
   });
 
@@ -44,14 +47,14 @@ export function BandApplicationRow({ bandId, application }: Props) {
       <Avatar size="lg" fallback={displayName} />
       <div className="min-w-0 flex-1">
         <p className="text-foreground truncate text-sm font-semibold">{displayName}</p>
-        <p className="text-foreground-muted text-caption mt-0.5">
-          {isPending ? '신청 대기 중' : STATUS_LABEL[application.status]}
-        </p>
+        {isPending && <p className="text-foreground-muted text-caption mt-0.5">신청 대기 중</p>}
       </div>
       {isPending ? (
         <div className="flex items-center gap-2">
           <Button
             size="sm"
+            variant="primary"
+            className="bg-blue hover:bg-blue/80 border-blue hover:border-blue/80 rounded-[5px]"
             onClick={() =>
               mutation.mutate({
                 applicationId: application.bandApplicationId,
@@ -65,6 +68,7 @@ export function BandApplicationRow({ bandId, application }: Props) {
           <Button
             size="sm"
             variant="danger"
+            className="rounded-[5px]"
             onClick={() =>
               mutation.mutate({
                 applicationId: application.bandApplicationId,
@@ -77,7 +81,7 @@ export function BandApplicationRow({ bandId, application }: Props) {
           </Button>
         </div>
       ) : (
-        <Badge variant={application.status === 'APPROVED' ? 'success' : 'danger'}>
+        <Badge variant={application.status === 'APPROVED' ? 'blue' : 'danger'}>
           {STATUS_LABEL[application.status]}
         </Badge>
       )}

--- a/src/domain/band/components/BandCreateForm.client.tsx
+++ b/src/domain/band/components/BandCreateForm.client.tsx
@@ -46,6 +46,7 @@ export function BandCreateForm() {
       />
       <Textarea
         label="소개"
+        required
         placeholder="밴드 소개를 입력하세요 (최대 200자)"
         error={form.formState.errors.description?.message}
         {...form.register('description')}

--- a/src/domain/band/components/BandCreateForm.client.tsx
+++ b/src/domain/band/components/BandCreateForm.client.tsx
@@ -54,7 +54,7 @@ export function BandCreateForm() {
         프로필 이미지는 밴드 생성 후 [밴드 설정 → 사진] 에서 업로드할 수 있습니다.
       </p>
       <Button type="submit" className="w-full" loading={mutation.isPending}>
-        밴드 만들기
+        밴드 생성
       </Button>
     </form>
   );

--- a/src/domain/band/components/BandCreateModal.client.tsx
+++ b/src/domain/band/components/BandCreateModal.client.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useRouter } from 'next/navigation';
 import { useState, type ReactNode } from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -14,17 +13,16 @@ import {
   ResponsiveSheetContent,
   ResponsiveSheetFooter,
   ResponsiveSheetHeader,
+  ResponsiveSheetDescription,
   ResponsiveSheetTitle,
   ResponsiveSheetTrigger,
 } from '@/components/ui/responsive-sheet';
 import { Textarea } from '@/components/ui/textarea';
 import { useCreateBand } from '@/domain/band/hooks/useCreateBand';
 import { createBandSchema, type CreateBandSchema } from '@/domain/band/types';
-import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
 
 export function BandCreateModal({ trigger }: { trigger: ReactNode }) {
-  const router = useRouter();
   const toast = useToast();
   const [open, setOpen] = useState(false);
 
@@ -35,11 +33,10 @@ export function BandCreateModal({ trigger }: { trigger: ReactNode }) {
   });
 
   const mutation = useCreateBand({
-    onSuccess: (data) => {
+    onSuccess: () => {
       toast.success('밴드가 생성되었습니다.');
       setOpen(false);
       form.reset();
-      router.replace(ROUTES.BAND_DETAIL(data.bandId));
     },
     onError: (err) => toast.error(err.message || '밴드 생성에 실패했습니다.'),
   });
@@ -53,10 +50,14 @@ export function BandCreateModal({ trigger }: { trigger: ReactNode }) {
       }}
     >
       <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>
-      <ResponsiveSheetContent>
-        <ResponsiveSheetHeader>
+      <ResponsiveSheetContent onOpenAutoFocus={(e) => e.preventDefault()}>
+        <ResponsiveSheetHeader className="border-b-0 pb-2">
           <ResponsiveSheetTitle>밴드 생성</ResponsiveSheetTitle>
+          <ResponsiveSheetDescription>
+            밴드 프로필 이미지는 밴드 생성 후 [밴드 설정 → 사진] 에서 업로드할 수 있습니다.
+          </ResponsiveSheetDescription>
         </ResponsiveSheetHeader>
+        <div className="border-border mx-5 border-b" />
         <ResponsiveSheetBody>
           <form
             id="band-create-form"
@@ -66,29 +67,43 @@ export function BandCreateModal({ trigger }: { trigger: ReactNode }) {
           >
             <Input
               label="밴드 이름"
-              placeholder="예: TuNA"
+              placeholder="밴드 이름을 입력하세요"
               required
+              hint={
+                <span className="block text-right">{(form.watch('name') ?? '').length}/50자</span>
+              }
               error={form.formState.errors.name?.message}
+              className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
               {...form.register('name')}
             />
             <Textarea
               label="소개"
-              placeholder="밴드 소개 (최대 200자)"
+              required
+              placeholder="밴드 소개글을 입력하세요"
+              hint={
+                <span className="block text-right">
+                  {(form.watch('description') ?? '').length}/200자
+                </span>
+              }
               error={form.formState.errors.description?.message}
+              className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
               {...form.register('description')}
             />
-            <p className="text-foreground-muted text-xs">
-              프로필 이미지는 밴드 생성 후 [밴드 설정 → 사진] 에서 업로드할 수 있습니다.
-            </p>
           </form>
         </ResponsiveSheetBody>
-        <ResponsiveSheetFooter>
+        <ResponsiveSheetFooter className="border-t-0 pt-1">
           <ResponsiveSheetClose asChild>
-            <Button type="button" variant="ghost">
+            <Button type="button" variant="ghost" className="h-8 rounded-[5px]">
               취소
             </Button>
           </ResponsiveSheetClose>
-          <Button type="submit" form="band-create-form" loading={mutation.isPending}>
+          <Button
+            type="submit"
+            form="band-create-form"
+            variant="secondary"
+            className="h-8 rounded-[5px] border-white bg-white px-2 text-neutral-900 hover:border-neutral-100 hover:bg-neutral-100 active:border-neutral-200 active:bg-neutral-200"
+            loading={mutation.isPending}
+          >
             밴드 생성
           </Button>
         </ResponsiveSheetFooter>

--- a/src/domain/band/components/BandCreateModal.client.tsx
+++ b/src/domain/band/components/BandCreateModal.client.tsx
@@ -55,7 +55,7 @@ export function BandCreateModal({ trigger }: { trigger: ReactNode }) {
       <ResponsiveSheetTrigger asChild>{trigger}</ResponsiveSheetTrigger>
       <ResponsiveSheetContent>
         <ResponsiveSheetHeader>
-          <ResponsiveSheetTitle>새 밴드 만들기</ResponsiveSheetTitle>
+          <ResponsiveSheetTitle>밴드 생성</ResponsiveSheetTitle>
         </ResponsiveSheetHeader>
         <ResponsiveSheetBody>
           <form
@@ -89,7 +89,7 @@ export function BandCreateModal({ trigger }: { trigger: ReactNode }) {
             </Button>
           </ResponsiveSheetClose>
           <Button type="submit" form="band-create-form" loading={mutation.isPending}>
-            밴드 만들기
+            밴드 생성
           </Button>
         </ResponsiveSheetFooter>
       </ResponsiveSheetContent>

--- a/src/domain/band/components/BandMemberRow.tsx
+++ b/src/domain/band/components/BandMemberRow.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { MoreVertical } from 'lucide-react';
 import { useState } from 'react';
 
 import { Avatar } from '@/components/ui/avatar';
@@ -14,9 +16,11 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useDelegateLeader } from '@/domain/band/hooks/useDelegateLeader';
+import { useRemoveBandMember } from '@/domain/band/hooks/useRemoveBandMember';
 import { getMemberDisplayName } from '@/domain/member/utils';
 import { RoleGuard } from '@/global/auth/RoleGuard';
 import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/cn';
 
 import { BandRoleBadge } from './BandRoleBadge';
 import type { BandMemberInfoResponse } from '../types';
@@ -27,14 +31,24 @@ type Props = {
 };
 
 export function BandMemberRow({ bandId, member }: Props) {
-  const [open, setOpen] = useState(false);
+  const [delegateOpen, setDelegateOpen] = useState(false);
+  const [removeOpen, setRemoveOpen] = useState(false);
   const toast = useToast();
+
   const delegateMutation = useDelegateLeader(bandId, {
     onSuccess: () => {
       toast.success('리더 권한을 위임했습니다.');
-      setOpen(false);
+      setDelegateOpen(false);
     },
     onError: (err) => toast.error(err.message || '리더 위임에 실패했습니다.'),
+  });
+
+  const removeMutation = useRemoveBandMember(bandId, {
+    onSuccess: () => {
+      toast.success('멤버를 강퇴했습니다.');
+      setRemoveOpen(false);
+    },
+    onError: (err) => toast.error(err.message || '강퇴에 실패했습니다.'),
   });
 
   const displayName = getMemberDisplayName({ memberId: member.memberId, name: member.name });
@@ -46,42 +60,112 @@ export function BandMemberRow({ bandId, member }: Props) {
     >
       <Avatar size="lg" fallback={displayName} />
       <div className="min-w-0 flex-1">
-        <p className="text-foreground truncate text-sm font-semibold">{displayName}</p>
-        <div className="mt-1">
-          <BandRoleBadge role={member.role} />
+        <div className="flex items-center gap-2">
+          <p className="text-foreground truncate text-sm font-semibold">{displayName}</p>
+          <BandRoleBadge role={member.role} className="shrink-0 bg-white/10 text-white" />
         </div>
       </div>
+
       {member.role !== 'LEADER' && (
         <RoleGuard bandId={bandId} role="LEADER">
-          <Button size="sm" variant="secondary" onClick={() => setOpen(true)}>
-            위임
-          </Button>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+              <button
+                type="button"
+                aria-label="멤버 옵션"
+                className="text-foreground-sub hover:text-foreground focus-visible:ring-accent rounded-sm p-1 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+              >
+                <MoreVertical className="h-4 w-4" />
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content
+                align="end"
+                sideOffset={4}
+                className={cn(
+                  'bg-card border-border z-50 min-w-[90px] rounded-lg border py-1 shadow-lg',
+                  'data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
+                )}
+              >
+                <DropdownMenu.Item
+                  className="text-foreground hover:bg-surface-hi cursor-pointer px-4 py-2.5 text-sm outline-none"
+                  onSelect={() => setDelegateOpen(true)}
+                >
+                  리더 위임
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  className="text-danger hover:bg-surface-hi cursor-pointer px-4 py-2.5 text-sm outline-none"
+                  onSelect={() => setRemoveOpen(true)}
+                >
+                  내보내기
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
         </RoleGuard>
       )}
 
-      <Dialog open={open} onOpenChange={setOpen}>
+      {/* 리더 위임 다이얼로그 */}
+      <Dialog open={delegateOpen} onOpenChange={setDelegateOpen}>
         <DialogContent>
-          <DialogHeader>
+          <DialogHeader className="border-b-0 pb-2">
             <DialogTitle>리더 권한 위임</DialogTitle>
             <DialogDescription>
-              이 멤버에게 리더 권한을 넘깁니다. 위임 후 본인은 일반 멤버로 전환됩니다.
+              해당 멤버에게 리더 권한을 넘깁니다. 위임 후 본인은 일반 멤버로 전환됩니다.
             </DialogDescription>
           </DialogHeader>
+          <div className="border-border mx-5 border-b" />
           <DialogBody>
             <p className="text-foreground-sub text-sm">
-              {displayName} 에게 리더를 위임하시겠어요? 이 동작은 되돌릴 수 없습니다.
+              <span className="text-nav-active font-bold">{displayName}</span> 에게 리더를
+              위임하시겠어요? 이 동작은 되돌릴 수 없습니다.
             </p>
           </DialogBody>
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setOpen(false)}>
+          <DialogFooter className="border-t-0">
+            <Button variant="ghost" className="h-8" onClick={() => setDelegateOpen(false)}>
               취소
             </Button>
             <Button
-              variant="primary"
+              variant="secondary"
+              className="h-8 rounded-[5px] border-white bg-white px-2 text-neutral-900 hover:border-neutral-100 hover:bg-neutral-100"
               loading={delegateMutation.isPending}
               onClick={() => delegateMutation.mutate(member.bandMemberId)}
             >
               위임하기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 멤버 강퇴 다이얼로그 */}
+      <Dialog open={removeOpen} onOpenChange={setRemoveOpen}>
+        <DialogContent>
+          <DialogHeader className="border-b-0 pb-2">
+            <DialogTitle>멤버 강제 탈퇴</DialogTitle>
+            <DialogDescription>해당 멤버를 밴드에서 강제 탈퇴시킵니다.</DialogDescription>
+          </DialogHeader>
+          <div className="border-border mx-5 border-b" />
+          <DialogBody>
+            <p className="text-foreground-sub text-sm">
+              <span className="text-nav-active font-bold">{displayName}</span> 을(를)
+              내보내시겠어요? 이 동작은 되돌릴 수 없습니다.
+            </p>
+          </DialogBody>
+          <DialogFooter className="border-t-0">
+            <Button
+              variant="ghost"
+              className="h-8 rounded-[5px]"
+              onClick={() => setRemoveOpen(false)}
+            >
+              취소
+            </Button>
+            <Button
+              variant="danger"
+              className="h-8 rounded-[5px] px-2"
+              loading={removeMutation.isPending}
+              onClick={() => removeMutation.mutate(member.bandMemberId)}
+            >
+              내보내기
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/domain/band/components/BandRoleBadge.tsx
+++ b/src/domain/band/components/BandRoleBadge.tsx
@@ -14,6 +14,10 @@ const roleVariant: Record<BandRole, BadgeVariant> = {
   MEMBER: 'default',
 };
 
-export function BandRoleBadge({ role }: { role: BandRole }) {
-  return <Badge variant={roleVariant[role]}>{roleLabel[role]}</Badge>;
+export function BandRoleBadge({ role, className }: { role: BandRole; className?: string }) {
+  return (
+    <Badge variant={roleVariant[role]} className={className}>
+      {roleLabel[role]}
+    </Badge>
+  );
 }

--- a/src/domain/band/components/BandSettingsModal.client.tsx
+++ b/src/domain/band/components/BandSettingsModal.client.tsx
@@ -116,6 +116,7 @@ export function BandSettingsModal({ open, onOpenChange, band }: Props) {
                 onChange={handleImageUploaded}
                 domain="BAND"
                 bandId={band.bandId}
+                size={96}
                 hint="JPEG / PNG / WEBP, 5MB 이하. 리더만 변경할 수 있습니다."
                 disabled={updateMutation.isPending}
               />

--- a/src/domain/band/hooks/useDecideApplication.ts
+++ b/src/domain/band/hooks/useDecideApplication.ts
@@ -22,7 +22,9 @@ export function useDecideApplication(bandId: string, options?: UseDecideApplicat
   return useMutation<void, Error, Variables>({
     mutationFn: ({ applicationId, decision }) => decideApplication(bandId, applicationId, decision),
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.applications(bandId)] });
+      queryClient.invalidateQueries({
+        queryKey: [...queryKeys.band.detail(bandId), 'applications'],
+      });
       queryClient.invalidateQueries({ queryKey: [...queryKeys.band.members(bandId)] });
       options?.onSuccess?.(variables);
     },

--- a/src/domain/band/hooks/useDelegateLeader.ts
+++ b/src/domain/band/hooks/useDelegateLeader.ts
@@ -18,6 +18,8 @@ export function useDelegateLeader(bandId: string, options?: UseDelegateLeaderOpt
     onSuccess: (_, bandMemberId) => {
       queryClient.invalidateQueries({ queryKey: [...queryKeys.band.members(bandId)] });
       queryClient.invalidateQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.band.my() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.band.list() });
       options?.onSuccess?.(bandMemberId);
     },
     onError: options?.onError,

--- a/src/domain/band/hooks/useDeleteBandProfileImage.ts
+++ b/src/domain/band/hooks/useDeleteBandProfileImage.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteBandProfileImage } from '@/domain/band/api/deleteBandProfileImage';
+import { queryKeys } from '@/global/config/queryKeys';
+
+interface Options {
+  onSuccess?: () => void;
+  onError?: (err: Error) => void;
+}
+
+export function useDeleteBandProfileImage(bandId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => deleteBandProfileImage(bandId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.band.detail(bandId) });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/band/hooks/useRemoveBandMember.ts
+++ b/src/domain/band/hooks/useRemoveBandMember.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { removeBandMember } from '../api/removeBandMember';
+
+type Options = {
+  onSuccess?: (bandMemberId: string) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useRemoveBandMember(bandId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (bandMemberId) => removeBandMember(bandId, bandMemberId),
+    onSuccess: (_, bandMemberId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.band.members(bandId) });
+      options?.onSuccess?.(bandMemberId);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/band/types/req.ts
+++ b/src/domain/band/types/req.ts
@@ -1,6 +1,7 @@
 export interface CreateBandRequest {
   name: string;
-  description?: string;
+  description: string;
+  profileImg?: string;
 }
 
 export type BandApplicationDecision = 'APPROVED' | 'REJECTED';

--- a/src/domain/band/types/schema.ts
+++ b/src/domain/band/types/schema.ts
@@ -7,8 +7,7 @@ export const createBandSchema = z.object({
     .max(50, '밴드 이름은 50자 이하로 입력해 주세요.'),
   description: z
     .string()
-    .max(200, '소개는 200자 이하로 입력해 주세요.')
-    .optional()
-    .or(z.literal('').transform(() => undefined)),
+    .min(1, '밴드 소개를 입력해 주세요.')
+    .max(200, '소개는 200자 이하로 입력해 주세요.'),
 });
 export type CreateBandSchema = z.infer<typeof createBandSchema>;

--- a/src/domain/member/api/deleteMyProfileImage.ts
+++ b/src/domain/member/api/deleteMyProfileImage.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function deleteMyProfileImage(): Promise<void> {
+  return apiClient.delete('/api/v1/members/me/profile-image');
+}

--- a/src/domain/member/components/ScheduleManagerModal.client.tsx
+++ b/src/domain/member/components/ScheduleManagerModal.client.tsx
@@ -612,7 +612,9 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                 className="placeholder:text-foreground-muted focus-visible:border-foreground-muted h-40 resize-none focus-visible:ring-0 focus-visible:ring-offset-0"
                 maxLength={500}
               />
-              <p className="text-foreground-muted mt-1 text-right text-[12px]">(500자 이내)</p>
+              <p className="text-foreground-muted mt-1 text-right text-[12px]">
+                {note.length}/500자
+              </p>
               <div className="mt-3 flex justify-between">
                 <Button
                   variant="ghost"

--- a/src/domain/member/components/ScheduleManagerModal.client.tsx
+++ b/src/domain/member/components/ScheduleManagerModal.client.tsx
@@ -1,16 +1,23 @@
 'use client';
 
-import { addDays, format, startOfWeek } from 'date-fns';
-import { X } from 'lucide-react';
+import { format } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
+import { Check, Plus, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { DatePicker } from '@/components/ui/date-picker';
 import { Textarea } from '@/components/ui/textarea';
 import { KST } from '@/lib/date';
 import { cn } from '@/lib/cn';
-import { toZonedTime } from 'date-fns-tz';
 
-import type { DayOfWeek, MemberAvailabilityResponse, WeeklyRuleRequest } from '../types';
+import type {
+  AvailabilityExceptionRequest,
+  AvailabilityKind,
+  DayOfWeek,
+  MemberAvailabilityResponse,
+  WeeklyRuleRequest,
+} from '../types';
 
 const DAY_OF_WEEK_KEYS: DayOfWeek[] = [
   'MONDAY',
@@ -23,12 +30,10 @@ const DAY_OF_WEEK_KEYS: DayOfWeek[] = [
 ];
 const DAY_SHORT = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 
-// 모달 표시 범위: 9:00(slot 18) ~ 22:00(slot 44)
 const START_SLOT = 18;
 const END_SLOT = 44;
-const SLOT_COUNT = END_SLOT - START_SLOT; // 26슬롯
-
-const CELL_HEIGHT = 22; // px
+const SLOT_COUNT = END_SLOT - START_SLOT;
+const CELL_HEIGHT = 22;
 
 function slotToTimeLabel(slot: number): string {
   const h = Math.floor(slot / 2);
@@ -36,7 +41,19 @@ function slotToTimeLabel(slot: number): string {
   return `${h}:${m}`;
 }
 
-/** [dayIdx][slotIdx] = selected? */
+function timeToSlot(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return (h ?? 0) * 2 + ((m ?? 0) >= 30 ? 1 : 0);
+}
+
+function slotToTime(slot: number): string {
+  const h = Math.floor(slot / 2)
+    .toString()
+    .padStart(2, '0');
+  const m = slot % 2 === 0 ? '00' : '30';
+  return `${h}:${m}`;
+}
+
 type GridState = boolean[][];
 
 function emptyGrid(): GridState {
@@ -47,19 +64,9 @@ function availabilityToGrid(availability: MemberAvailabilityResponse | undefined
   const grid = emptyGrid();
   if (!availability) return grid;
 
-  const now = toZonedTime(new Date(), KST);
-  const monday = startOfWeek(now, { weekStartsOn: 1 });
-  const weekDates = Array.from({ length: 7 }, (_, i) => addDays(monday, i));
-  const weekDateStrs = weekDates.map((d) => format(d, 'yyyy-MM-dd'));
-
   for (const rule of availability.weeklyRules) {
     const dayIdx = DAY_OF_WEEK_KEYS.indexOf(rule.dayOfWeek);
     if (dayIdx === -1) continue;
-    const dateStr = weekDateStrs[dayIdx];
-    if (!dateStr) continue;
-    if (rule.effectiveTo && dateStr > rule.effectiveTo) continue;
-    if (dateStr < rule.effectiveFrom) continue;
-
     for (let s = rule.startSlot; s < rule.endSlot; s++) {
       const idx = s - START_SLOT;
       if (idx >= 0 && idx < SLOT_COUNT) grid[dayIdx]![idx] = true;
@@ -68,18 +75,16 @@ function availabilityToGrid(availability: MemberAvailabilityResponse | undefined
   return grid;
 }
 
-function gridToWeeklyRules(grid: GridState): WeeklyRuleRequest[] {
+function gridToWeeklyRules(
+  grid: GridState,
+  effectiveFrom: string,
+  effectiveTo: string,
+): WeeklyRuleRequest[] {
   const rules: WeeklyRuleRequest[] = [];
-  const now = toZonedTime(new Date(), KST);
-  const monday = startOfWeek(now, { weekStartsOn: 1 });
-
   for (let d = 0; d < 7; d++) {
     const dayOfWeek = DAY_OF_WEEK_KEYS[d];
     if (!dayOfWeek) continue;
-    const dayDate = addDays(monday, d);
-    const effectiveFrom = format(dayDate, 'yyyy-MM-dd');
     const daySlots = grid[d]!;
-
     let i = 0;
     while (i < SLOT_COUNT) {
       if (daySlots[i]) {
@@ -90,6 +95,7 @@ function gridToWeeklyRules(grid: GridState): WeeklyRuleRequest[] {
           startSlot: start + START_SLOT,
           endSlot: i + START_SLOT,
           effectiveFrom,
+          effectiveTo: effectiveTo || undefined,
         });
       } else {
         i++;
@@ -107,30 +113,52 @@ type Props = {
   open: boolean;
   onClose: () => void;
   availability: MemberAvailabilityResponse | undefined;
-  onSave: (weeklyRules: WeeklyRuleRequest[], note: string) => void;
+  onSave: (
+    weeklyRules: WeeklyRuleRequest[],
+    note: string,
+    exceptions: AvailabilityExceptionRequest[],
+  ) => void;
   isSaving?: boolean;
 };
 
 export function ScheduleManagerModal({ open, onClose, availability, onSave, isSaving }: Props) {
-  const [step, setStep] = useState<1 | 2>(1);
+  const today = format(toZonedTime(new Date(), KST), 'yyyy-MM-dd');
+
+  const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
+  const [effectiveFrom, setEffectiveFrom] = useState(today);
+  const [effectiveTo, setEffectiveTo] = useState('');
   const [grid, setGrid] = useState<GridState>(emptyGrid);
+  const [exceptions, setExceptions] = useState<AvailabilityExceptionRequest[]>([]);
   const [note, setNote] = useState('');
 
-  // 드래그 상태
+  const [newExcDate, setNewExcDate] = useState('');
+  const [newExcKind, setNewExcKind] = useState<AvailabilityKind>('BLOCKED');
+  const [newExcAllDay, setNewExcAllDay] = useState(true);
+  const [newExcStartTime, setNewExcStartTime] = useState('09:00');
+  const [newExcEndTime, setNewExcEndTime] = useState('18:00');
+
   const dragState = useRef<{
     active: boolean;
     dayIdx: number;
-    painting: boolean; // true=선택, false=해제
-    startSlot: number;
+    painting: boolean;
   } | null>(null);
 
   useEffect(() => {
     if (open) {
       setStep(1);
+      const firstRule = availability?.weeklyRules[0];
+      setEffectiveFrom(firstRule?.effectiveFrom ?? today);
+      setEffectiveTo(firstRule?.effectiveTo ?? '');
       setGrid(availabilityToGrid(availability));
+      setExceptions(availability?.exceptions ?? []);
       setNote(availability?.note ?? '');
+      setNewExcDate('');
+      setNewExcKind('BLOCKED');
+      setNewExcAllDay(true);
+      setNewExcStartTime('09:00');
+      setNewExcEndTime('18:00');
     }
-  }, [open, availability]);
+  }, [open, availability, today]);
 
   const toggleSlot = useCallback((dayIdx: number, slotIdx: number, paint: boolean) => {
     setGrid((prev) => {
@@ -142,7 +170,7 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
 
   const handlePointerDown = (dayIdx: number, slotIdx: number) => {
     const painting = !grid[dayIdx]![slotIdx];
-    dragState.current = { active: true, dayIdx, painting, startSlot: slotIdx };
+    dragState.current = { active: true, dayIdx, painting };
     toggleSlot(dayIdx, slotIdx, painting);
   };
 
@@ -155,13 +183,21 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
     if (dragState.current) dragState.current.active = false;
   };
 
-  const handleReset = () => setGrid(emptyGrid());
-
-  const handleNext = () => setStep(2);
+  const handleAddException = () => {
+    if (!newExcDate) return;
+    const exc: AvailabilityExceptionRequest = {
+      date: newExcDate,
+      kind: newExcKind,
+      ...(newExcAllDay
+        ? {}
+        : { startSlot: timeToSlot(newExcStartTime), endSlot: timeToSlot(newExcEndTime) }),
+    };
+    setExceptions((prev) => [...prev.filter((e) => e.date !== newExcDate), exc]);
+    setNewExcDate('');
+  };
 
   const handleSave = () => {
-    const rules = gridToWeeklyRules(grid);
-    onSave(rules, note);
+    onSave(gridToWeeklyRules(grid, effectiveFrom, effectiveTo), note, exceptions);
   };
 
   if (!open) return null;
@@ -179,9 +215,8 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
         className="bg-card relative mx-4 flex w-full max-w-lg flex-col overflow-hidden rounded-xl shadow-xl"
         style={{ maxHeight: '90vh' }}
       >
-        {/* 헤더 — 고정 */}
+        {/* 헤더 */}
         <div className="shrink-0 px-5 pt-5">
-          {/* 닫기 버튼 */}
           <button
             type="button"
             onClick={onClose}
@@ -190,17 +225,62 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
           >
             <X className="h-5 w-5" />
           </button>
-
-          {/* 제목 */}
           <h3 className="text-foreground mb-1 text-[17px] font-bold">
             나의 스케줄 관리{' '}
-            <span className="text-foreground-muted text-[13px] font-normal">({step}/2)</span>
+            <span className="text-foreground-muted text-caption font-normal">({step}/4)</span>
           </h3>
         </div>
 
-        {step === 1 ? (
+        {/* Step 1: 기간 선택 */}
+        {step === 1 && (
           <>
-            {/* 설명 + 초기화 — 고정 */}
+            <div className="flex-1 overflow-y-auto px-5 pt-1 pb-2">
+              <p className="text-foreground-sub mb-4 text-[12px]">
+                이 스케줄이 적용될 기간을 선택해주세요
+              </p>
+              <div className="space-y-3">
+                <div className="grid grid-cols-[64px_1fr] items-center gap-3">
+                  <span className="text-foreground-sub text-[13px]">시작일</span>
+                  <DatePicker
+                    value={effectiveFrom}
+                    min={today}
+                    onChange={setEffectiveFrom}
+                    placeholder="시작일 선택"
+                  />
+                </div>
+                <div className="grid grid-cols-[64px_1fr] items-center gap-3">
+                  <span className="text-foreground-sub text-[13px]">종료일</span>
+                  <DatePicker
+                    value={effectiveTo}
+                    min={effectiveFrom || today}
+                    onChange={setEffectiveTo}
+                    placeholder="종료일 선택 (선택)"
+                  />
+                </div>
+                <p className="text-foreground-muted text-micro">
+                  {effectiveTo
+                    ? `* ${effectiveFrom} ~ ${effectiveTo} 기간에 적용됩니다`
+                    : '* 종료일 미입력 시 무기한 적용됩니다'}
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 justify-end px-5 pt-3 pb-5">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setStep(2)}
+                disabled={!effectiveFrom}
+                className="rounded-[5px]"
+              >
+                다음
+              </Button>
+            </div>
+          </>
+        )}
+
+        {/* Step 2: 주간 타임테이블 */}
+        {step === 2 && (
+          <>
             <div className="shrink-0 px-5 pt-1">
               <p className="text-foreground-sub mb-3 text-[12px]">
                 주간 가능 시간대를 모두 채워주세요
@@ -208,19 +288,17 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               <div className="mb-2 flex justify-end">
                 <button
                   type="button"
-                  onClick={handleReset}
-                  className="text-foreground-sub border-border rounded border px-2 py-0.5 text-[11px]"
+                  onClick={() => setGrid(emptyGrid())}
+                  className="text-foreground-sub border-border text-micro rounded border px-2 py-0.5"
                 >
                   스케줄 초기화
                 </button>
               </div>
             </div>
 
-            {/* 선택 그리드 — 내부 스크롤 */}
             <div className="min-h-0 flex-1 overflow-y-auto px-5">
               <div className="overflow-x-auto select-none" onPointerLeave={handlePointerUp}>
                 <div className="min-w-[320px]">
-                  {/* 요일 헤더 */}
                   <div className="grid" style={{ gridTemplateColumns: '36px repeat(7, 1fr)' }}>
                     <div />
                     {DAY_SHORT.map((day, i) => (
@@ -230,12 +308,10 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                     ))}
                   </div>
 
-                  {/* 슬롯 그리드 */}
                   <div
                     className="relative grid"
                     style={{ gridTemplateColumns: '36px repeat(7, 1fr)' }}
                   >
-                    {/* 시간 레이블 */}
                     <div className="relative">
                       {hourSlots.map((slotIdx) => (
                         <span
@@ -258,14 +334,12 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                       <div style={{ height: SLOT_COUNT * CELL_HEIGHT }} />
                     </div>
 
-                    {/* 요일별 슬롯 */}
                     {Array.from({ length: 7 }, (_, dayIdx) => (
                       <div
                         key={dayIdx}
                         className="border-border relative border-l"
                         style={{ height: SLOT_COUNT * CELL_HEIGHT }}
                       >
-                        {/* 수평 구분선 */}
                         {hourSlots.map((slotIdx) => (
                           <div
                             key={slotIdx}
@@ -273,8 +347,6 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                             style={{ top: slotIdx * CELL_HEIGHT }}
                           />
                         ))}
-
-                        {/* 슬롯 셀 */}
                         {Array.from({ length: SLOT_COUNT }, (_, slotIdx) => (
                           <div
                             key={slotIdx}
@@ -282,10 +354,7 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                               'absolute right-0 left-0 cursor-pointer transition-colors',
                               grid[dayIdx]![slotIdx] ? 'bg-[#e8856a]' : 'hover:bg-[#e8856a]/20',
                             )}
-                            style={{
-                              top: slotIdx * CELL_HEIGHT,
-                              height: CELL_HEIGHT,
-                            }}
+                            style={{ top: slotIdx * CELL_HEIGHT, height: CELL_HEIGHT }}
                             onPointerDown={(e) => {
                               e.preventDefault();
                               handlePointerDown(dayIdx, slotIdx);
@@ -300,19 +369,24 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               </div>
             </div>
 
-            {/* 푸터 — 고정 */}
             <div className="shrink-0 px-5 pb-5">
-              <p className="text-foreground-muted mt-2.5 text-[11px]">
-                * 셀 1칸 당 30분 단위입니다
-              </p>
-              <p className="text-foreground-muted text-[11px]">
+              <p className="text-foreground-muted text-micro mt-2.5">* 셀 1칸 당 30분 단위입니다</p>
+              <p className="text-foreground-muted text-micro">
                 * 입력한 주간 가능 시간대는 향후 전 주 동일 적용됩니다
               </p>
-              <div className="mt-4 flex justify-end">
+              <div className="mt-4 flex justify-between">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setStep(1)}
+                  className="rounded-[5px]"
+                >
+                  이전
+                </Button>
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={handleNext}
+                  onClick={() => setStep(3)}
                   disabled={!hasAnySelected(grid)}
                   className="rounded-[5px]"
                 >
@@ -321,20 +395,233 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               </div>
             </div>
           </>
-        ) : (
+        )}
+
+        {/* Step 3: 예외 날짜 */}
+        {step === 3 && (
+          <>
+            <div className="flex-1 space-y-4 overflow-y-auto px-5 pt-1 pb-2">
+              <p className="text-foreground-sub text-[12px]">
+                위 규칙과 다른 날짜가 있으면 추가해주세요 (선택)
+              </p>
+
+              {/* 추가 폼 */}
+              <div className="border-border space-y-3 rounded-md border p-3">
+                <div className="grid grid-cols-[52px_1fr] items-center gap-2">
+                  <span className="text-foreground-sub text-[12px]">날짜</span>
+                  <DatePicker
+                    value={newExcDate}
+                    min={effectiveFrom}
+                    max={effectiveTo || undefined}
+                    onChange={setNewExcDate}
+                    placeholder="날짜 선택"
+                  />
+                </div>
+                <div className="grid grid-cols-[52px_1fr] items-center gap-2">
+                  <span className="text-foreground-sub text-[12px]">종류</span>
+                  <div className="flex gap-4">
+                    {(['AVAILABLE', 'BLOCKED'] as AvailabilityKind[]).map((k) => (
+                      <label key={k} className="flex cursor-pointer items-center gap-1.5">
+                        <input
+                          type="radio"
+                          name="excKind"
+                          value={k}
+                          checked={newExcKind === k}
+                          onChange={() => setNewExcKind(k)}
+                          className="sr-only"
+                        />
+                        <span
+                          className={cn(
+                            'flex h-4 w-4 items-center justify-center rounded-full border-2',
+                            newExcKind === k ? 'border-[#d1d5db]' : 'border-[#6b7280]',
+                          )}
+                        >
+                          {newExcKind === k && (
+                            <span className="h-2 w-2 rounded-full bg-[#d1d5db]" />
+                          )}
+                        </span>
+                        <span
+                          className={cn(
+                            'text-[12px]',
+                            newExcKind === k ? 'text-[#d1d5db]' : 'text-[#6b7280]',
+                          )}
+                        >
+                          {k === 'AVAILABLE' ? '가능' : '불가'}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+                <div className="grid grid-cols-[52px_1fr] items-center gap-2">
+                  <span className="text-foreground-sub text-[12px]">시간</span>
+                  <label className="flex cursor-pointer items-center gap-1.5">
+                    <input
+                      type="checkbox"
+                      checked={newExcAllDay}
+                      onChange={(e) => setNewExcAllDay(e.target.checked)}
+                      className="sr-only"
+                    />
+                    <span
+                      className={cn(
+                        'flex h-4 w-4 items-center justify-center rounded border-2',
+                        newExcAllDay ? 'border-[#d1d5db] bg-[#d1d5db]' : 'border-[#6b7280]',
+                      )}
+                    >
+                      {newExcAllDay && <Check className="h-3 w-3 text-black" strokeWidth={3} />}
+                    </span>
+                    <span
+                      className={cn(
+                        'text-[12px]',
+                        newExcAllDay ? 'text-[#d1d5db]' : 'text-foreground',
+                      )}
+                    >
+                      하루 종일
+                    </span>
+                  </label>
+                </div>
+                {!newExcAllDay && (
+                  <div className="grid grid-cols-[52px_1fr] items-center gap-2">
+                    <div />
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="time"
+                          value={newExcStartTime}
+                          min="09:00"
+                          max="22:00"
+                          step={1800}
+                          onChange={(e) => setNewExcStartTime(e.target.value)}
+                          className="border-border bg-surface rounded-md border px-2 py-1.5 text-[12px] text-[#d1d5db]"
+                        />
+                        <span className="text-foreground-muted text-[12px]">~</span>
+                        <input
+                          type="time"
+                          value={newExcEndTime}
+                          min="09:00"
+                          max="22:00"
+                          step={1800}
+                          onChange={(e) => setNewExcEndTime(e.target.value)}
+                          className="border-border bg-surface rounded-md border px-2 py-1.5 text-[12px] text-[#d1d5db]"
+                        />
+                      </div>
+                      <p className="text-foreground-muted text-[10px]">
+                        * 09:00~22:00 범위 내에서만 선택 가능합니다
+                      </p>
+                      {(newExcStartTime < '09:00' ||
+                        newExcEndTime > '22:00' ||
+                        newExcStartTime >= newExcEndTime) && (
+                        <p className="text-[10px] text-red-400">
+                          {newExcStartTime >= newExcEndTime
+                            ? '* 시작 시간은 종료 시간보다 빨라야 합니다'
+                            : '* 09:00~22:00 범위를 벗어난 시간입니다'}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                )}
+                <div className="flex justify-end">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleAddException}
+                    disabled={
+                      !newExcDate ||
+                      (!newExcAllDay &&
+                        (newExcStartTime < '09:00' ||
+                          newExcEndTime > '22:00' ||
+                          newExcStartTime >= newExcEndTime))
+                    }
+                    className="gap-1 rounded-[5px]"
+                  >
+                    <Plus className="h-3 w-3" />
+                    추가
+                  </Button>
+                </div>
+              </div>
+
+              {/* 예외 목록 */}
+              {exceptions.length > 0 && (
+                <ul className="space-y-2">
+                  {exceptions.map((exc) => (
+                    <li
+                      key={exc.date}
+                      className="border-border flex items-center justify-between rounded-md border px-3 py-2"
+                    >
+                      <div>
+                        <span className="text-foreground text-[13px] font-medium">{exc.date}</span>
+                        <span
+                          className={cn(
+                            'ml-2 text-[11px]',
+                            exc.kind === 'AVAILABLE' ? 'text-[#d1d5db]' : 'text-foreground-muted',
+                          )}
+                        >
+                          {exc.kind === 'AVAILABLE' ? '가능' : '불가'}
+                        </span>
+                        {exc.startSlot != null && exc.endSlot != null && (
+                          <span className="text-foreground-muted ml-1 text-[11px]">
+                            {slotToTime(exc.startSlot)}~{slotToTime(exc.endSlot)}
+                          </span>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setExceptions((prev) => prev.filter((e) => e.date !== exc.date))
+                        }
+                        className="text-foreground-muted hover:text-foreground"
+                        aria-label="삭제"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className="flex shrink-0 justify-between px-5 pt-3 pb-5">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setStep(2)}
+                className="rounded-[5px]"
+              >
+                이전
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setStep(4)}
+                className="rounded-[5px]"
+              >
+                다음
+              </Button>
+            </div>
+          </>
+        )}
+
+        {/* Step 4: 특이사항 */}
+        {step === 4 && (
           <>
             <div className="px-5 pb-5">
               <p className="text-foreground-sub mb-3 text-[12px]">특이사항을 적어주세요</p>
-
               <Textarea
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
-                placeholder="평일 저녁만, 주말은 1시 이후부터 가능합니다."
-                className="h-40 resize-none"
+                placeholder="ex) 평일 저녁만, 주말은 1시 이후부터 가능합니다."
+                className="placeholder:text-foreground-muted focus-visible:border-foreground-muted h-40 resize-none focus-visible:ring-0 focus-visible:ring-offset-0"
                 maxLength={500}
               />
-
-              <div className="mt-4 flex justify-end">
+              <p className="text-foreground-muted mt-1 text-right text-[12px]">(500자 이내)</p>
+              <div className="mt-3 flex justify-between">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setStep(3)}
+                  className="rounded-[5px]"
+                >
+                  이전
+                </Button>
                 <Button
                   variant="secondary"
                   size="sm"

--- a/src/domain/member/components/WeeklyTimetable.client.tsx
+++ b/src/domain/member/components/WeeklyTimetable.client.tsx
@@ -3,6 +3,8 @@
 import { addDays, format, startOfWeek } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { toZonedTime } from 'date-fns-tz';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useRef, useState } from 'react';
 
 import type { PerformanceListItemResponse } from '@/domain/performance/types';
 import type { PracticeListItemResponse } from '@/domain/practice/types';
@@ -42,20 +44,36 @@ function startAtToSlot(startAt: string): number {
 
 function buildAvailabilityMatrix(
   rules: MemberAvailabilityResponse['weeklyRules'],
+  exceptions: MemberAvailabilityResponse['exceptions'],
   weekDates: Date[],
 ): boolean[][] {
   const matrix: boolean[][] = Array.from({ length: 7 }, () =>
     new Array<boolean>(SLOT_COUNT).fill(false),
   );
 
+  const weekDateStrs = weekDates.map((d) => format(d, 'yyyy-MM-dd'));
+
+  // effectiveFrom 이전 날짜는 빈 셀(가능/미설정)로 표시
+  const earliestFrom = rules.reduce<string | null>(
+    (min, r) =>
+      r.effectiveFrom && (min === null || r.effectiveFrom < min) ? r.effectiveFrom : min,
+    null,
+  );
+  if (earliestFrom) {
+    for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
+      const dateStr = weekDateStrs[dayIdx];
+      if (dateStr && dateStr < earliestFrom) matrix[dayIdx]!.fill(true);
+    }
+  }
+
+  // weeklyRules 적용
   for (const rule of rules) {
     const dayIdx = DAY_OF_WEEK_KEYS.indexOf(rule.dayOfWeek);
     if (dayIdx === -1) continue;
-    const weekDate = weekDates[dayIdx];
-    if (!weekDate) continue;
-    const dateStr = format(weekDate, 'yyyy-MM-dd');
+    const dateStr = weekDateStrs[dayIdx];
+    if (!dateStr) continue;
+    if (!rule.effectiveFrom || dateStr < rule.effectiveFrom) continue;
     if (rule.effectiveTo && dateStr > rule.effectiveTo) continue;
-    if (dateStr < rule.effectiveFrom) continue;
 
     const row = matrix[dayIdx]!;
     for (let s = rule.startSlot; s < rule.endSlot; s++) {
@@ -63,6 +81,26 @@ function buildAvailabilityMatrix(
       if (idx >= 0 && idx < SLOT_COUNT) row[idx] = true;
     }
   }
+
+  // exceptions 적용 (weeklyRules 위에 덮어쓰기)
+  for (const exc of exceptions) {
+    const dayIdx = weekDateStrs.indexOf(exc.date);
+    if (dayIdx === -1) continue;
+
+    const row = matrix[dayIdx]!;
+    const isAvailable = exc.kind === 'AVAILABLE';
+    const isAllDay = exc.startSlot == null || exc.endSlot == null || exc.startSlot >= exc.endSlot;
+
+    if (isAllDay) {
+      row.fill(isAvailable);
+    } else {
+      for (let s = exc.startSlot!; s < exc.endSlot!; s++) {
+        const idx = s - START_SLOT;
+        if (idx >= 0 && idx < SLOT_COUNT) row[idx] = isAvailable;
+      }
+    }
+  }
+
   return matrix;
 }
 
@@ -72,6 +110,14 @@ type TimetableEvent = {
   startSlot: number;
   slotSpan: number;
   dayIdx: number;
+};
+
+type MockEvent = {
+  id: number;
+  type: 'practice' | 'performance';
+  dayIdx: number;
+  startSlot: number;
+  slotSpan: number;
 };
 
 function buildEvents(
@@ -133,8 +179,37 @@ export function WeeklyTimetable({
   performances,
   onManageSchedule,
 }: Props) {
+  const [weekOffset, setWeekOffset] = useState(0);
+  const [paintPractice, setPaintPractice] = useState(false);
+  const [paintPerformance, setPaintPerformance] = useState(false);
+  const [mockEvents, setMockEvents] = useState<MockEvent[]>([]);
+  const mockIdRef = useRef(0);
+
+  const handleCellClick = (dayIdx: number, e: React.MouseEvent<HTMLDivElement>) => {
+    if (!paintPractice && !paintPerformance) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const slot = Math.floor((e.clientY - rect.top) / CELL_HEIGHT);
+    if (slot < 0 || slot >= SLOT_COUNT) return;
+    setMockEvents((prev) => {
+      let next = [...prev];
+      for (const type of (['practice', 'performance'] as const).filter(
+        (t) => (t === 'practice' && paintPractice) || (t === 'performance' && paintPerformance),
+      )) {
+        const existing = next.find(
+          (m) => m.dayIdx === dayIdx && m.startSlot === slot && m.type === type,
+        );
+        if (existing) {
+          next = next.filter((m) => m.id !== existing.id);
+        } else {
+          next = [...next, { id: mockIdRef.current++, type, dayIdx, startSlot: slot, slotSpan: 1 }];
+        }
+      }
+      return next;
+    });
+  };
+
   const now = toZonedTime(new Date(), KST);
-  const monday = startOfWeek(now, { weekStartsOn: 1 });
+  const monday = addDays(startOfWeek(now, { weekStartsOn: 1 }), weekOffset * 7);
   const weekDates: Date[] = Array.from({ length: 7 }, (_, i) => addDays(monday, i));
 
   const weekLabel =
@@ -142,7 +217,11 @@ export function WeeklyTimetable({
     ' ~ ' +
     format(weekDates[6]!, 'MM-dd (EEE)', { locale: ko });
 
-  const availMatrix = buildAvailabilityMatrix(availability?.weeklyRules ?? [], weekDates);
+  const availMatrix = buildAvailabilityMatrix(
+    availability?.weeklyRules ?? [],
+    availability?.exceptions ?? [],
+    weekDates,
+  );
   const events = buildEvents(practices, performances, weekDates);
 
   const eventsByDay: TimetableEvent[][] = Array.from({ length: 7 }, () => []);
@@ -154,12 +233,30 @@ export function WeeklyTimetable({
 
   return (
     <section className="mt-15">
-      <div className="mb-s-3 flex items-center justify-between">
-        <p className="text-foreground-sub text-[13px]">{weekLabel}</p>
+      <div className="mb-s-3 relative flex items-center justify-center">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setWeekOffset((o) => o - 1)}
+            className="text-foreground-sub hover:text-foreground"
+            aria-label="이전 주"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <p className="text-foreground-sub text-sm">{weekLabel}</p>
+          <button
+            type="button"
+            onClick={() => setWeekOffset((o) => o + 1)}
+            className="text-foreground-sub hover:text-foreground"
+            aria-label="다음 주"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
         <button
           type="button"
           onClick={onManageSchedule}
-          className="text-foreground border-border shrink-0 rounded-[5px] border px-3 py-1 text-sm font-medium"
+          className="text-foreground border-border absolute right-0 shrink-0 rounded-[5px] border px-3 py-1 text-sm font-medium"
         >
           나의 스케줄 관리
         </button>
@@ -213,8 +310,12 @@ export function WeeklyTimetable({
             {weekDates.map((_, dayIdx) => (
               <div
                 key={dayIdx}
-                className="border-border relative border-r last:border-r-0"
+                className={cn(
+                  'border-border relative border-r last:border-r-0',
+                  paintPractice || paintPerformance ? 'cursor-crosshair' : 'cursor-default',
+                )}
                 style={{ height: SLOT_COUNT * CELL_HEIGHT }}
+                onClick={(e) => handleCellClick(dayIdx, e)}
               >
                 {hourSlots.map((slotIdx) => (
                   <div
@@ -228,7 +329,7 @@ export function WeeklyTimetable({
                 {buildUnavailableBlocks(availMatrix[dayIdx]!).map((block, bi) => (
                   <div
                     key={bi}
-                    className="bg-surface/70 absolute right-0 left-0"
+                    className="bg-foreground-sub/80 absolute right-0 left-0"
                     style={{
                       top: block.start * CELL_HEIGHT,
                       height: block.length * CELL_HEIGHT,
@@ -244,11 +345,12 @@ export function WeeklyTimetable({
                   return (
                     <div
                       key={ei}
+                      onClick={(e) => e.stopPropagation()}
                       className={cn(
                         'absolute right-0 left-0 overflow-hidden rounded-sm px-1 py-0.5',
                         ev.type === 'practice'
-                          ? 'bg-[#e8e8c0] text-[#4a4a20]'
-                          : 'bg-[#7a9e8c] text-white',
+                          ? 'bg-[#4ade80]/20 text-[#4ade80]'
+                          : 'bg-[#60a5fa]/20 text-[#60a5fa]',
                       )}
                       style={{ top: clippedStart * CELL_HEIGHT, height }}
                     >
@@ -259,10 +361,60 @@ export function WeeklyTimetable({
                     </div>
                   );
                 })}
+
+                {/* 임시 이벤트 블록 */}
+                {mockEvents
+                  .filter(
+                    (me) =>
+                      me.dayIdx === dayIdx &&
+                      ((me.type === 'practice' && paintPractice) ||
+                        (me.type === 'performance' && paintPerformance)),
+                  )
+                  .map((me) => (
+                    <div
+                      key={me.id}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setMockEvents((prev) => prev.filter((m) => m.id !== me.id));
+                      }}
+                      className={cn(
+                        'absolute right-0 left-0 cursor-pointer overflow-hidden',
+                        me.type === 'practice' ? 'bg-[#4ade80]/60' : 'bg-[#60a5fa]/60',
+                      )}
+                      style={{ top: me.startSlot * CELL_HEIGHT, height: me.slotSpan * CELL_HEIGHT }}
+                    />
+                  ))}
               </div>
             ))}
           </div>
         </div>
+      </div>
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setPaintPractice((v) => !v)}
+          className={cn(
+            'rounded-full border px-3.5 py-1 text-sm font-medium transition-colors',
+            paintPractice
+              ? 'border-[#4ade80] bg-[#4ade80]/10 text-[#4ade80]'
+              : 'border-border text-foreground-muted',
+          )}
+        >
+          합주 표시
+        </button>
+        <button
+          type="button"
+          onClick={() => setPaintPerformance((v) => !v)}
+          className={cn(
+            'rounded-full border px-3.5 py-1 text-sm font-medium transition-colors',
+            paintPerformance
+              ? 'border-[#60a5fa] bg-[#60a5fa]/10 text-[#60a5fa]'
+              : 'border-border text-foreground-muted',
+          )}
+        >
+          공연 표시
+        </button>
       </div>
     </section>
   );

--- a/src/domain/member/components/WeeklyTimetable.client.tsx
+++ b/src/domain/member/components/WeeklyTimetable.client.tsx
@@ -217,11 +217,11 @@ export function WeeklyTimetable({
     ' ~ ' +
     format(weekDates[6]!, 'MM-dd (EEE)', { locale: ko });
 
-  const availMatrix = buildAvailabilityMatrix(
-    availability?.weeklyRules ?? [],
-    availability?.exceptions ?? [],
-    weekDates,
-  );
+  // updatedAt이 null이거나 availability 미로드 시 한 번도 설정한 적 없는 상태 → 전 슬롯 공백
+  const neverSet = !availability || availability.updatedAt === null;
+  const availMatrix = neverSet
+    ? Array.from({ length: 7 }, () => new Array<boolean>(SLOT_COUNT).fill(true))
+    : buildAvailabilityMatrix(availability.weeklyRules, availability.exceptions, weekDates);
   const events = buildEvents(practices, performances, weekDates);
 
   const eventsByDay: TimetableEvent[][] = Array.from({ length: 7 }, () => []);

--- a/src/domain/member/hooks/useDeleteMyProfileImage.ts
+++ b/src/domain/member/hooks/useDeleteMyProfileImage.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deleteMyProfileImage } from '../api/deleteMyProfileImage';
+
+type UseDeleteMyProfileImageOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDeleteMyProfileImage(options?: UseDeleteMyProfileImageOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: deleteMyProfileImage,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.member.me] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/member/types/req.ts
+++ b/src/domain/member/types/req.ts
@@ -2,12 +2,10 @@ export interface JoinRequest {
   email: string;
   password: string;
   name: string;
-  contact?: string;
 }
 
 export interface UpdateMeRequest {
   name?: string;
-  contact?: string;
   /** presigned URL 업로드 후 받은 objectKey 또는 그대로의 CloudFront URL. */
   profileImg?: string;
 }

--- a/src/domain/member/types/req.ts
+++ b/src/domain/member/types/req.ts
@@ -29,7 +29,7 @@ export interface AvailabilityExceptionRequest {
 
 /** API_SPEC §2-8 — 가용성 등록/수정. weeklyRules·exceptions 전체 교체 방식. */
 export interface UpdateMyAvailabilityRequest {
-  weeklyRules?: WeeklyRuleRequest[];
-  exceptions?: AvailabilityExceptionRequest[];
+  weeklyRules: WeeklyRuleRequest[];
+  exceptions: AvailabilityExceptionRequest[];
   note?: string | null;
 }

--- a/src/domain/member/types/res.ts
+++ b/src/domain/member/types/res.ts
@@ -9,7 +9,6 @@ export interface MemberInfoResponse {
   memberId?: number;
   email: string;
   name: string;
-  contact: string;
   /** 프로필 이미지 URL. 미설정 시 null. */
   profileImg?: string | null;
   createdAt?: string;

--- a/src/domain/member/types/schema.ts
+++ b/src/domain/member/types/schema.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-const CONTACT_REGEX = /^01\d-\d{3,4}-\d{4}$/;
-
 export const joinSchema = z
   .object({
     email: z.string().min(1, '이메일을 입력해 주세요').email('올바른 이메일 형식이 아닙니다'),
@@ -15,12 +13,7 @@ export const joinSchema = z
   });
 export type JoinSchema = z.infer<typeof joinSchema>;
 
-export const updateMeSchema = z
-  .object({
-    name: z.string().min(2, '이름은 2자 이상이어야 합니다').optional(),
-    contact: z.string().regex(CONTACT_REGEX, '올바른 전화번호 형식이 아닙니다').optional(),
-  })
-  .refine((data) => data.name !== undefined || data.contact !== undefined, {
-    message: '수정할 항목을 하나 이상 입력해 주세요',
-  });
+export const updateMeSchema = z.object({
+  name: z.string().min(2, '이름은 2자 이상이어야 합니다').optional(),
+});
 export type UpdateMeSchema = z.infer<typeof updateMeSchema>;

--- a/src/global/auth/AuthBootstrapper.client.tsx
+++ b/src/global/auth/AuthBootstrapper.client.tsx
@@ -19,10 +19,12 @@ interface Props {
  *
  * 동작 순서
  * 1. 마운트 시 401 핸들러 등록 (refresh 실패 → /login 라우팅 + 토스트).
- * 2. accessToken 이 메모리에 없으면 refresh 한 번 시도 (refreshToken 쿠키 기반).
+ * 2. Zustand persist 하이드레이션 완료 대기 (sessionStorage → 메모리 복원).
+ * 3. 하이드레이션 후 accessToken 이 있으면 bootstrap 스킵.
+ *    없으면 refreshToken 쿠키로 POST /auth/refresh 한 번 시도.
  *    - 성공 → useMe 가 활성화되어 children 렌더 가능.
  *    - 실패 → /login 으로 라우팅.
- * 3. 부트스트랩 진행 중에는 Skeleton 으로 children 가드 → /home 깜빡임 방지.
+ * 4. 부트스트랩 진행 중에는 Skeleton 으로 children 가드 → /home 깜빡임 방지.
  */
 export function AuthBootstrapper({ children }: Props) {
   const router = useRouter();
@@ -31,7 +33,8 @@ export function AuthBootstrapper({ children }: Props) {
   const authenticated = useAuthStore((s) => s.accessToken !== null);
   const handlerInstalled = useRef(false);
   const bootstrapTried = useRef(false);
-  const [bootstrapping, setBootstrapping] = useState(!authenticated);
+  const [bootstrapping, setBootstrapping] = useState(true);
+  const [hydrated, setHydrated] = useState(false);
 
   // 401 핸들러 등록.
   useEffect(() => {
@@ -45,8 +48,20 @@ export function AuthBootstrapper({ children }: Props) {
     });
   }, [router, toast]);
 
-  // accessToken 부트스트랩.
+  // Zustand persist 하이드레이션 완료 감지 (클라이언트 전용).
+  // useState(false)로 초기화해야 SSR의 noopStorage가 hasHydrated()=true를 반환하는 것을 방지.
   useEffect(() => {
+    if (useAuthStore.persist.hasHydrated()) {
+      setHydrated(true);
+      return;
+    }
+    return useAuthStore.persist.onFinishHydration(() => setHydrated(true));
+  }, []);
+
+  // 하이드레이션 완료 후 accessToken 여부에 따라 bootstrap 결정.
+  // sessionStorage에 유효한 토큰이 있으면 bootstrap 스킵 — 불필요한 /refresh 호출 방지.
+  useEffect(() => {
+    if (!hydrated) return;
     if (bootstrapTried.current) return;
     bootstrapTried.current = true;
     if (authenticated) {
@@ -56,13 +71,12 @@ export function AuthBootstrapper({ children }: Props) {
     bootstrapAccessToken()
       .then(() => setBootstrapping(false))
       .catch(() => {
-        // refresh 실패 → /login 으로 (handleAuthFailure 가 이미 처리하지만 안전망).
         setBootstrapping(false);
         const from = searchParams?.toString();
         const url = from ? `${ROUTES.LOGIN}?from=${encodeURIComponent(from)}` : ROUTES.LOGIN;
         router.replace(url);
       });
-  }, [authenticated, router, searchParams]);
+  }, [hydrated, authenticated, router, searchParams]);
 
   // useMe 는 인증 후에만 자연스럽게 동작 — 깜빡임 가드는 부트스트랩 완료까지만.
   const me = useMe();

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,5 +1,38 @@
 import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { extendTailwindMerge } from 'tailwind-merge';
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      // globals.css --text-* 커스텀 폰트 크기 토큰 등록
+      'font-size': [
+        { text: ['micro', 'caption', 'body', 'subtitle', 'title', 'title-lg', 'display'] },
+      ],
+      // globals.css --color-* 커스텀 색상 토큰 등록 (text-* 색상 유틸리티)
+      'text-color': [
+        {
+          text: [
+            'foreground',
+            'foreground-sub',
+            'foreground-muted',
+            'accent',
+            'accent-hi',
+            'brand',
+            'nav-active',
+            'success',
+            'warn',
+            'danger',
+            'amber',
+            'blue',
+            'role-leader',
+            'role-admin',
+            'role-member',
+          ],
+        },
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-92](https://sunwoo1137.atlassian.net/browse/BD-92)

📌 작업 내용 및 특이사항

**밴드 목록 페이지**
- 모바일 밴드 목록을 풀스크린 + 바텀시트 방식으로 전환 (`BandsMobileShell.client.tsx` 신규 추가)
- PC: 밴드 클릭 시 우측 슬라이드 패널 (slide-in/out-right 애니메이션), 모바일: 바텀시트로 분기
- PC 토글(내 밴드/탐색) 헤딩 옆 150px 인라인 배치, 모바일은 풀너비 배치
- 선택된 밴드 항목에 왼쪽 테두리 인디케이터 표시
- 밴드 항목 프로필 이미지 지원, radius/border 스타일 통일 (`rounded-[5px]`)
- 밴드 생성 버튼 hover/active 스타일 적용 (흰색 배경 전환 + 회색 pressed 효과)
- 검색 placeholder `밴드명 검색`으로 변경, 검색바 radius 통일
- Discover 탭 검색을 클라이언트 필터 → API 검색(`useBandSearch`)으로 교체
- 탭 전환 시 검색어 초기화

**밴드 생성 모달**
- 로그인 스타일 입력창(border-white/20, focus 시 border-white/70) 적용
- 밴드 이름 / 소개 글자수 카운터 실시간 표시 (50자 / 200자)
- `description` 필수 필드로 변경 (schema + req DTO 동기화)
- 모달 열릴 때 자동 포커스 방지 (`onOpenAutoFocus`)
- 밴드 생성 후 상세 페이지 리다이렉트 제거 → 목록 갱신만 수행
- 버튼 radius 5, 취소/생성 버튼 h-8 크기 통일

**밴드 상세 패널**
- 헤더의 '밴드 탐색' 텍스트 및 하단 구분선 제거
- 가입 신청 / 밴드 탈퇴 버튼 아웃라인 화이트 스타일 (hover 시 반전)
- PC 닫기(X) 버튼 상단 여백 조정

**밴드 상세 > 멤버 탭**
- 리더용 위임 버튼 제거 → 3-dot 드롭다운 메뉴로 교체 (`리더 위임` / `내보내기`)
- 리더 위임 / 내보내기 각각 확인 다이얼로그 추가
- 위임 성공 후 내 밴드 목록 및 탐색 목록 즉시 갱신 (`queryKeys.band.my` / `list` 무효화)

**밴드 상세 > 신청 현황 탭**
- "거부됨" → "거절됨" 레이블 수정

**밴드 상세 > 설정 탭**
- 서브탭(정보/이미지/삭제) 화이트 active 스타일, 탭 전환 슬라이드 효과
- 정보 탭: 입력창 로그인 스타일 통일, 글자수 카운터, 저장 버튼 우측 정렬·radius 5
- 이미지 탭: 풀스크린 이미지 박스 (`h-[220px] w-full`), 클릭 시 드롭다운(이미지 교체/삭제)
  - `DELETE /api/v1/bands/{bandId}/profile-image` API 연동 (`deleteBandProfileImage`)
- 삭제 탭: 경고 텍스트 `text-xs`로 축소, 삭제 버튼 우측 정렬·radius 5, 입력창 상단 여백 추가

**마이페이지**
- 스케줄 노트 실시간 글자수 표시 (현재 글자수/500자)

**신규 파일**
- `src/domain/band/api/deleteBandProfileImage.ts`
- `src/domain/band/hooks/useDeleteBandProfileImage.ts`
- `src/domain/band/hooks/useRemoveBandMember.ts`

📚 참고사항
- `middleware.ts` 변경분은 미포함, 별도 처리 예정
- `BandSettingsModal`은 파일은 유지되나 밴드 상세에서 더 이상 사용하지 않음 (향후 정리 대상)

[BD-92]: https://sunwoo1137.atlassian.net/browse/BD-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ