### PR TITLE
[BD-138] feat: 미설정 스케줄 시 시간표 공백 처리

### DIFF
--- a/src/domain/member/components/WeeklyTimetable.client.tsx
+++ b/src/domain/member/components/WeeklyTimetable.client.tsx
@@ -217,11 +217,11 @@ export function WeeklyTimetable({
     ' ~ ' +
     format(weekDates[6]!, 'MM-dd (EEE)', { locale: ko });
 
-  const availMatrix = buildAvailabilityMatrix(
-    availability?.weeklyRules ?? [],
-    availability?.exceptions ?? [],
-    weekDates,
-  );
+  // updatedAt이 null이거나 availability 미로드 시 한 번도 설정한 적 없는 상태 → 전 슬롯 공백
+  const neverSet = !availability || availability.updatedAt === null;
+  const availMatrix = neverSet
+    ? Array.from({ length: 7 }, () => new Array<boolean>(SLOT_COUNT).fill(true))
+    : buildAvailabilityMatrix(availability.weeklyRules, availability.exceptions, weekDates);
   const events = buildEvents(practices, performances, weekDates);
 
   const eventsByDay: TimetableEvent[][] = Array.from({ length: 7 }, () => []);


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-138](https://sunwoo1137.atlassian.net/browse/BD-138)

📌 **작업 내용 및 특이사항**

- 한 번도 스케줄을 설정한 적 없는 경우(`updatedAt === null`) 시간표 전체를 공백(회색 블록 미표시)으로 렌더링
- `availability`가 아직 로드되지 않은 상태(`undefined`)에서도 동일하게 공백 처리하여 깜빡임 방지
- `buildAvailabilityMatrix` 호출 전 `neverSet` 플래그로 분기 처리

📚 **참고사항**

- 판단 기준: `MemberAvailabilityResponse.updatedAt === null` (API 스펙 §2-7 미등록 상태 정의)
- 이전 동작: 규칙이 없을 때 행렬이 모두 `false`(불가)로 초기화되어 전체가 회색으로 표시됨

[BD-138]: https://sunwoo1137.atlassian.net/browse/BD-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ