### PR TITLE
[BD-126] chore: fe-areas.json notification 영역 등록

### DIFF
--- a/fe-areas.json
+++ b/fe-areas.json
@@ -71,6 +71,13 @@
       "notes": "일부 화면이 mock 데이터(domain/setlist-meeting/mock)와 병존한다. 영향 조회 시 mock 구간은 BE 미연동으로 간주."
     },
     {
+      "id": "notification",
+      "label": "알림",
+      "routes": ["/notifications"],
+      "endpointPrefixes": ["/api/v1/notifications"],
+      "status": "active"
+    },
+    {
       "id": "schedule-coordination",
       "label": "일정 조율",
       "routes": ["/setlist-meetings/scheduling"],


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-126](https://sunwoo1137.atlassian.net/browse/BD-126)

📌 **작업 내용 및 특이사항**

- `fe-areas.json`에 `notification` 영역 추가
- `endpointPrefixes: ["/api/v1/notifications"]` 매핑으로 MCP `check_impacting_changes` 영향평가 대상에 포함
- 이후 BE 알림 API 변경 시 자동으로 감지됨

📚 **참고사항**

- `fe-areas.json`은 GitHub 원격 레포에서 읽히므로 이 PR 머지 후 MCP 조회 가능

[BD-126]: https://sunwoo1137.atlassian.net/browse/BD-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ