### PR TITLE
[BD-167] feat: 합주 상세 UI 개선

### DIFF
--- a/src/app/(main)/jams/[jamId]/JamDetailContent.client.tsx
+++ b/src/app/(main)/jams/[jamId]/JamDetailContent.client.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Music, Trash2, UserPlus } from 'lucide-react';
+import { ExternalLink, MapPin, Music, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-
-import { ExternalLink } from 'lucide-react';
 
 import { EmptyState } from '@/components/feedback/empty-state';
 import { ErrorState } from '@/components/feedback/error-state';
@@ -16,15 +14,16 @@ import {
   Dialog,
   DialogBody,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { JamScheduleBadge } from '@/domain/jam/components/JamScheduleBadge';
-import { JamVenueInline } from '@/domain/jam/components/JamVenueInline.client';
 import { SessionCreateForm } from '@/domain/jam/components/SessionCreateForm.client';
 import { SessionRow } from '@/domain/jam/components/SessionRow';
 import { useAddParticipant } from '@/domain/jam/hooks/useAddParticipant';
@@ -32,8 +31,8 @@ import { useDeleteJam } from '@/domain/jam/hooks/useDeleteJam';
 import { useJam } from '@/domain/jam/hooks/useJam';
 import { useUpdateParticipantSession } from '@/domain/jam/hooks/useUpdateParticipantSession';
 import { useUpdateSchedule } from '@/domain/jam/hooks/useUpdateSchedule';
+import { useUpdateVenue } from '@/domain/jam/hooks/useUpdateVenue';
 import { addParticipantSchema, type AddParticipantSchema } from '@/domain/jam/types';
-import type { JamSessionResponse } from '@/domain/jam/types';
 import { ROUTES } from '@/global/config/routes';
 import { useToast } from '@/hooks/useToast';
 
@@ -55,17 +54,34 @@ export function JamDetailContent({
   const router = useRouter();
   const toast = useToast();
   const { data: practice, isLoading, isError, refetch } = useJam(jamId);
-  const [scheduleOpen, setScheduleOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   const scheduleForm = useForm<{ startAt: string; durationMinutes: number }>({
     defaultValues: { startAt: '', durationMinutes: 60 },
   });
 
+  useEffect(() => {
+    if (practice) {
+      scheduleForm.reset({
+        startAt: toDatetimeLocal(practice.startAt),
+        durationMinutes: practice.durationMinutes,
+      });
+    }
+  }, [practice?.startAt, practice?.durationMinutes]);
+
+  const [venueValue, setVenueValue] = useState('');
+  useEffect(() => {
+    if (practice) setVenueValue(practice.venue ?? '');
+  }, [practice?.venue]);
+
+  const updateVenueMutation = useUpdateVenue(jamId, {
+    onSuccess: () => toast.success('장소가 수정되었습니다.'),
+    onError: (err) => toast.error(err.message || '장소 수정에 실패했습니다.'),
+  });
+
   const updateScheduleMutation = useUpdateSchedule(jamId, {
     onSuccess: () => {
       toast.success('일정이 변경되었습니다.');
-      setScheduleOpen(false);
     },
     onError: (err) => toast.error(err.message || '일정 변경에 실패했습니다.'),
   });
@@ -130,43 +146,123 @@ export function JamDetailContent({
             <h1 className="text-foreground text-xl font-bold">{practice.title}</h1>
             <Button
               size="sm"
-              variant="ghost"
-              className="text-danger hover:opacity-80"
+              variant="secondary"
+              className="rounded-[5px] border-white text-white hover:border-transparent hover:bg-white hover:text-neutral-900 active:border-transparent active:bg-neutral-200 active:text-neutral-900"
               onClick={() => setDeleteOpen(true)}
             >
               <Trash2 className="h-4 w-4" />
-              삭제
+              합주 삭제
             </Button>
           </div>
+
           <div className="flex flex-wrap items-center gap-2">
             <JamScheduleBadge
               startAt={practice.startAt}
               durationMinutes={practice.durationMinutes}
             />
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => {
-                scheduleForm.reset({
-                  startAt: toDatetimeLocal(practice.startAt),
-                  durationMinutes: practice.durationMinutes,
-                });
-                setScheduleOpen(true);
-              }}
-            >
-              일정 변경
-            </Button>
+            {practice.venue && (
+              <span className="text-foreground-sub inline-flex items-center gap-1 text-sm">
+                <MapPin className="h-3 w-3" aria-hidden="true" />
+                {practice.venue}
+              </span>
+            )}
           </div>
-          <JamVenueInline jamId={jamId} venue={practice.venue} />
         </div>
       </Card>
 
       <Tabs defaultValue="song">
-        <TabsList>
-          <TabsTrigger value="song">곡</TabsTrigger>
-          <TabsTrigger value="sessions">세션</TabsTrigger>
-          <TabsTrigger value="participants">참여자</TabsTrigger>
+        <TabsList className="w-full">
+          <TabsTrigger
+            value="song"
+            className="flex-1 data-[state=active]:bg-white data-[state=active]:text-neutral-900"
+          >
+            곡
+          </TabsTrigger>
+          <TabsTrigger
+            value="schedule"
+            className="flex-1 data-[state=active]:bg-white data-[state=active]:text-neutral-900"
+          >
+            일정
+          </TabsTrigger>
+          <TabsTrigger
+            value="sessions"
+            className="flex-1 data-[state=active]:bg-white data-[state=active]:text-neutral-900"
+          >
+            세션
+          </TabsTrigger>
+          <TabsTrigger
+            value="participants"
+            className="flex-1 data-[state=active]:bg-white data-[state=active]:text-neutral-900"
+          >
+            참여자
+          </TabsTrigger>
         </TabsList>
+
+        <TabsContent value="schedule" className="mt-6">
+          <Card padding="md">
+            <div className="space-y-4">
+              <form
+                className="space-y-2"
+                onSubmit={scheduleForm.handleSubmit((values) =>
+                  updateScheduleMutation.mutate({
+                    startAt: fromDatetimeLocal(values.startAt),
+                    durationMinutes: Number(values.durationMinutes),
+                  }),
+                )}
+              >
+                <p className="text-foreground-sub text-sm font-medium">일정</p>
+                <div
+                  className="grid gap-x-3 gap-y-1.5"
+                  style={{ gridTemplateColumns: '2fr 1fr auto' }}
+                >
+                  <span className="text-foreground text-xs font-medium">시작 시각</span>
+                  <span className="text-foreground text-xs font-medium">소요 시간 (분)</span>
+                  <span />
+                  <Input
+                    type="datetime-local"
+                    className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0 [&::-webkit-calendar-picker-indicator]:opacity-70 [&::-webkit-calendar-picker-indicator]:invert"
+                    {...scheduleForm.register('startAt')}
+                  />
+                  <Input
+                    type="number"
+                    min={5}
+                    max={480}
+                    step={5}
+                    className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
+                    {...scheduleForm.register('durationMinutes', { valueAsNumber: true })}
+                  />
+                  <Button
+                    type="submit"
+                    variant="secondary"
+                    className="h-8 w-fit self-end rounded-[5px] border-white bg-white px-3 text-neutral-900 hover:bg-white/90 active:bg-white/80"
+                    loading={updateScheduleMutation.isPending}
+                  >
+                    저장
+                  </Button>
+                </div>
+              </form>
+              <div className="space-y-1.5">
+                <p className="text-foreground-sub text-sm font-medium">장소</p>
+                <div className="grid gap-3" style={{ gridTemplateColumns: '1fr auto' }}>
+                  <Input
+                    placeholder="장소를 입력하세요"
+                    value={venueValue}
+                    onChange={(e) => setVenueValue(e.target.value)}
+                    className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
+                  />
+                  <Button
+                    variant="secondary"
+                    className="h-8 w-fit self-end rounded-[5px] border-white bg-white px-3 text-neutral-900 hover:bg-white/90 active:bg-white/80"
+                    loading={updateVenueMutation.isPending}
+                    onClick={() => updateVenueMutation.mutate({ venue: venueValue.trim() })}
+                  >
+                    저장
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </Card>
+        </TabsContent>
 
         <TabsContent value="song">
           <Card header="합주곡" padding="md">
@@ -213,59 +309,54 @@ export function JamDetailContent({
           <Card header="참여자" padding="md">
             <div className="space-y-4">
               <form
-                className="space-y-3"
                 onSubmit={addParticipantForm.handleSubmit((values) =>
                   addParticipantMutation.mutate(values),
                 )}
                 noValidate
               >
-                <div className="flex flex-wrap items-end gap-2">
+                <div
+                  className="grid gap-x-3 gap-y-1.5"
+                  style={{ gridTemplateColumns: '1fr 1fr auto' }}
+                >
+                  <span className="text-foreground text-xs font-medium">멤버 ID</span>
+                  <span className="text-foreground text-xs font-medium">세션 선택</span>
+                  <span />
                   <Input
-                    label="멤버 ID"
                     type="number"
-                    placeholder="예: 3"
-                    className="max-w-xs"
-                    error={addParticipantForm.formState.errors.memberId?.message}
+                    min={1}
+                    className="[appearance:textfield] rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                     {...addParticipantForm.register('memberId', { valueAsNumber: true })}
                   />
+                  <Select
+                    placeholder="세션을 선택하세요"
+                    options={practice.sessions
+                      .filter((s) => s.participants.length < s.need)
+                      .map((s) => ({
+                        value: s.sessionId,
+                        label: `${s.short} · ${s.label}`,
+                      }))}
+                    className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
+                    disabled={
+                      practice.sessions.filter((s) => s.participants.length < s.need).length === 0
+                    }
+                    {...addParticipantForm.register('sessionId')}
+                  />
+                  <Button
+                    type="submit"
+                    variant="secondary"
+                    className="h-8 w-fit self-end rounded-[5px] border-white bg-white px-3 text-neutral-900 hover:bg-white/90 active:bg-white/80"
+                    loading={addParticipantMutation.isPending}
+                  >
+                    추가
+                  </Button>
                 </div>
-                <div className="space-y-1">
-                  <p className="text-foreground-sub text-sm font-medium">세션 선택</p>
-                  {practice.sessions.length === 0 ? (
-                    <p className="text-foreground-muted text-xs">먼저 세션을 등록해 주세요.</p>
-                  ) : (
-                    <div className="flex flex-wrap gap-2">
-                      {practice.sessions.map((s: JamSessionResponse) => {
-                        const selected = addParticipantForm.watch('sessionId') === s.sessionId;
-                        return (
-                          <button
-                            key={s.sessionId}
-                            type="button"
-                            onClick={() =>
-                              addParticipantForm.setValue('sessionId', s.sessionId, {
-                                shouldValidate: true,
-                              })
-                            }
-                            className={`border-border rounded-md border px-3 py-1.5 text-sm transition-colors ${
-                              selected ? 'bg-accent border-transparent text-white' : 'hover:bg-card'
-                            }`}
-                          >
-                            {s.short} · {s.label}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  )}
-                  {addParticipantForm.formState.errors.sessionId && (
-                    <p className="text-danger text-xs">
-                      {addParticipantForm.formState.errors.sessionId.message}
-                    </p>
-                  )}
-                </div>
-                <Button type="submit" loading={addParticipantMutation.isPending}>
-                  <UserPlus className="h-4 w-4" />
-                  추가
-                </Button>
+                {(addParticipantForm.formState.errors.memberId ||
+                  addParticipantForm.formState.errors.sessionId) && (
+                  <p className="text-danger mt-1.5 text-xs">
+                    {addParticipantForm.formState.errors.memberId?.message ??
+                      addParticipantForm.formState.errors.sessionId?.message}
+                  </p>
+                )}
               </form>
               {practice.participants.length === 0 ? (
                 <EmptyState title="참여자가 없습니다" />
@@ -307,48 +398,6 @@ export function JamDetailContent({
         </TabsContent>
       </Tabs>
 
-      <Dialog open={scheduleOpen} onOpenChange={setScheduleOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>일정 변경</DialogTitle>
-          </DialogHeader>
-          <form
-            onSubmit={scheduleForm.handleSubmit((values) =>
-              updateScheduleMutation.mutate({
-                startAt: fromDatetimeLocal(values.startAt),
-                durationMinutes: Number(values.durationMinutes),
-              }),
-            )}
-          >
-            <DialogBody>
-              <div className="space-y-3">
-                <Input
-                  label="시작 시각"
-                  type="datetime-local"
-                  {...scheduleForm.register('startAt')}
-                />
-                <Input
-                  label="소요 시간 (분)"
-                  type="number"
-                  min={15}
-                  max={480}
-                  step={15}
-                  {...scheduleForm.register('durationMinutes', { valueAsNumber: true })}
-                />
-              </div>
-            </DialogBody>
-            <DialogFooter>
-              <Button type="button" variant="ghost" onClick={() => setScheduleOpen(false)}>
-                취소
-              </Button>
-              <Button type="submit" loading={updateScheduleMutation.isPending}>
-                저장
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
-
       <Dialog
         open={sessionAssignTarget !== null}
         onOpenChange={(open) => {
@@ -367,31 +416,26 @@ export function JamDetailContent({
               <p className="text-foreground-muted text-sm">
                 멤버 {sessionAssignTarget?.memberId}에게 세션을 배정합니다.
               </p>
-              {practice.sessions.length === 0 ? (
-                <p className="text-foreground-muted text-sm">등록된 세션이 없습니다.</p>
-              ) : (
-                <div className="gap-s-2 flex flex-wrap">
-                  {practice.sessions.map((s: JamSessionResponse) => (
-                    <button
-                      key={s.sessionId}
-                      type="button"
-                      onClick={() => setAssignSessionId(s.sessionId)}
-                      className={`border-border rounded-md border px-3 py-1.5 text-sm transition-colors ${
-                        assignSessionId === s.sessionId
-                          ? 'bg-accent border-transparent text-white'
-                          : 'hover:bg-card'
-                      }`}
-                    >
-                      {s.short} · {s.label}
-                    </button>
-                  ))}
-                </div>
-              )}
+              <Select
+                placeholder="세션을 선택하세요"
+                value={assignSessionId}
+                onChange={(e) => setAssignSessionId(e.target.value)}
+                options={(() => {
+                  const mySessionId = practice.participants.find(
+                    (p) => p.participantId === sessionAssignTarget?.participantId,
+                  )?.sessionId;
+                  return practice.sessions
+                    .filter((s) => s.participants.length < s.need || s.sessionId === mySessionId)
+                    .map((s) => ({ value: s.sessionId, label: `${s.short} · ${s.label}` }));
+                })()}
+                className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
+              />
             </div>
           </DialogBody>
           <DialogFooter>
             <Button
               variant="ghost"
+              className="h-8 rounded-[5px]"
               onClick={() => {
                 setSessionAssignTarget(null);
                 setAssignSessionId('');
@@ -400,6 +444,8 @@ export function JamDetailContent({
               취소
             </Button>
             <Button
+              variant="secondary"
+              className="h-8 rounded-[5px] border-white bg-white px-3 text-neutral-900 hover:bg-white/90 active:bg-white/80"
               disabled={!assignSessionId}
               loading={updateSessionMutation.isPending}
               onClick={() => {
@@ -418,24 +464,30 @@ export function JamDetailContent({
 
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent>
-          <DialogHeader>
-            <DialogTitle>합주 삭제</DialogTitle>
+          <DialogHeader className="border-b-0 pb-2">
+            <DialogTitle>합주를 삭제하시겠어요?</DialogTitle>
           </DialogHeader>
-          <DialogBody>
-            <p className="text-foreground-sub text-sm">
+          <div className="border-border mx-5 border-b" />
+          <DialogBody className="pt-2">
+            <DialogDescription className="text-foreground-sub text-sm">
               삭제된 합주는 복구할 수 없습니다. 세션과 참여자 정보도 함께 제거됩니다.
-            </p>
+            </DialogDescription>
           </DialogBody>
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setDeleteOpen(false)}>
+          <DialogFooter className="border-t-0">
+            <Button
+              variant="ghost"
+              className="h-8 rounded-[5px]"
+              onClick={() => setDeleteOpen(false)}
+            >
               취소
             </Button>
             <Button
               variant="danger"
+              className="h-8 rounded-[5px] px-2"
               loading={deleteMutation.isPending}
               onClick={() => deleteMutation.mutate()}
             >
-              삭제
+              삭제하기
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/app/(main)/jams/new/JamCreateWizard.client.tsx
+++ b/src/app/(main)/jams/new/JamCreateWizard.client.tsx
@@ -55,7 +55,7 @@ export function JamCreateWizard() {
   });
 
   const trackReady = !!trackTitle.trim() && !!trackArtist.trim();
-  const scheduleReady = !!startAt && durationMinutes >= 15;
+  const scheduleReady = !!startAt && durationMinutes >= 5;
 
   const canNext =
     step === 0
@@ -210,9 +210,9 @@ export function JamCreateWizard() {
               <div className="mt-s-2">
                 <input
                   type="number"
-                  min={15}
+                  min={5}
                   max={480}
-                  step={15}
+                  step={5}
                   required
                   value={durationMinutes}
                   onChange={(e) => setDurationMinutes(Number(e.target.value) || 0)}

--- a/src/domain/jam/components/SessionCreateForm.client.tsx
+++ b/src/domain/jam/components/SessionCreateForm.client.tsx
@@ -24,7 +24,7 @@ export function SessionCreateForm({ jamId, onCreated }: { jamId: string; onCreat
     onError: (err) => toast.error(err.message || '세션 추가에 실패했습니다.'),
   });
 
-  function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
     if (!label.trim()) return toast.error('세션 이름을 입력해 주세요.');
     if (!short.trim()) return toast.error('약어를 입력해 주세요.');
@@ -38,38 +38,42 @@ export function SessionCreateForm({ jamId, onCreated }: { jamId: string; onCreat
   }
 
   return (
-    <form
-      className="flex flex-col gap-3 sm:flex-row sm:items-end"
-      onSubmit={handleSubmit}
-      noValidate
-    >
-      <Input
-        label="세션 이름"
-        placeholder="예: Guitar 2"
-        value={label}
-        onChange={(e) => setLabel(e.target.value)}
-        className="sm:flex-1"
-      />
-      <Input
-        label="약어"
-        placeholder="예: G2"
-        value={short}
-        onChange={(e) => setShort(e.target.value)}
-        className="sm:w-24"
-        maxLength={3}
-      />
-      <Input
-        label="정원"
-        type="number"
-        min={1}
-        max={20}
-        value={need}
-        onChange={(e) => setNeed(Number(e.target.value) || 1)}
-        className="sm:w-20"
-      />
-      <Button type="submit" loading={mutation.isPending}>
-        추가
-      </Button>
+    <form onSubmit={handleSubmit} noValidate>
+      <div className="grid gap-x-3 gap-y-1.5" style={{ gridTemplateColumns: '2fr 1fr 1fr auto' }}>
+        <span className="text-foreground text-xs font-medium">세션 이름</span>
+        <span className="text-foreground text-xs font-medium">약어</span>
+        <span className="text-foreground text-xs font-medium">정원</span>
+        <span />
+        <Input
+          placeholder="예: Guitar 2"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
+        />
+        <Input
+          placeholder="예: G2"
+          value={short}
+          onChange={(e) => setShort(e.target.value)}
+          maxLength={3}
+          className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
+        />
+        <Input
+          type="number"
+          min={1}
+          max={20}
+          value={need}
+          onChange={(e) => setNeed(Number(e.target.value) || 1)}
+          className="rounded-[5px] border-white/20 hover:border-white/35 focus-visible:border-white/70 focus-visible:ring-0"
+        />
+        <Button
+          type="submit"
+          variant="secondary"
+          className="h-8 w-fit self-end rounded-[5px] border-white bg-white px-3 text-neutral-900 hover:bg-white/90 active:bg-white/80"
+          loading={mutation.isPending}
+        >
+          추가
+        </Button>
+      </div>
     </form>
   );
 }

--- a/src/domain/jam/components/SessionRow.tsx
+++ b/src/domain/jam/components/SessionRow.tsx
@@ -40,7 +40,7 @@ export function SessionRow({ jamId, session }: Props) {
   return (
     <div className="border-border flex items-center justify-between gap-3 border-b py-3 last:border-b-0">
       <div className="flex min-w-0 items-center gap-3">
-        <Chip>{session.short}</Chip>
+        <Chip className="rounded-[5px] border-white/30">{session.short}</Chip>
         <div className="min-w-0">
           <span className="text-foreground truncate text-sm font-medium">{session.label}</span>
           <span className="text-foreground-muted ml-2 text-xs">
@@ -53,7 +53,7 @@ export function SessionRow({ jamId, session }: Props) {
         size="sm"
         variant="ghost"
         aria-label="세션 삭제"
-        className="text-danger hover:opacity-80"
+        className="text-foreground-muted hover:text-foreground"
         onClick={() => setConfirmDelete(true)}
       >
         <Trash2 className="h-4 w-4" aria-hidden="true" />
@@ -61,24 +61,30 @@ export function SessionRow({ jamId, session }: Props) {
 
       <Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>
         <DialogContent>
-          <DialogHeader>
-            <DialogTitle>세션 삭제</DialogTitle>
+          <DialogHeader className="border-b-0 pb-2">
+            <DialogTitle>세션을 삭제하시겠어요?</DialogTitle>
           </DialogHeader>
-          <DialogBody>
+          <div className="border-border mx-5 border-b" />
+          <DialogBody className="pt-2">
             <p className="text-foreground-sub text-sm">
-              &apos;{session.label}&apos; 세션을 삭제합니다.
+              &apos;{session.label}&apos; 세션은 복구할 수 없습니다.
             </p>
           </DialogBody>
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setConfirmDelete(false)}>
+          <DialogFooter className="border-t-0">
+            <Button
+              variant="ghost"
+              className="h-8 rounded-[5px]"
+              onClick={() => setConfirmDelete(false)}
+            >
               취소
             </Button>
             <Button
               variant="danger"
+              className="h-8 rounded-[5px] px-2"
               loading={deleteMutation.isPending}
               onClick={() => deleteMutation.mutate(session.sessionId)}
             >
-              삭제
+              삭제하기
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
### 🛠️ Issue Number
### closes [BD-167](https://sunwoo1137.atlassian.net/browse/BD-167)

📌 **작업 내용 및 특이사항**

- 합주 삭제 버튼 및 다이얼로그 밴드 탈퇴 패턴으로 통일 (화이트 스타일, border-b-0/border-t-0, 구분선)
- 상단 정보 카드 날짜·장소 인라인 배치, 구분점 제거
- 탭 구성 변경: 곡·일정·세션·참여자 순서, 화이트 액티브 탭, 균등 너비
- 일정 탭: 시작시각·소요시간 그리드 한 행 배치 + 저장 버튼, 장소 입력폼 추가
- 소요시간 step 15분 → 5분으로 변경 (합주 생성 포함)
- 세션 탭: 추가 폼 그리드 레이아웃 적용, 삭제 아이콘 화이트, 세션 칩 radius-5 + 화이트 테두리
- 세션 삭제 다이얼로그 합주 삭제 패턴으로 통일
- 참여자 탭: 멤버ID·세션 선택 그리드 한 행 배치, 세션 드롭다운 전환 (정원 미달 세션만 표시)
- 세션 배정 모달 드롭다운 전환, 화이트 버튼 스타일, 본인 세션 항상 표시
- 모든 입력창 로그인 스타일 통일 (rounded-[5px], border-white/20, hover/focus 상태)

 📚 **참고사항**

- **[BE 요청]** `JamDetailResponse`에 `createdBy` / `canDelete` / `canEdit` 등 권한 판단 필드 추가 필요 — 해당 필드가 없으면 프론트에서 삭제·수정 버튼을 권한 있는 멤버에게만 노출하는 것이 불가능. 현재는 모든 멤버에게 버튼 노출 상태로 임시 처리
- 참여자 이름/프로필 표시는 BE에서 `JamParticipantResponse`에 name 필드 추가 필요 (현재 memberId만 반환)
- `middleware.ts`, `sidebar.tsx`, `queryKeys.ts`, `BandDetailContent.client.tsx` 변경분은 별도 PR로 분리 예정

[BD-167]: https://sunwoo1137.atlassian.net/browse/BD-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ