### PR TITLE
[BD-147] feat: 글로벌 상단바 및 알림 기능 구현

### DIFF
--- a/src/app/(main)/bands/page.tsx
+++ b/src/app/(main)/bands/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function BandsPage() {
   return (
     <Suspense fallback={null}>
-      <div className="p-s-4 lg:pt-15">
+      <div className="p-s-4 lg:pt-10">
         <BandsMobileShell />
       </div>
     </Suspense>

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -33,7 +33,7 @@ function ViewAllLink({ href, label }: { href: string; label: string }) {
 
 export default function HomePage() {
   return (
-    <div className="space-y-s-8 lg:p-s-10 lg:w-full">
+    <div className="space-y-s-8 lg:px-s-10 lg:pb-s-10 lg:w-full lg:pt-7.5">
       <HomeGreeting />
 
       <HomeStatCards />

--- a/src/app/(main)/jams/new/JamCreateWizard.client.tsx
+++ b/src/app/(main)/jams/new/JamCreateWizard.client.tsx
@@ -121,7 +121,7 @@ export function JamCreateWizard() {
   }
 
   return (
-    <div className="p-s-4 mx-auto w-full max-w-3xl lg:py-15" data-slot="jam-create-wizard">
+    <div className="p-s-4 mx-auto w-full max-w-3xl lg:py-10" data-slot="jam-create-wizard">
       <header className="mb-s-6">
         <h1 className="text-title font-bold">합주 생성</h1>
       </header>

--- a/src/app/(main)/jams/page.tsx
+++ b/src/app/(main)/jams/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function PracticesPage() {
   return (
     <Suspense fallback={null}>
-      <div className="p-s-4 lg:pt-15">
+      <div className="p-s-4 lg:pt-10">
         <JamsMobileShell />
       </div>
     </Suspense>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -3,6 +3,7 @@ import { Suspense, type ReactNode } from 'react';
 import { LeaveConfirmDialog } from '@/components/feedback/leave-confirm-dialog';
 import { BottomNav } from '@/components/layout/bottom-nav';
 import { Container } from '@/components/layout/container';
+import { GlobalTopbar } from '@/components/layout/global-topbar.client';
 import { Shell } from '@/components/layout/shell';
 import { Sidebar } from '@/components/layout/sidebar';
 import { AuthBootstrapper } from '@/global/auth/AuthBootstrapper.client';
@@ -27,16 +28,18 @@ export default function MainLayout({ children }: { children: ReactNode }) {
     <Suspense fallback={null}>
       <AuthBootstrapper>
         <DirtyFormProvider>
+          <GlobalTopbar />
+
           {/* Desktop */}
           <div className="hidden lg:block">
             <Shell>
               <Sidebar />
-              <main className="flex flex-1 flex-col overflow-y-auto">{children}</main>
+              <main className="flex flex-1 flex-col overflow-y-auto pt-14">{children}</main>
             </Shell>
           </div>
 
           {/* Mobile */}
-          <div className="min-h-screen pb-16 lg:hidden">
+          <div className="min-h-screen pt-14 pb-16 lg:hidden">
             <Container maxWidth="xl" padding className="py-s-6">
               {children}
             </Container>

--- a/src/app/(main)/me/page.tsx
+++ b/src/app/(main)/me/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function MyPage() {
   return (
-    <div className="space-y-s-6 p-s-4 mx-auto w-full max-w-3xl lg:py-15">
+    <div className="space-y-s-6 p-s-4 mx-auto w-full max-w-3xl lg:py-10">
       <MeContent />
     </div>
   );

--- a/src/components/layout/__snapshots__/sidebar.test.tsx.snap
+++ b/src/components/layout/__snapshots__/sidebar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
 <DocumentFragment>
   <aside
     aria-label="주 탐색"
-    class="bg-surface border-border py-s-4 gap-s-1 relative hidden shrink-0 flex-col border-r lg:flex transition-[width] duration-200 ease-in-out px-s-3"
+    class="bg-surface border-border py-s-4 gap-s-1 relative z-30 hidden shrink-0 flex-col border-r lg:flex transition-[width] duration-200 ease-in-out px-s-3"
     data-slot="sidebar"
     style="width: var(--sidebar-w);"
   >
@@ -355,30 +355,17 @@ exports[`Sidebar > 활성 경로(/bands) 및 로그인 사용자 정보 렌더 �
       class="border-border mt-s-3 pt-s-3 gap-s-1 flex flex-col border-t"
     >
       <div
-        class="gap-s-2 px-s-2 py-s-1 flex min-w-0 items-center"
+        class="px-s-4 py-s-1 min-w-0"
       >
-        <span
-          class="bg-card-hover text-foreground-sub rounded-pill inline-flex items-center justify-center overflow-hidden font-semibold select-none h-7.5 w-7.5 shrink-0 text-xs"
-        >
-          <span
-            aria-label="수연"
-          >
-            수연
-          </span>
-        </span>
         <div
-          class="min-w-0 flex-1"
+          class="text-foreground text-caption truncate font-semibold"
         >
-          <div
-            class="text-foreground text-caption truncate font-semibold"
-          >
-            수연
-          </div>
-          <div
-            class="text-foreground-muted text-micro truncate"
-          >
-            sooyeon@example.com
-          </div>
+          수연
+        </div>
+        <div
+          class="text-foreground-muted text-micro truncate"
+        >
+          sooyeon@example.com
         </div>
       </div>
       <button

--- a/src/components/layout/global-topbar.client.tsx
+++ b/src/components/layout/global-topbar.client.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { NotificationBell } from '@/domain/notification/components/NotificationBell.client';
+import { useMe } from '@/domain/member/hooks/useMe';
+import { Avatar } from '@/components/ui/avatar';
+import { ROUTES } from '@/global/config/routes';
+
+export function GlobalTopbar() {
+  const { data: me, isLoading: meLoading } = useMe();
+
+  return (
+    <header className="bg-surface border-border fixed top-0 right-0 left-0 z-20 flex h-14 shrink-0 items-center justify-between border-b px-4">
+      {/* 로고 — 데스크톱에서는 사이드바에 가려짐, 모바일에서만 표시 */}
+      <Image
+        src="/brand/bandage_wave_text_white.png"
+        alt="Bandage"
+        width={80}
+        height={17}
+        priority
+        className="lg:invisible"
+      />
+      <div className="flex items-center gap-5">
+        <NotificationBell collapsed placement="topbar" />
+        {meLoading ? (
+          <Skeleton rounded="pill" className="h-7 w-7 shrink-0" />
+        ) : (
+          <Link href={ROUTES.ME} aria-label="마이페이지" className="mr-4 inline-flex items-center">
+            <Avatar
+              src={me?.profileImg ?? undefined}
+              fallback={me?.name ?? me?.email ?? '?'}
+              className="h-7 w-7 text-xs"
+            />
+          </Link>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -23,7 +23,6 @@ import { ROUTES } from '@/global/config/routes';
 import { useUiStore } from '@/global/store/uiStore';
 import { useToast } from '@/hooks/useToast';
 import { cn } from '@/lib/cn';
-import { Avatar } from '../ui/avatar';
 import { Button } from '../ui/button';
 import { Skeleton } from '../ui/skeleton';
 
@@ -102,8 +101,8 @@ export function Sidebar({ className }: SidebarProps) {
   const pathname = usePathname() ?? '';
   const router = useRouter();
   const toast = useToast();
-  const { data: me, isLoading: meLoading } = useMe();
   const { sidebarCollapsed, toggleSidebar } = useUiStore();
+  const { data: me, isLoading: meLoading } = useMe();
 
   const logoutMutation = useLogout({
     onSuccess: () => {
@@ -118,7 +117,7 @@ export function Sidebar({ className }: SidebarProps) {
   return (
     <aside
       className={cn(
-        'bg-surface border-border py-s-4 gap-s-1 relative hidden shrink-0 flex-col border-r lg:flex',
+        'bg-surface border-border py-s-4 gap-s-1 relative z-30 hidden shrink-0 flex-col border-r lg:flex',
         'transition-[width] duration-200 ease-in-out',
         collapsed ? 'px-s-2' : 'px-s-3',
         className,
@@ -185,38 +184,14 @@ export function Sidebar({ className }: SidebarProps) {
       </nav>
 
       <div className="border-border mt-s-3 pt-s-3 gap-s-1 flex flex-col border-t">
-        {collapsed ? (
-          <div className="flex justify-center py-1">
-            {meLoading ? (
-              <Skeleton rounded="pill" className="h-8 w-8 shrink-0" />
-            ) : (
-              <Avatar
-                src={me?.profileImg ?? undefined}
-                fallback={me?.name ?? me?.email ?? '게스트'}
-                className="h-7.5 w-7.5 shrink-0 text-xs"
-                title={me?.name ?? '게스트'}
-              />
-            )}
-          </div>
-        ) : meLoading ? (
-          <div
-            className="gap-s-2 px-s-2 py-s-2 flex min-w-0 items-center"
-            aria-label="사용자 정보 로딩 중"
-          >
-            <Skeleton rounded="pill" className="h-8 w-8 shrink-0" />
-            <div className="min-w-0 flex-1 space-y-1">
+        {!collapsed &&
+          (meLoading ? (
+            <div className="px-s-4 py-s-1 space-y-1">
               <Skeleton className="h-3 w-20" />
               <Skeleton className="h-2.5 w-28" />
             </div>
-          </div>
-        ) : (
-          <div className="gap-s-2 px-s-2 py-s-1 flex min-w-0 items-center">
-            <Avatar
-              src={me?.profileImg ?? undefined}
-              fallback={me?.name ?? me?.email ?? '게스트'}
-              className="h-7.5 w-7.5 shrink-0 text-xs"
-            />
-            <div className="min-w-0 flex-1">
+          ) : (
+            <div className="px-s-4 py-s-1 min-w-0">
               <div className="text-foreground text-caption truncate font-semibold">
                 {me?.name ?? '게스트'}
               </div>
@@ -224,8 +199,7 @@ export function Sidebar({ className }: SidebarProps) {
                 {me?.email ?? '로그인이 필요합니다'}
               </div>
             </div>
-          </div>
-        )}
+          ))}
         {!collapsed && (
           <Button
             variant="secondary"

--- a/src/domain/notification/api/getMyNotifications.ts
+++ b/src/domain/notification/api/getMyNotifications.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { NotificationResponse } from '../types/res';
+
+type NotificationListRaw = NotificationResponse[] | CursorResponse<NotificationResponse, number>;
+
+export async function getMyNotifications(): Promise<NotificationResponse[]> {
+  const data = await apiClient.get<NotificationListRaw | null>('/api/v1/notifications');
+  if (!data) return [];
+  if (Array.isArray(data)) return data;
+  return data.content;
+}

--- a/src/domain/notification/api/getUnreadCount.ts
+++ b/src/domain/notification/api/getUnreadCount.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { UnreadNotificationCountResponse } from '../types/res';
+
+export async function getUnreadCount(): Promise<UnreadNotificationCountResponse> {
+  const data = await apiClient.get<UnreadNotificationCountResponse | null>(
+    '/api/v1/notifications/unread-count',
+  );
+  return data ?? { count: 0 };
+}

--- a/src/domain/notification/api/markAllAsRead.ts
+++ b/src/domain/notification/api/markAllAsRead.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function markAllAsRead(): Promise<void> {
+  await apiClient.patch('/api/v1/notifications/read-all');
+}

--- a/src/domain/notification/api/markAsRead.ts
+++ b/src/domain/notification/api/markAsRead.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function markAsRead(notificationId: number): Promise<void> {
+  await apiClient.patch(`/api/v1/notifications/${notificationId}/read`);
+}

--- a/src/domain/notification/components/NotificationBell.client.tsx
+++ b/src/domain/notification/components/NotificationBell.client.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { Bell, Check, CheckCheck } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { cn } from '@/lib/cn';
+import { formatRelative } from '@/lib/date';
+
+import { useMarkAllAsRead } from '../hooks/useMarkAllAsRead';
+import { useMarkAsRead } from '../hooks/useMarkAsRead';
+import { useMyNotifications } from '../hooks/useMyNotifications';
+import { useUnreadCount } from '../hooks/useUnreadCount';
+
+interface Props {
+  collapsed: boolean;
+  placement?: 'sidebar' | 'topbar';
+}
+
+export function NotificationBell({ collapsed, placement = 'sidebar' }: Props) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { data: unreadData } = useUnreadCount();
+  const { data: notifications = [], isLoading } = useMyNotifications();
+  const markAsRead = useMarkAsRead();
+  const markAllAsRead = useMarkAllAsRead();
+
+  const unreadCount = unreadData?.count ?? 0;
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="알림"
+        aria-expanded={open}
+        className={cn(
+          'relative flex items-center rounded-[8px] font-medium transition-colors',
+          'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+          open
+            ? 'bg-card text-foreground'
+            : 'text-foreground-sub hover:bg-card hover:text-foreground',
+          placement === 'topbar'
+            ? 'h-[20px] w-[20px] justify-center'
+            : cn(
+                'gap-s-3 py-s-2 text-caption w-full',
+                collapsed ? 'justify-center px-0' : 'px-s-3',
+              ),
+        )}
+      >
+        <span className="relative shrink-0">
+          <Bell
+            className={placement === 'topbar' ? 'h-5 w-5' : 'h-3.25 w-3.25'}
+            aria-hidden="true"
+          />
+          {unreadCount > 0 && (
+            <span className="bg-accent text-accent-foreground absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full px-0.5 text-[10px] leading-none font-bold">
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </span>
+          )}
+        </span>
+        {placement === 'sidebar' && !collapsed && <span className="truncate">알림</span>}
+      </button>
+
+      {open && (
+        <div
+          className={cn(
+            'bg-card border-border absolute z-50 flex flex-col rounded-xl border shadow-xl',
+            placement === 'topbar' ? 'top-full -right-[15px] mt-3' : 'bottom-0 left-full ml-3',
+            'w-80',
+            'max-h-120',
+          )}
+          role="dialog"
+          aria-label="알림 패널"
+        >
+          {placement === 'topbar' && (
+            <span className="bg-card border-border absolute -top-2 right-4 h-4 w-4 rotate-45 border-t border-l" />
+          )}
+          <div className="border-border flex items-center justify-between border-b px-4 py-3">
+            <span className="text-foreground text-sm font-semibold">알림</span>
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                onClick={() => markAllAsRead.mutate()}
+                disabled={markAllAsRead.isPending}
+                className="text-foreground-muted hover:text-foreground flex items-center gap-1 text-xs transition-colors disabled:opacity-50"
+              >
+                <CheckCheck className="h-3.5 w-3.5" />
+                전체 읽음
+              </button>
+            )}
+          </div>
+
+          <ul className="flex-1 overflow-y-auto">
+            {isLoading ? (
+              <li className="text-foreground-muted px-4 py-8 text-center text-sm">불러오는 중…</li>
+            ) : notifications.length === 0 ? (
+              <li className="text-foreground-muted px-4 py-8 text-center text-sm">
+                알림이 없습니다.
+              </li>
+            ) : (
+              notifications.map((n) => (
+                <li
+                  key={n.notificationId}
+                  className={cn(
+                    'border-border flex items-start gap-3 border-b px-4 py-3 last:border-b-0',
+                    !n.isRead && 'bg-surface',
+                  )}
+                >
+                  <div className="mt-0.5 shrink-0">
+                    {!n.isRead && (
+                      <span className="bg-accent block h-2 w-2 rounded-full" aria-hidden="true" />
+                    )}
+                    {n.isRead && <span className="block h-2 w-2" aria-hidden="true" />}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className={cn(
+                        'text-sm leading-snug',
+                        n.isRead ? 'text-foreground-muted' : 'text-foreground',
+                      )}
+                    >
+                      {n.message}
+                    </p>
+                    <p className="text-foreground-muted mt-0.5 text-xs">
+                      {formatRelative(new Date(n.createdAt))}
+                    </p>
+                  </div>
+                  {!n.isRead && (
+                    <button
+                      type="button"
+                      onClick={() => markAsRead.mutate(n.notificationId)}
+                      disabled={markAsRead.isPending}
+                      aria-label="읽음 처리"
+                      className="text-foreground-muted hover:text-foreground mt-0.5 shrink-0 transition-colors disabled:opacity-50"
+                    >
+                      <Check className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/domain/notification/hooks/useMarkAllAsRead.ts
+++ b/src/domain/notification/hooks/useMarkAllAsRead.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { markAllAsRead } from '../api/markAllAsRead';
+
+export function useMarkAllAsRead() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: markAllAsRead,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.notification.list() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.notification.unreadCount() });
+    },
+  });
+}

--- a/src/domain/notification/hooks/useMarkAsRead.ts
+++ b/src/domain/notification/hooks/useMarkAsRead.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { markAsRead } from '../api/markAsRead';
+
+export function useMarkAsRead() {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: markAsRead,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.notification.list() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.notification.unreadCount() });
+    },
+  });
+}

--- a/src/domain/notification/hooks/useMyNotifications.ts
+++ b/src/domain/notification/hooks/useMyNotifications.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+
+import { getMyNotifications } from '../api/getMyNotifications';
+import type { NotificationResponse } from '../types/res';
+
+export function useMyNotifications() {
+  const authenticated = useIsAuthenticated();
+  return useQuery<NotificationResponse[], Error>({
+    queryKey: queryKeys.notification.list(),
+    queryFn: getMyNotifications,
+    enabled: authenticated,
+    staleTime: 30 * 1000,
+  });
+}

--- a/src/domain/notification/hooks/useUnreadCount.ts
+++ b/src/domain/notification/hooks/useUnreadCount.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+
+import { getUnreadCount } from '../api/getUnreadCount';
+
+export function useUnreadCount() {
+  const authenticated = useIsAuthenticated();
+  return useQuery({
+    queryKey: queryKeys.notification.unreadCount(),
+    queryFn: getUnreadCount,
+    enabled: authenticated,
+    staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
+  });
+}

--- a/src/domain/notification/types/res.ts
+++ b/src/domain/notification/types/res.ts
@@ -1,0 +1,13 @@
+export type NotificationType = string;
+
+export interface NotificationResponse {
+  notificationId: number;
+  type: NotificationType;
+  message: string;
+  isRead: boolean;
+  createdAt: string;
+}
+
+export interface UnreadNotificationCountResponse {
+  count: number;
+}

--- a/src/global/config/queryKeys.ts
+++ b/src/global/config/queryKeys.ts
@@ -27,6 +27,11 @@ export const queryKeys = {
     detail: (id: string) => [...queryKeys.jam.all, id] as const,
     songs: (id: string) => [...queryKeys.jam.all, id, 'songs'] as const,
   },
+  notification: {
+    all: ['notification'] as const,
+    list: () => [...queryKeys.notification.all, 'list'] as const,
+    unreadCount: () => [...queryKeys.notification.all, 'unread-count'] as const,
+  },
   performance: {
     all: ['performance'] as const,
     list: (bandId?: string) => [...queryKeys.performance.all, 'list', bandId ?? null] as const,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     env: {
       NEXT_PUBLIC_API_BASE_URL: 'http://localhost:8080',
       NEXT_PUBLIC_APP_ENV: 'local',
+      NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
     },
   },
 });


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-147](https://sunwoo1137.atlassian.net/browse/BD-147)

📌 **작업 내용 및 특이사항**

- `GlobalTopbar` 컴포넌트 추가 (전체 폭 고정 상단바, `z-20`, `h-14`)
  - 모바일에서는 Bandage 로고 표시, 데스크톱에서는 사이드바에 가려짐
  - 우측: 알림 벨 + 프로필 아바타 (마이페이지 링크)
- `NotificationBell`에 `placement` prop 추가 (`sidebar` | `topbar`)
  - topbar 시: 하단 방향 드롭다운, 말풍선 꼬리 효과 적용
  - sidebar 시: 기존 우측 방향 드롭다운 유지
- 사이드바에서 알림 벨 제거, 프로필 이미지 제거 (이름/이메일은 유지)
- `notification` 도메인 초기 구현 (API, 훅, 타입, 컴포넌트)
- 상단바 추가로 인한 주요 페이지 상단 여백 조정 (PC 기준)
  - 홈: 40px → 30px
  - 밴드/합주 목록·생성·마이페이지: 60px → 40px
- 사이드바 스냅샷 갱신 및 vitest env 보완 (`NEXT_PUBLIC_APP_URL`)

📚 **참고사항**

- 알림 API 실서버 검증은 별도 커밋/태스크에서 진행 예정
- `src/middleware.ts`, `BandDetailContent.client.tsx` 변경분은 이 PR에 미포함 (별도 관리)
- 사이드바 `z-30` 설정으로 상단바(`z-20`) 좌측 영역을 자연스럽게 가림

[BD-147]: https://sunwoo1137.atlassian.net/browse/BD-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ