### PR TITLE
[BD-115] fix: 페이지 새로고침 시 로그인 화면으로 이동하는 문제 수정

### DIFF
--- a/src/global/auth/AuthBootstrapper.client.tsx
+++ b/src/global/auth/AuthBootstrapper.client.tsx
@@ -19,10 +19,12 @@ interface Props {
  *
  * 동작 순서
  * 1. 마운트 시 401 핸들러 등록 (refresh 실패 → /login 라우팅 + 토스트).
- * 2. accessToken 이 메모리에 없으면 refresh 한 번 시도 (refreshToken 쿠키 기반).
+ * 2. Zustand persist 하이드레이션 완료 대기 (sessionStorage → 메모리 복원).
+ * 3. 하이드레이션 후 accessToken 이 있으면 bootstrap 스킵.
+ *    없으면 refreshToken 쿠키로 POST /auth/refresh 한 번 시도.
  *    - 성공 → useMe 가 활성화되어 children 렌더 가능.
  *    - 실패 → /login 으로 라우팅.
- * 3. 부트스트랩 진행 중에는 Skeleton 으로 children 가드 → /home 깜빡임 방지.
+ * 4. 부트스트랩 진행 중에는 Skeleton 으로 children 가드 → /home 깜빡임 방지.
  */
 export function AuthBootstrapper({ children }: Props) {
   const router = useRouter();
@@ -31,7 +33,8 @@ export function AuthBootstrapper({ children }: Props) {
   const authenticated = useAuthStore((s) => s.accessToken !== null);
   const handlerInstalled = useRef(false);
   const bootstrapTried = useRef(false);
-  const [bootstrapping, setBootstrapping] = useState(!authenticated);
+  const [bootstrapping, setBootstrapping] = useState(true);
+  const [hydrated, setHydrated] = useState(false);
 
   // 401 핸들러 등록.
   useEffect(() => {
@@ -45,8 +48,20 @@ export function AuthBootstrapper({ children }: Props) {
     });
   }, [router, toast]);
 
-  // accessToken 부트스트랩.
+  // Zustand persist 하이드레이션 완료 감지 (클라이언트 전용).
+  // useState(false)로 초기화해야 SSR의 noopStorage가 hasHydrated()=true를 반환하는 것을 방지.
   useEffect(() => {
+    if (useAuthStore.persist.hasHydrated()) {
+      setHydrated(true);
+      return;
+    }
+    return useAuthStore.persist.onFinishHydration(() => setHydrated(true));
+  }, []);
+
+  // 하이드레이션 완료 후 accessToken 여부에 따라 bootstrap 결정.
+  // sessionStorage에 유효한 토큰이 있으면 bootstrap 스킵 — 불필요한 /refresh 호출 방지.
+  useEffect(() => {
+    if (!hydrated) return;
     if (bootstrapTried.current) return;
     bootstrapTried.current = true;
     if (authenticated) {
@@ -56,13 +71,12 @@ export function AuthBootstrapper({ children }: Props) {
     bootstrapAccessToken()
       .then(() => setBootstrapping(false))
       .catch(() => {
-        // refresh 실패 → /login 으로 (handleAuthFailure 가 이미 처리하지만 안전망).
         setBootstrapping(false);
         const from = searchParams?.toString();
         const url = from ? `${ROUTES.LOGIN}?from=${encodeURIComponent(from)}` : ROUTES.LOGIN;
         router.replace(url);
       });
-  }, [authenticated, router, searchParams]);
+  }, [hydrated, authenticated, router, searchParams]);
 
   // useMe 는 인증 후에만 자연스럽게 동작 — 깜빡임 가드는 부트스트랩 완료까지만.
   const me = useMe();


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-115](https://sunwoo1137.atlassian.net/browse/BD-115)

📌 **작업 내용 및 특이사항**

**문제**
- 로그인 이후 페이지에서 새로고침 시 로그인 화면으로 이동하는 버그

**원인 분석**
- `AuthBootstrapper`에서 `useState(() => useAuthStore.persist.hasHydrated())`로 hydration 감지
- SSR 환경에서 `noopStorage`가 `hasHydrated() = true`를 즉시 반환 → 클라이언트 마운트 전부터 `hydrated = true`로 설정됨
- sessionStorage에서 accessToken을 복원하기 전에 bootstrap이 실행되어 불필요한 `POST /auth/refresh` 호출 발생
- refresh token이 만료된 경우 로그인 화면으로 이동

**수정**
- `useState(false)`로 초기화하여 SSR noopStorage의 영향 차단
- `useEffect` 내에서만 `hasHydrated()` 체크 → 클라이언트 마운트 후 sessionStorage 복원 완료 시점에 `hydrated = true` 설정
- sessionStorage에 유효한 accessToken이 있으면 bootstrap 스킵 → 현재 페이지 유지

📚 **참고사항**

- `src/middleware.ts` 변경분은 별도 커밋으로 관리 (본 PR 미포함)
- `PATCH /api/v1/auth/password` (비밀번호 변경): API 연동 완료, 진입 경로(UI) 추후 수정 예정
- `POST /api/v1/auth/refresh` (토큰 갱신): FE 연동 정상 확인 (쿠키 전송·401 인터셉터 동작), refresh token JWT 유효 상태임에도 BE에서 400 반환 중 → BE 측 확인 필요 @willjsw 
- `domain/auth/api/refresh.ts`는 데드 코드로 확인되었으나 별도 정리 예정

[BD-115]: https://sunwoo1137.atlassian.net/browse/BD-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ