### PR TITLE
[BD-125] feat: 프로필 이미지 삭제 API 연동

### DIFF
--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -27,6 +27,7 @@ import { WeeklyTimetable } from '@/domain/member/components/WeeklyTimetable.clie
 import { useMe } from '@/domain/member/hooks/useMe';
 import { useMyAvailability } from '@/domain/member/hooks/useMyAvailability';
 import { useUpdateMyAvailability } from '@/domain/member/hooks/useUpdateMyAvailability';
+import { useDeleteMyProfileImage } from '@/domain/member/hooks/useDeleteMyProfileImage';
 import { useUpdateMe } from '@/domain/member/hooks/useUpdateMe';
 import { useWithdraw } from '@/domain/member/hooks/useWithdraw';
 import {
@@ -262,6 +263,11 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
     onError: (err) => toast.error(err.message || '프로필 이미지 변경에 실패했습니다.'),
   });
 
+  const deleteImgMutation = useDeleteMyProfileImage({
+    onSuccess: () => toast.success('프로필 이미지가 삭제되었습니다.'),
+    onError: (err) => toast.error(err.message || '프로필 이미지 삭제에 실패했습니다.'),
+  });
+
   return (
     <Card padding="none" className="overflow-visible rounded-md border-[3px]">
       <form onSubmit={form.handleSubmit((values) => mutation.mutate(values))} noValidate>
@@ -277,7 +283,7 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
               disabled={imgMutation.isPending}
               imageClassName="rounded-[100px]"
               showButton={false}
-              onDelete={() => {}}
+              onDelete={() => deleteImgMutation.mutate()}
             />
           </div>
 

--- a/src/domain/member/api/deleteMyProfileImage.ts
+++ b/src/domain/member/api/deleteMyProfileImage.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function deleteMyProfileImage(): Promise<void> {
+  return apiClient.delete('/api/v1/members/me/profile-image');
+}

--- a/src/domain/member/hooks/useDeleteMyProfileImage.ts
+++ b/src/domain/member/hooks/useDeleteMyProfileImage.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deleteMyProfileImage } from '../api/deleteMyProfileImage';
+
+type UseDeleteMyProfileImageOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDeleteMyProfileImage(options?: UseDeleteMyProfileImageOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: deleteMyProfileImage,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.member.me] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-125](https://sunwoo1137.atlassian.net/browse/BD-125)

📌 **작업 내용 및 특이사항**

- `DELETE /api/v1/members/me/profile-image` 호출 API 함수 추가 (`domain/member/api/deleteMyProfileImage.ts`)
- `useDeleteMyProfileImage` 훅 추가 — 성공 시 `queryKeys.member.me` invalidate
- 마이페이지 프로필 정보 관리(EditCard)에서 [이미지 삭제] 선택 시 API 호출 연결

📚 **참고사항**

- `ProfileImageUpload`의 `onDelete` 콜백이 빈 함수(`() => {}`)로 방치되어 있던 것을 실제 API 호출로 교체
- `src/middleware.ts`는 별도 브랜치 관리 규칙에 따라 이번 커밋에 미포함

[BD-125]: https://sunwoo1137.atlassian.net/browse/BD-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ