### PR TITLE
[BD-120] feat: 회원 API 변경 대응 및 마이페이지 UI 수정

### DIFF
--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChevronLeft, LogOut } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { ErrorState } from '@/components/feedback/error-state';
@@ -19,9 +19,12 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { PasswordStrength } from '@/components/ui/password-strength';
 import { ProfileImageUpload } from '@/components/ui/profile-image-upload';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useChangePassword } from '@/domain/auth/hooks/useChangePassword';
 import { useLogout } from '@/domain/auth/hooks/useLogout';
+import { passwordChangeSchema, type PasswordChangeSchema } from '@/domain/auth/types/schema';
 import { ScheduleManagerModal } from '@/domain/member/components/ScheduleManagerModal.client';
 import { WeeklyTimetable } from '@/domain/member/components/WeeklyTimetable.client';
 import { useMe } from '@/domain/member/hooks/useMe';
@@ -56,6 +59,15 @@ export function MeContent() {
   const [isEditing, setEditing] = useState(false);
   const [withdrawOpen, setWithdrawOpen] = useState(false);
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
+
+  const editContainerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!isEditing) return;
+    const id = requestAnimationFrame(() => {
+      (document.activeElement as HTMLElement)?.blur();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [isEditing]);
 
   const updateAvailabilityMutation = useUpdateMyAvailability({
     onSuccess: () => {
@@ -104,7 +116,7 @@ export function MeContent() {
   }
 
   return (
-    <div className="space-y-s-6">
+    <div ref={editContainerRef} tabIndex={-1} className="space-y-s-6 outline-none">
       {/* 프로필 정보 섹션 */}
       <section>
         <div className="mb-s-3 relative flex min-h-8 items-center">
@@ -160,6 +172,14 @@ export function MeContent() {
           performances={performances}
           onManageSchedule={() => setScheduleModalOpen(true)}
         />
+      )}
+
+      {/* 비밀번호 변경 — 편집 모드에서만 표시 */}
+      {isEditing && (
+        <section className="mt-[60px]">
+          <h2 className="text-foreground mb-s-3 text-[16px] font-bold">비밀번호 변경</h2>
+          <PasswordChangeCard />
+        </section>
       )}
 
       {/* 계정 탈퇴 — 편집 모드에서만 표시 */}
@@ -293,7 +313,7 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
               <span className="text-foreground-sub text-sm">이름</span>
               <Input
                 error={form.formState.errors.name?.message}
-                className="focus-visible:ring-white"
+                className={EDIT_INPUT_CLASS}
                 {...form.register('name')}
               />
             </div>
@@ -313,6 +333,99 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
                 수정 완료
               </Button>
             </div>
+          </div>
+        </div>
+      </form>
+    </Card>
+  );
+}
+
+const EDIT_INPUT_CLASS =
+  'rounded-[5px] border-white/20 hover:border-white/35 focus-visible:ring-0 focus-visible:border-white/70';
+
+const PASSWORD_INPUT_CLASS =
+  'rounded-[5px] border-white/20 hover:border-white/35 focus-visible:ring-0 focus-visible:border-white/70 not-placeholder-shown:border-white/70';
+
+function PasswordChangeCard() {
+  const toast = useToast();
+  const form = useForm<PasswordChangeSchema>({
+    resolver: zodResolver(passwordChangeSchema),
+    mode: 'onChange',
+    defaultValues: { originalPassword: '', newPassword: '', confirmPassword: '' },
+  });
+
+  const mutation = useChangePassword({
+    onSuccess: () => {
+      toast.success('비밀번호가 변경되었습니다.');
+      form.reset();
+    },
+    onError: (err) => toast.error(err.message || '비밀번호 변경에 실패했습니다.'),
+  });
+
+  return (
+    <Card padding="none" className="overflow-visible rounded-md border-[3px]">
+      <form onSubmit={form.handleSubmit((values) => mutation.mutate(values))} noValidate>
+        <div className="gap-s-4 p-s-6 flex flex-col">
+          <div className="flex items-start gap-6">
+            <span className="text-foreground-sub w-36 shrink-0 pt-2.5 text-sm whitespace-nowrap">
+              현재 비밀번호
+            </span>
+            <div className="min-w-0 flex-1">
+              <Input
+                type="password"
+                placeholder="현재 비밀번호 입력"
+                error={form.formState.errors.originalPassword?.message}
+                className={PASSWORD_INPUT_CLASS}
+                {...form.register('originalPassword')}
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-start gap-6">
+              <span className="text-foreground-sub w-36 shrink-0 pt-2.5 text-sm whitespace-nowrap">
+                새 비밀번호
+              </span>
+              <div className="min-w-0 flex-1">
+                <Input
+                  type="password"
+                  placeholder="새 비밀번호 입력"
+                  error={form.formState.errors.newPassword?.message}
+                  className={PASSWORD_INPUT_CLASS}
+                  {...form.register('newPassword')}
+                />
+              </div>
+            </div>
+            {form.watch('newPassword') && (
+              <div className="flex items-start gap-6">
+                <span className="w-36 shrink-0" aria-hidden="true" />
+                <PasswordStrength password={form.watch('newPassword')} className="flex-1" />
+              </div>
+            )}
+          </div>
+          <div className="flex items-start gap-6">
+            <span className="text-foreground-sub w-36 shrink-0 pt-2.5 text-sm whitespace-nowrap">
+              새 비밀번호 확인
+            </span>
+            <div className="min-w-0 flex-1">
+              <Input
+                type="password"
+                placeholder="새 비밀번호 재입력"
+                error={form.formState.errors.confirmPassword?.message}
+                className={PASSWORD_INPUT_CLASS}
+                {...form.register('confirmPassword')}
+              />
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              variant="secondary"
+              size="sm"
+              loading={mutation.isPending}
+              className="rounded-[5px]"
+            >
+              변경하기
+            </Button>
           </div>
         </div>
       </form>

--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -167,7 +167,7 @@ export function MeContent() {
           <h2 className="text-foreground mb-s-3 text-[16px] font-bold">계정 탈퇴</h2>
           <Card padding="lg" className="border-foreground-sub bg-bg">
             <div className="flex items-center justify-between gap-4">
-              <p className="text-foreground-sub text-[12px]">
+              <p className="text-foreground-sub text-[14px]">
                 탈퇴 후에는 참여 중인 밴드·합주·공연 데이터에 접근할 수 없습니다. 탈퇴를
                 진행하시겠습니까?
               </p>
@@ -265,13 +265,13 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
       <form onSubmit={form.handleSubmit((values) => mutation.mutate(values))} noValidate>
         <div className="flex">
           {/* 좌측: 프로필 이미지 */}
-          <div className="py-s-6 flex w-[220px] shrink-0 items-center justify-center">
+          <div className="py-s-6 flex w-[180px] shrink-0 items-center justify-center">
             <ProfileImageUpload
               value={member.profileImg ?? null}
               onChange={(objectKey) => imgMutation.mutate({ profileImg: objectKey })}
               domain="MEMBER"
               label=""
-              size={150}
+              size={120}
               disabled={imgMutation.isPending}
               imageClassName="rounded-[100px]"
               showButton={false}

--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -40,7 +40,6 @@ import { useMyPerformances } from '@/domain/performance/hooks/useMyPerformances'
 import { useMyPractices } from '@/domain/practice/hooks/useMyPractices';
 import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
-import { formatPhone } from '@/lib/phone';
 
 export function MeContent() {
   const router = useRouter();
@@ -146,7 +145,6 @@ export function MeContent() {
               <div className="space-y-1 pt-0.5">
                 <div className="text-foreground text-lg font-semibold">{me.name}</div>
                 <div className="text-foreground-sub text-sm">{me.email}</div>
-                {me.contact && <div className="text-foreground-muted text-xs">{me.contact}</div>}
               </div>
             </div>
           </Card>
@@ -246,7 +244,7 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
   const toast = useToast();
   const form = useForm<UpdateMeSchema>({
     resolver: zodResolver(updateMeSchema),
-    defaultValues: { name: member.name, contact: member.contact },
+    defaultValues: { name: member.name },
   });
 
   const mutation = useUpdateMe({
@@ -297,19 +295,7 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
               <span className="text-foreground-sub text-sm">이메일</span>
               <Input value={member.email} disabled readOnly className="focus-visible:ring-white" />
             </div>
-            <div className="grid grid-cols-[80px_1fr] items-center gap-4">
-              <span className="text-foreground-sub text-sm">연락처</span>
-              <Input
-                error={form.formState.errors.contact?.message}
-                className="focus-visible:ring-white"
-                {...form.register('contact')}
-                onChange={(e) => {
-                  const formatted = formatPhone(e.target.value);
-                  e.target.value = formatted;
-                  void form.register('contact').onChange(e);
-                }}
-              />
-            </div>
+
             <div className="flex justify-end">
               <Button
                 type="submit"

--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -27,6 +27,7 @@ import { WeeklyTimetable } from '@/domain/member/components/WeeklyTimetable.clie
 import { useMe } from '@/domain/member/hooks/useMe';
 import { useMyAvailability } from '@/domain/member/hooks/useMyAvailability';
 import { useUpdateMyAvailability } from '@/domain/member/hooks/useUpdateMyAvailability';
+import { useDeleteMyProfileImage } from '@/domain/member/hooks/useDeleteMyProfileImage';
 import { useUpdateMe } from '@/domain/member/hooks/useUpdateMe';
 import { useWithdraw } from '@/domain/member/hooks/useWithdraw';
 import {
@@ -260,6 +261,11 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
     onError: (err) => toast.error(err.message || '프로필 이미지 변경에 실패했습니다.'),
   });
 
+  const deleteImgMutation = useDeleteMyProfileImage({
+    onSuccess: () => toast.success('프로필 이미지가 삭제되었습니다.'),
+    onError: (err) => toast.error(err.message || '프로필 이미지 삭제에 실패했습니다.'),
+  });
+
   return (
     <Card padding="none" className="overflow-visible rounded-md border-[3px]">
       <form onSubmit={form.handleSubmit((values) => mutation.mutate(values))} noValidate>
@@ -275,7 +281,7 @@ function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: ()
               disabled={imgMutation.isPending}
               imageClassName="rounded-[100px]"
               showButton={false}
-              onDelete={() => {}}
+              onDelete={() => deleteImgMutation.mutate()}
             />
           </div>
 

--- a/src/domain/member/api/deleteMyProfileImage.ts
+++ b/src/domain/member/api/deleteMyProfileImage.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function deleteMyProfileImage(): Promise<void> {
+  return apiClient.delete('/api/v1/members/me/profile-image');
+}

--- a/src/domain/member/hooks/useDeleteMyProfileImage.ts
+++ b/src/domain/member/hooks/useDeleteMyProfileImage.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deleteMyProfileImage } from '../api/deleteMyProfileImage';
+
+type UseDeleteMyProfileImageOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDeleteMyProfileImage(options?: UseDeleteMyProfileImageOptions) {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: deleteMyProfileImage,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.member.me] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/member/types/req.ts
+++ b/src/domain/member/types/req.ts
@@ -2,12 +2,10 @@ export interface JoinRequest {
   email: string;
   password: string;
   name: string;
-  contact?: string;
 }
 
 export interface UpdateMeRequest {
   name?: string;
-  contact?: string;
   /** presigned URL 업로드 후 받은 objectKey 또는 그대로의 CloudFront URL. */
   profileImg?: string;
 }

--- a/src/domain/member/types/res.ts
+++ b/src/domain/member/types/res.ts
@@ -9,7 +9,6 @@ export interface MemberInfoResponse {
   memberId?: number;
   email: string;
   name: string;
-  contact: string;
   /** 프로필 이미지 URL. 미설정 시 null. */
   profileImg?: string | null;
   createdAt?: string;

--- a/src/domain/member/types/schema.ts
+++ b/src/domain/member/types/schema.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-const CONTACT_REGEX = /^01\d-\d{3,4}-\d{4}$/;
-
 export const joinSchema = z
   .object({
     email: z.string().min(1, '이메일을 입력해 주세요').email('올바른 이메일 형식이 아닙니다'),
@@ -15,12 +13,7 @@ export const joinSchema = z
   });
 export type JoinSchema = z.infer<typeof joinSchema>;
 
-export const updateMeSchema = z
-  .object({
-    name: z.string().min(2, '이름은 2자 이상이어야 합니다').optional(),
-    contact: z.string().regex(CONTACT_REGEX, '올바른 전화번호 형식이 아닙니다').optional(),
-  })
-  .refine((data) => data.name !== undefined || data.contact !== undefined, {
-    message: '수정할 항목을 하나 이상 입력해 주세요',
-  });
+export const updateMeSchema = z.object({
+  name: z.string().min(2, '이름은 2자 이상이어야 합니다').optional(),
+});
 export type UpdateMeSchema = z.infer<typeof updateMeSchema>;


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-120](https://sunwoo1137.atlassian.net/browse/BD-120)

📌 **작업 내용 및 특이사항**

- `GET /api/v1/members/me` 응답에서 `contact` 필드 제거에 따른 타입·UI 대응
  - `MemberInfoResponse`, `JoinRequest`, `UpdateMeRequest`에서 `contact` 제거
  - `updateMeSchema`에서 contact 유효성 검사 및 `CONTACT_REGEX` 제거
  - 마이페이지 뷰/편집 모드에서 연락처 표시·입력 UI 제거
- 마이페이지 프로필 편집 UI 사이즈 조정
  - 프로필 이미지 크기 150 → 120px, 컨테이너 너비 220 → 180px
  - 계정 탈퇴 안내 텍스트 크기 12px → 14px
- 마이페이지 편집 모드에 비밀번호 변경 섹션 추가
  - 현재 비밀번호 / 새 비밀번호 / 새 비밀번호 확인 입력 폼
  - 실시간 유효성 검사(mode: onChange) 및 PasswordStrength 표시
  - 편집 모드 진입 시 자동 포커스 방지 처리

📚 **참고사항**

- `PATCH /api/v1/members/me`, `POST /api/v1/members/join` 요청 DTO에서도 `contact` 동시 제거
- `src/middleware.ts`는 별도 브랜치 관리 규칙에 따라 미포함
- `GET /api/v1/members/me/metrics` (회원 메트릭 조회): 연동 보류
- `GET /api/v1/members/search` (회원 검색): 합주 생성, 선곡회의 생성 등 참여자 추가 기능에서 사용 예정

[BD-120]: https://sunwoo1137.atlassian.net/browse/BD-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ