### PR TITLE
[BD-140] feat: 합주 목록 탭 분리 및 API 수정

### DIFF
--- a/src/app/(main)/jams/JamsListPane.client.tsx
+++ b/src/app/(main)/jams/JamsListPane.client.tsx
@@ -9,6 +9,7 @@ import { useCallback, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useJams } from '@/domain/jam/hooks/useJams';
 import { useMyJams } from '@/domain/jam/hooks/useMyJams';
 import type { JamListItemResponse } from '@/domain/jam/types';
 import { ROUTES } from '@/global/config/routes';
@@ -58,11 +59,13 @@ export function JamsListPane() {
   const initialTab = (searchParams?.get('tab') === 'discover' ? 'discover' : 'mine') as Tab;
   const [tab, setTab] = useState<Tab>(initialTab);
 
-  // 내가 속하지 않은 합주는 노출하지 않음 (사용자 정책 — 디자인 컨펌 대기 후 검색 탭은 useSearchMyJams 로 이관 예정)
-  const { data, isLoading } = useMyJams(20);
-  const all = data?.pages.flatMap((p) => p.content) ?? [];
+  const { data: myData, isLoading: myLoading } = useMyJams(20);
+  const myJams = myData?.pages.flatMap((p) => p.content) ?? [];
+
+  const { data: allData, isLoading: allLoading } = useJams(undefined, 20);
+  const allJams = allData?.pages.flatMap((p) => p.content) ?? [];
   const accessorRef = useCallback(accessor, []);
-  const { query, setQuery, filtered, isFiltering } = useDiscoverySearch(all, accessorRef);
+  const { query, setQuery, filtered, isFiltering } = useDiscoverySearch(allJams, accessorRef);
 
   const onTabChange = (next: string) => {
     const t = next === 'discover' ? 'discover' : 'mine';
@@ -103,13 +106,13 @@ export function JamsListPane() {
           </TabsList>
         </div>
         <TabsContent value="mine" className="px-s-2 py-s-2 flex-1 overflow-y-auto">
-          {isLoading ? (
+          {myLoading ? (
             <p className="text-foreground-muted p-s-3 text-caption">불러오는 중…</p>
-          ) : all.length === 0 ? (
+          ) : myJams.length === 0 ? (
             <p className="text-foreground-muted p-s-3 text-caption">예정된 합주가 없습니다.</p>
           ) : (
             <ul className="gap-s-1 flex flex-col">
-              {all.map((p) => (
+              {myJams.map((p) => (
                 <PracticeRow key={p.jamId} p={p} pathname={pathname} />
               ))}
             </ul>
@@ -130,7 +133,7 @@ export function JamsListPane() {
             </div>
           </div>
           <div className="px-s-2 py-s-2 flex-1 overflow-y-auto">
-            {isLoading ? (
+            {allLoading ? (
               <p className="text-foreground-muted p-s-3 text-caption">불러오는 중…</p>
             ) : filtered.length === 0 ? (
               <p className="text-foreground-muted p-s-3 text-caption">

--- a/src/app/(main)/jams/JamsMobileShell.client.tsx
+++ b/src/app/(main)/jams/JamsMobileShell.client.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useJams } from '@/domain/jam/hooks/useJams';
 import { useMyJams } from '@/domain/jam/hooks/useMyJams';
 import type { JamListItemResponse } from '@/domain/jam/types';
 import { ROUTES } from '@/global/config/routes';
@@ -63,10 +64,13 @@ export function JamsMobileShell() {
   const [selectedJamId, setSelectedPracticeId] = useState<string | null>(null);
   const isDesktop = useIsDesktop();
 
-  const { data, isLoading } = useMyJams(50);
-  const all = data?.pages.flatMap((p) => p.content) ?? [];
+  const { data: myData, isLoading: myLoading } = useMyJams(50);
+  const myJams = myData?.pages.flatMap((p) => p.content) ?? [];
+
+  const { data: allData, isLoading: allLoading } = useJams(undefined, 50);
+  const allJams = allData?.pages.flatMap((p) => p.content) ?? [];
   const accessorRef = useCallback(accessor, []);
-  const { query, setQuery, filtered, isFiltering } = useDiscoverySearch(all, accessorRef);
+  const { query, setQuery, filtered, isFiltering } = useDiscoverySearch(allJams, accessorRef);
 
   return (
     <>
@@ -120,19 +124,19 @@ export function JamsMobileShell() {
         </div>
 
         <TabsContent value="mine">
-          {isLoading ? (
+          {myLoading ? (
             <div className="space-y-s-2">
               <Skeleton className="h-14 w-full" rounded="md" />
               <Skeleton className="h-14 w-full" rounded="md" />
               <Skeleton className="h-14 w-full" rounded="md" />
             </div>
-          ) : all.length === 0 ? (
+          ) : myJams.length === 0 ? (
             <p className="text-foreground-muted py-s-6 text-center text-sm">
               예정된 합주가 없습니다.
             </p>
           ) : (
             <ul className="gap-s-1 flex flex-col">
-              {all.map((p) => (
+              {myJams.map((p) => (
                 <PracticeSelectRow
                   key={p.jamId}
                   practice={p}
@@ -157,7 +161,7 @@ export function JamsMobileShell() {
             />
           </div>
 
-          {isLoading ? (
+          {allLoading ? (
             <div className="space-y-s-2">
               <Skeleton className="h-14 w-full" rounded="md" />
               <Skeleton className="h-14 w-full" rounded="md" />

--- a/src/app/(main)/jams/[jamId]/JamDetailContent.client.tsx
+++ b/src/app/(main)/jams/[jamId]/JamDetailContent.client.tsx
@@ -30,8 +30,10 @@ import { SessionRow } from '@/domain/jam/components/SessionRow';
 import { useAddParticipant } from '@/domain/jam/hooks/useAddParticipant';
 import { useDeleteJam } from '@/domain/jam/hooks/useDeleteJam';
 import { useJam } from '@/domain/jam/hooks/useJam';
+import { useUpdateParticipantSession } from '@/domain/jam/hooks/useUpdateParticipantSession';
 import { useUpdateSchedule } from '@/domain/jam/hooks/useUpdateSchedule';
 import { addParticipantSchema, type AddParticipantSchema } from '@/domain/jam/types';
+import type { JamSessionResponse } from '@/domain/jam/types';
 import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
 
@@ -80,6 +82,12 @@ export function JamDetailContent({
     onError: (err) => toast.error(err.message || '합주 삭제에 실패했습니다.'),
   });
 
+  const [sessionAssignTarget, setSessionAssignTarget] = useState<{
+    participantId: string;
+    memberId: number;
+  } | null>(null);
+  const [assignSessionId, setAssignSessionId] = useState('');
+
   const addParticipantForm = useForm<AddParticipantSchema>({
     resolver: zodResolver(addParticipantSchema),
     defaultValues: { memberId: undefined as unknown as number, sessionId: '' },
@@ -87,9 +95,18 @@ export function JamDetailContent({
   const addParticipantMutation = useAddParticipant(jamId, {
     onSuccess: () => {
       toast.success('참여자가 추가되었습니다.');
-      addParticipantForm.reset({ memberId: undefined as unknown as number });
+      addParticipantForm.reset({ memberId: undefined as unknown as number, sessionId: '' });
     },
     onError: (err) => toast.error(err.message || '참여자 추가에 실패했습니다.'),
+  });
+
+  const updateSessionMutation = useUpdateParticipantSession(jamId, {
+    onSuccess: () => {
+      toast.success('세션이 배정되었습니다.');
+      setSessionAssignTarget(null);
+      setAssignSessionId('');
+    },
+    onError: (err) => toast.error(err.message || '세션 배정에 실패했습니다.'),
   });
 
   if (isLoading) {
@@ -196,27 +213,55 @@ export function JamDetailContent({
           <Card header="참여자" padding="md">
             <div className="space-y-4">
               <form
-                className="flex flex-wrap items-end gap-2"
+                className="space-y-3"
                 onSubmit={addParticipantForm.handleSubmit((values) =>
                   addParticipantMutation.mutate(values),
                 )}
                 noValidate
               >
-                <Input
-                  label="멤버 ID"
-                  type="number"
-                  placeholder="예: 3"
-                  className="max-w-xs"
-                  error={addParticipantForm.formState.errors.memberId?.message}
-                  {...addParticipantForm.register('memberId', { valueAsNumber: true })}
-                />
-                <Input
-                  label="세션 ID"
-                  placeholder="예: GUITAR"
-                  className="max-w-xs"
-                  error={addParticipantForm.formState.errors.sessionId?.message}
-                  {...addParticipantForm.register('sessionId')}
-                />
+                <div className="flex flex-wrap items-end gap-2">
+                  <Input
+                    label="멤버 ID"
+                    type="number"
+                    placeholder="예: 3"
+                    className="max-w-xs"
+                    error={addParticipantForm.formState.errors.memberId?.message}
+                    {...addParticipantForm.register('memberId', { valueAsNumber: true })}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <p className="text-foreground-sub text-sm font-medium">세션 선택</p>
+                  {practice.sessions.length === 0 ? (
+                    <p className="text-foreground-muted text-xs">먼저 세션을 등록해 주세요.</p>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {practice.sessions.map((s: JamSessionResponse) => {
+                        const selected = addParticipantForm.watch('sessionId') === s.sessionId;
+                        return (
+                          <button
+                            key={s.sessionId}
+                            type="button"
+                            onClick={() =>
+                              addParticipantForm.setValue('sessionId', s.sessionId, {
+                                shouldValidate: true,
+                              })
+                            }
+                            className={`border-border rounded-md border px-3 py-1.5 text-sm transition-colors ${
+                              selected ? 'bg-accent border-transparent text-white' : 'hover:bg-card'
+                            }`}
+                          >
+                            {s.short} · {s.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                  {addParticipantForm.formState.errors.sessionId && (
+                    <p className="text-danger text-xs">
+                      {addParticipantForm.formState.errors.sessionId.message}
+                    </p>
+                  )}
+                </div>
                 <Button type="submit" loading={addParticipantMutation.isPending}>
                   <UserPlus className="h-4 w-4" />
                   추가
@@ -225,12 +270,36 @@ export function JamDetailContent({
               {practice.participants.length === 0 ? (
                 <EmptyState title="참여자가 없습니다" />
               ) : (
-                <ul className="space-y-2">
-                  {practice.participants.map((p) => (
-                    <li key={p.participantId} className="text-foreground-sub text-sm">
-                      멤버 {p.memberId} · {p.sessionId}
-                    </li>
-                  ))}
+                <ul className="divide-border divide-y">
+                  {practice.participants.map((p) => {
+                    const session = practice.sessions.find((s) => s.sessionId === p.sessionId);
+                    return (
+                      <li
+                        key={p.participantId}
+                        className="py-s-2 flex items-center justify-between gap-3"
+                      >
+                        <span className="text-foreground-sub text-sm">
+                          멤버 {p.memberId}
+                          {session && (
+                            <span className="text-foreground-muted ml-2">· {session.label}</span>
+                          )}
+                        </span>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setSessionAssignTarget({
+                              participantId: p.participantId,
+                              memberId: p.memberId,
+                            });
+                            setAssignSessionId(p.sessionId ?? '');
+                          }}
+                        >
+                          {p.sessionId ? '세션 변경' : '세션 배정'}
+                        </Button>
+                      </li>
+                    );
+                  })}
                 </ul>
               )}
             </div>
@@ -277,6 +346,73 @@ export function JamDetailContent({
               </Button>
             </DialogFooter>
           </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={sessionAssignTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSessionAssignTarget(null);
+            setAssignSessionId('');
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>세션 배정</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <div className="space-y-3">
+              <p className="text-foreground-muted text-sm">
+                멤버 {sessionAssignTarget?.memberId}에게 세션을 배정합니다.
+              </p>
+              {practice.sessions.length === 0 ? (
+                <p className="text-foreground-muted text-sm">등록된 세션이 없습니다.</p>
+              ) : (
+                <div className="gap-s-2 flex flex-wrap">
+                  {practice.sessions.map((s: JamSessionResponse) => (
+                    <button
+                      key={s.sessionId}
+                      type="button"
+                      onClick={() => setAssignSessionId(s.sessionId)}
+                      className={`border-border rounded-md border px-3 py-1.5 text-sm transition-colors ${
+                        assignSessionId === s.sessionId
+                          ? 'bg-accent border-transparent text-white'
+                          : 'hover:bg-card'
+                      }`}
+                    >
+                      {s.short} · {s.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </DialogBody>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setSessionAssignTarget(null);
+                setAssignSessionId('');
+              }}
+            >
+              취소
+            </Button>
+            <Button
+              disabled={!assignSessionId}
+              loading={updateSessionMutation.isPending}
+              onClick={() => {
+                if (!sessionAssignTarget || !assignSessionId) return;
+                updateSessionMutation.mutate({
+                  participantId: sessionAssignTarget.participantId,
+                  req: { sessionId: assignSessionId },
+                });
+              }}
+            >
+              배정
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 

--- a/src/domain/jam/api/getJam.ts
+++ b/src/domain/jam/api/getJam.ts
@@ -2,6 +2,6 @@ import { apiClient } from '@/global/api/apiClient';
 
 import type { JamDetailResponse } from '../types';
 
-export async function getJam(practiceId: string): Promise<JamDetailResponse | null> {
-  return apiClient.get<JamDetailResponse | null>(`/api/v1/jams/${practiceId}`);
+export async function getJam(jamId: string): Promise<JamDetailResponse | null> {
+  return apiClient.get<JamDetailResponse | null>(`/api/v1/jams/${jamId}`);
 }

--- a/src/domain/jam/api/updateParticipantSession.ts
+++ b/src/domain/jam/api/updateParticipantSession.ts
@@ -1,0 +1,16 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { JamParticipantResponse, UpdateParticipantSessionRequest } from '../types';
+
+export async function updateParticipantSession(
+  jamId: string,
+  participantId: string,
+  req: UpdateParticipantSessionRequest,
+): Promise<JamParticipantResponse> {
+  const data = await apiClient.patch<JamParticipantResponse>(
+    `/api/v1/jams/${jamId}/participants/${participantId}/session`,
+    req,
+  );
+  if (!data) throw new Error('세션 배정 응답이 비어 있습니다.');
+  return data;
+}

--- a/src/domain/jam/hooks/useJam.ts
+++ b/src/domain/jam/hooks/useJam.ts
@@ -7,10 +7,10 @@ import { queryKeys } from '@/global/config/queryKeys';
 import { getJam } from '../api/getJam';
 import type { JamDetailResponse } from '../types';
 
-export function useJam(practiceId: string, options?: { enabled?: boolean }) {
+export function useJam(jamId: string, options?: { enabled?: boolean }) {
   return useQuery<JamDetailResponse | null, Error>({
-    queryKey: [...queryKeys.jam.detail(practiceId)],
-    queryFn: () => getJam(practiceId),
-    enabled: (options?.enabled ?? true) && !!practiceId,
+    queryKey: [...queryKeys.jam.detail(jamId)],
+    queryFn: () => getJam(jamId),
+    enabled: (options?.enabled ?? true) && !!jamId,
   });
 }

--- a/src/domain/jam/hooks/useUpdateParticipantSession.ts
+++ b/src/domain/jam/hooks/useUpdateParticipantSession.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateParticipantSession } from '../api/updateParticipantSession';
+import type { JamParticipantResponse, UpdateParticipantSessionRequest } from '../types';
+
+type Vars = { participantId: string; req: UpdateParticipantSessionRequest };
+
+type Options = {
+  onSuccess?: (data: JamParticipantResponse) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useUpdateParticipantSession(jamId: string, options?: Options) {
+  const queryClient = useQueryClient();
+  return useMutation<JamParticipantResponse, Error, Vars>({
+    mutationFn: ({ participantId, req }) => updateParticipantSession(jamId, participantId, req),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.jam.detail(jamId)] });
+      options?.onSuccess?.(data);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/jam/types/index.ts
+++ b/src/domain/jam/types/index.ts
@@ -6,6 +6,7 @@ export type {
   UpdateVenueRequest,
   UpdateSessionsRequest,
   AddParticipantRequest,
+  UpdateParticipantSessionRequest,
 } from './req';
 export type {
   TrackInfoResponse,

--- a/src/domain/jam/types/req.ts
+++ b/src/domain/jam/types/req.ts
@@ -41,3 +41,7 @@ export interface AddParticipantRequest {
   memberId: number;
   sessionId: string;
 }
+
+export interface UpdateParticipantSessionRequest {
+  sessionId: string;
+}

--- a/src/domain/jam/types/res.ts
+++ b/src/domain/jam/types/res.ts
@@ -18,7 +18,7 @@ export interface JamSessionResponse {
 export interface JamParticipantResponse {
   participantId: string;
   memberId: number;
-  sessionId: string;
+  sessionId: string | null;
 }
 
 export interface JamDetailResponse {


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-140](https://sunwoo1137.atlassian.net/browse/BD-140)

📌 **작업 내용 및 특이사항**

- `JamsListPane` · `JamsMobileShell`: mine 탭은 `useMyJams`, discover 탭은 `useJams`로 분리
- `JamDetailContent`: 참여자 추가 폼에 세션 선택 UI 추가 (버튼 방식)
- `JamDetailContent`: 기존 참여자 세션 배정/변경 다이얼로그 추가
- `domain/jam/api/updateParticipantSession`: `PATCH /jams/{jamId}/participants/{participantId}/session`
- `domain/jam/hooks/useUpdateParticipantSession`: 세션 배정 뮤테이션 훅
- `domain/jam/types/req`: `UpdateParticipantSessionRequest` 타입 추가
- `domain/jam/types/res`: `JamParticipantResponse.sessionId` nullable 수정
- `domain/jam/api/getJam` · `hooks/useJam`: 파라미터명 `practiceId` → `jamId` 정정

📚 **참고사항**

- `middleware.ts`, `queryKeys.ts`(notification 키), `BandDetailContent`, `sidebar.tsx`는 별도 커밋 예정

[BD-140]: https://sunwoo1137.atlassian.net/browse/BD-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ