### PR TITLE
[BD-92] chore: deploy 워크플로우 LFS checkout 비활성화

### DIFF
--- a/.github/workflows/develop_deploy.yml
+++ b/.github/workflows/develop_deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
 
       - name: Configure AWS Credentials
         # ECR 한정 권한을 가진 IAM 사용자 키 — S3 / 기타 권한과 분리되어 있다.


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-92](https://sunwoo1137.atlassian.net/browse/BD-92)

📌 작업 내용 및 특이사항

- `develop_deploy.yml` checkout 단계의 `lfs: true` → `lfs: false` 로 변경
- GitHub LFS 예산 초과로 인해 deploy 워크플로우 Checkout 단계에서 실패하는 문제 임시 대응
- CI 워크플로우(`develop_ci_test.yml`)에는 이미 동일한 처리가 적용되어 있었음

📚 참고사항

- LFS 예산 충전 후 `lfs: true` 로 되돌려야 함 (디자인 에셋 등 LFS 파일 필요 시)

[BD-92]: https://sunwoo1137.atlassian.net/browse/BD-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ