### PR TITLE
[BD-126] feat: 알림 API 연동

### DIFF
--- a/src/app/(main)/bands/BandsMobileShell.client.tsx
+++ b/src/app/(main)/bands/BandsMobileShell.client.tsx
@@ -1,10 +1,16 @@
 'use client';
 
 import { Root, Portal, Overlay, Content, Title, Close } from '@radix-ui/react-dialog';
-import { Plus, Search, Users, X } from 'lucide-react';
+import { Maximize2, Plus, Search, Users, X } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-import { BottomSheet, BottomSheetContent, BottomSheetTitle } from '@/components/ui/bottom-sheet';
+import {
+  BottomSheet,
+  BottomSheetClose,
+  BottomSheetContent,
+  BottomSheetTitle,
+} from '@/components/ui/bottom-sheet';
 import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
 import { MyItemMarker } from '@/components/ui/my-item-marker';
@@ -18,6 +24,7 @@ import { useMyBands } from '@/domain/band/hooks/useMyBands';
 import type { BandInfoResponse, MyBandInfoResponse } from '@/domain/band/types';
 import { useIsDesktop } from '@/hooks/use-media-query';
 import { cn } from '@/lib/cn';
+import { ROUTES } from '@/global/config/routes';
 import { DOMAIN_TONES } from '@/lib/domain-icons';
 
 import { BandDetailContent } from './[bandId]/BandDetailContent.client';
@@ -74,9 +81,16 @@ function BandSelectRow({
 }
 
 export function BandsMobileShell() {
+  const router = useRouter();
   const [query, setQuery] = useState('');
   const [selectedBandId, setSelectedBandId] = useState<string | null>(null);
   const isDesktop = useIsDesktop();
+
+  function handleExpand() {
+    if (!selectedBandId) return;
+    setSelectedBandId(null);
+    router.push(ROUTES.BAND_DETAIL(selectedBandId));
+  }
 
   const { data: myBandsData, isLoading: myLoading } = useMyBands(50);
   const myBands = myBandsData ?? [];
@@ -227,7 +241,15 @@ export function BandsMobileShell() {
               )}
             >
               <Title className="sr-only">밴드 상세</Title>
-              <div className="flex shrink-0 items-center justify-end px-4 py-5">
+              <div className="flex shrink-0 items-center justify-between px-4 py-5">
+                <button
+                  type="button"
+                  onClick={handleExpand}
+                  aria-label="전체 화면으로 보기"
+                  className="text-foreground-sub hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg rounded-sm p-1 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  <Maximize2 className="h-3.5 w-3.5" />
+                </button>
                 <Close
                   aria-label="닫기"
                   className="text-foreground-sub hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg rounded-sm p-1 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
@@ -248,6 +270,22 @@ export function BandsMobileShell() {
         >
           <BottomSheetContent className="h-dvh">
             <BottomSheetTitle className="sr-only">밴드 상세</BottomSheetTitle>
+            <div className="flex shrink-0 items-center justify-between px-4 py-3">
+              <button
+                type="button"
+                onClick={handleExpand}
+                aria-label="전체 화면으로 보기"
+                className="text-foreground-sub hover:text-foreground rounded-sm p-1 transition-colors"
+              >
+                <Maximize2 className="h-4 w-4" />
+              </button>
+              <BottomSheetClose
+                aria-label="닫기"
+                className="text-foreground-sub hover:text-foreground rounded-sm p-1 transition-colors"
+              >
+                <X className="h-4 w-4" />
+              </BottomSheetClose>
+            </div>
             <div className="flex-1 overflow-y-auto">
               {selectedBandId && <BandDetailContent bandId={selectedBandId} />}
             </div>

--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Camera, LogOut, UserPlus } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 import { EmptyState } from '@/components/feedback/empty-state';
 import { ErrorState } from '@/components/feedback/error-state';
@@ -43,9 +43,14 @@ import { useToast } from '@/hooks/useToast';
  */
 export function BandDetailContent({ bandId }: { bandId: string }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const toast = useToast();
   const [leaveOpen, setLeaveOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState('info');
+  const [activeTab, setActiveTab] = useState(searchParams.get('tab') ?? 'info');
+
+  useEffect(() => {
+    setActiveTab(searchParams.get('tab') ?? 'info');
+  }, [searchParams]);
 
   const { data: band, isLoading, isError, refetch } = useBandDetail(bandId);
   const { data: myRole } = useBandRole(bandId);
@@ -108,7 +113,7 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
               가입 신청
             </Button>
           )}
-          {isMember && !isLeader && (
+          {isMember && (
             <Button
               size="sm"
               variant="secondary"
@@ -199,12 +204,14 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
             </DialogDescription>
           </DialogHeader>
           <div className="border-border mx-5 border-b" />
-          <DialogBody>
-            <p className="text-foreground-sub text-sm">
-              <span className="text-nav-active font-bold">밴드 리더</span> 인 경우 먼저 리더 권한을
-              다른 멤버에게 위임해야 합니다.
-            </p>
-          </DialogBody>
+          {isLeader && (
+            <DialogBody>
+              <p className="text-foreground-sub text-sm">
+                <span className="text-nav-active font-bold">리더 권한</span>은 탈퇴 시 다른 멤버에게
+                자동으로 위임됩니다.
+              </p>
+            </DialogBody>
+          )}
           <DialogFooter className="border-t-0">
             <Button
               variant="ghost"

--- a/src/app/(main)/bands/[bandId]/page.tsx
+++ b/src/app/(main)/bands/[bandId]/page.tsx
@@ -1,4 +1,7 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { ROUTES } from '@/global/config/routes';
 
 import { BandDetailContent } from './BandDetailContent.client';
 
@@ -12,5 +15,17 @@ type PageProps = {
 
 export default async function BandDetailPage({ params }: PageProps) {
   const { bandId } = await params;
-  return <BandDetailContent bandId={bandId} />;
+  return (
+    <>
+      <div className="py-3 pr-5 pl-2 lg:pr-8 lg:pl-4">
+        <Link
+          href={ROUTES.BANDS}
+          className="text-foreground-sub hover:text-foreground inline-flex items-center gap-1 text-sm no-underline transition-colors"
+        >
+          ← 밴드 목록
+        </Link>
+      </div>
+      <BandDetailContent bandId={bandId} />
+    </>
+  );
 }

--- a/src/app/(main)/jams/JamsMobileShell.client.tsx
+++ b/src/app/(main)/jams/JamsMobileShell.client.tsx
@@ -2,11 +2,16 @@
 
 import { Root, Portal, Overlay, Content, Title, Close } from '@radix-ui/react-dialog';
 import { formatInTimeZone } from 'date-fns-tz';
-import { Plus, Search, X } from 'lucide-react';
+import { Maximize2, Plus, Search, X } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback, useState } from 'react';
 
-import { BottomSheet, BottomSheetContent, BottomSheetTitle } from '@/components/ui/bottom-sheet';
+import {
+  BottomSheet,
+  BottomSheetClose,
+  BottomSheetContent,
+  BottomSheetTitle,
+} from '@/components/ui/bottom-sheet';
 import { Button } from '@/components/ui/button';
 import { IconTile } from '@/components/ui/icon-tile';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -18,6 +23,7 @@ import { ROUTES } from '@/global/config/routes';
 import { useIsDesktop } from '@/hooks/use-media-query';
 import { useDiscoverySearch } from '@/hooks/useDiscoverySearch';
 import { cn } from '@/lib/cn';
+import { useRouter } from 'next/navigation';
 import { DOMAIN_ICONS, DOMAIN_TONES } from '@/lib/domain-icons';
 
 import { JamDetailContent } from './[jamId]/JamDetailContent.client';
@@ -61,8 +67,15 @@ function PracticeSelectRow({
 }
 
 export function JamsMobileShell() {
+  const router = useRouter();
   const [selectedJamId, setSelectedPracticeId] = useState<string | null>(null);
   const isDesktop = useIsDesktop();
+
+  function handleExpand() {
+    if (!selectedJamId) return;
+    setSelectedPracticeId(null);
+    router.push(ROUTES.JAM_DETAIL(selectedJamId));
+  }
 
   const { data: myData, isLoading: myLoading } = useMyJams(50);
   const myJams = myData?.pages.flatMap((p) => p.content) ?? [];
@@ -199,7 +212,15 @@ export function JamsMobileShell() {
               )}
             >
               <Title className="sr-only">합주 상세</Title>
-              <div className="flex shrink-0 items-center justify-end px-4 py-5">
+              <div className="flex shrink-0 items-center justify-between px-4 py-5">
+                <button
+                  type="button"
+                  onClick={handleExpand}
+                  aria-label="전체 화면으로 보기"
+                  className="text-foreground-sub hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg rounded-sm p-1 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  <Maximize2 className="h-3.5 w-3.5" />
+                </button>
                 <Close
                   aria-label="닫기"
                   className="text-foreground-sub hover:text-foreground focus-visible:ring-accent focus-visible:ring-offset-bg rounded-sm p-1 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
@@ -225,6 +246,22 @@ export function JamsMobileShell() {
         >
           <BottomSheetContent className="h-dvh">
             <BottomSheetTitle className="sr-only">합주 상세</BottomSheetTitle>
+            <div className="flex shrink-0 items-center justify-between px-4 py-3">
+              <button
+                type="button"
+                onClick={handleExpand}
+                aria-label="전체 화면으로 보기"
+                className="text-foreground-sub hover:text-foreground rounded-sm p-1 transition-colors"
+              >
+                <Maximize2 className="h-4 w-4" />
+              </button>
+              <BottomSheetClose
+                aria-label="닫기"
+                className="text-foreground-sub hover:text-foreground rounded-sm p-1 transition-colors"
+              >
+                <X className="h-4 w-4" />
+              </BottomSheetClose>
+            </div>
             <div className="flex-1 overflow-y-auto p-4">
               {selectedJamId && (
                 <JamDetailContent

--- a/src/app/(main)/jams/[jamId]/page.tsx
+++ b/src/app/(main)/jams/[jamId]/page.tsx
@@ -1,4 +1,7 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { ROUTES } from '@/global/config/routes';
 
 import { JamDetailContent } from './JamDetailContent.client';
 
@@ -13,8 +16,18 @@ type PageProps = {
 export default async function JamDetailPage({ params }: PageProps) {
   const { jamId } = await params;
   return (
-    <div className="px-5 py-4 lg:px-8 lg:py-6">
-      <JamDetailContent jamId={jamId} />
-    </div>
+    <>
+      <div className="py-3 pr-5 pl-2 lg:pr-8 lg:pl-4">
+        <Link
+          href={ROUTES.JAMS}
+          className="text-foreground-sub hover:text-foreground inline-flex items-center gap-1 text-sm no-underline transition-colors"
+        >
+          ← 합주 목록
+        </Link>
+      </div>
+      <div className="px-5 py-4 lg:px-8 lg:py-6">
+        <JamDetailContent jamId={jamId} />
+      </div>
+    </>
   );
 }

--- a/src/app/(main)/jams/[jamId]/page.tsx
+++ b/src/app/(main)/jams/[jamId]/page.tsx
@@ -12,5 +12,9 @@ type PageProps = {
 
 export default async function JamDetailPage({ params }: PageProps) {
   const { jamId } = await params;
-  return <JamDetailContent jamId={jamId} />;
+  return (
+    <div className="px-5 py-4 lg:px-8 lg:py-6">
+      <JamDetailContent jamId={jamId} />
+    </div>
+  );
 }

--- a/src/app/(main)/jams/layout.tsx
+++ b/src/app/(main)/jams/layout.tsx
@@ -1,36 +1,13 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { Suspense, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 import { ROUTES } from '@/global/config/routes';
 
-import { JamsListPane } from './JamsListPane.client';
-
-/**
- * /jams 영역 레이아웃.
- * - 기본: 좌측 ListPane(360px) + 우측 children (master-detail).
- * - /jams/new: 풀페이지 마법사 — ListPane 비노출, children 만 단일 패널로.
- */
 export default function JamsLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname() ?? '';
-  const isWizard = pathname === ROUTES.JAM_NEW || pathname.startsWith(`${ROUTES.JAM_NEW}/`);
   const isRoot = pathname === ROUTES.JAMS;
 
-  if (isWizard) {
-    return <div className="h-full overflow-y-auto">{children}</div>;
-  }
-
-  if (isRoot) {
-    return <div className="h-full">{children}</div>;
-  }
-
-  return (
-    <div className="flex h-full flex-col lg:flex-row">
-      <Suspense fallback={null}>
-        <JamsListPane />
-      </Suspense>
-      <div className="min-w-0 flex-1 lg:overflow-y-auto">{children}</div>
-    </div>
-  );
+  return <div className={isRoot ? 'h-full' : 'h-full overflow-y-auto'}>{children}</div>;
 }

--- a/src/domain/notification/api/markAsRead.ts
+++ b/src/domain/notification/api/markAsRead.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/global/api/apiClient';
 
-export async function markAsRead(notificationId: number): Promise<void> {
+export async function markAsRead(notificationId: string): Promise<void> {
   await apiClient.patch(`/api/v1/notifications/${notificationId}/read`);
 }

--- a/src/domain/notification/components/NotificationBell.client.tsx
+++ b/src/domain/notification/components/NotificationBell.client.tsx
@@ -18,14 +18,14 @@ interface Props {
   placement?: 'sidebar' | 'topbar';
 }
 
-function resolveHref(category: NotifyCategory): string | null {
+function resolveHref(category: NotifyCategory, referenceId: string): string | null {
   switch (category) {
     case 'BAND_APPLICATION':
     case 'BAND_APPLICATION_RESULT':
     case 'AUTHORITY_PROMOTION':
-      return ROUTES.BANDS;
+      return ROUTES.BAND_DETAIL(referenceId);
     case 'JAM_UPCOMING':
-      return ROUTES.JAMS;
+      return ROUTES.JAM_DETAIL(referenceId);
     default:
       return null;
   }
@@ -56,10 +56,11 @@ export function NotificationBell({ collapsed, placement = 'sidebar' }: Props) {
   function handleNotificationClick(
     notificationId: string,
     category: NotifyCategory,
+    referenceId: string,
     read: boolean,
   ) {
     if (!read) markAsRead.mutate(notificationId);
-    const href = resolveHref(category);
+    const href = resolveHref(category, referenceId);
     if (href) {
       setOpen(false);
       router.push(href);
@@ -139,12 +140,14 @@ export function NotificationBell({ collapsed, placement = 'sidebar' }: Props) {
               </li>
             ) : (
               notifications.map((n) => {
-                const href = resolveHref(n.category);
+                const href = resolveHref(n.category, n.referenceId);
                 return (
                   <li key={n.id}>
                     <button
                       type="button"
-                      onClick={() => handleNotificationClick(n.id, n.category, n.read)}
+                      onClick={() =>
+                        handleNotificationClick(n.id, n.category, n.referenceId, n.read)
+                      }
                       className={cn(
                         'border-border flex w-full items-start gap-3 border-b px-4 py-3 text-left last:border-b-0',
                         'hover:bg-card-hover transition-colors',

--- a/src/domain/notification/components/NotificationBell.client.tsx
+++ b/src/domain/notification/components/NotificationBell.client.tsx
@@ -21,9 +21,11 @@ interface Props {
 function resolveHref(category: NotifyCategory, referenceId: string): string | null {
   switch (category) {
     case 'BAND_APPLICATION':
+      return `${ROUTES.BAND_DETAIL(referenceId)}?tab=applications`;
     case 'BAND_APPLICATION_RESULT':
-    case 'AUTHORITY_PROMOTION':
       return ROUTES.BAND_DETAIL(referenceId);
+    case 'AUTHORITY_PROMOTION':
+      return `${ROUTES.BAND_DETAIL(referenceId)}?tab=members`;
     case 'JAM_UPCOMING':
       return ROUTES.JAM_DETAIL(referenceId);
     default:

--- a/src/domain/notification/components/NotificationBell.client.tsx
+++ b/src/domain/notification/components/NotificationBell.client.tsx
@@ -1,31 +1,46 @@
 'use client';
 
-import { Bell, Check, CheckCheck } from 'lucide-react';
+import { Bell, CheckCheck } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
 import { cn } from '@/lib/cn';
 import { formatRelative } from '@/lib/date';
+import { ROUTES } from '@/global/config/routes';
 
 import { useMarkAllAsRead } from '../hooks/useMarkAllAsRead';
 import { useMarkAsRead } from '../hooks/useMarkAsRead';
 import { useMyNotifications } from '../hooks/useMyNotifications';
-import { useUnreadCount } from '../hooks/useUnreadCount';
+import type { NotifyCategory } from '../types/res';
 
 interface Props {
   collapsed: boolean;
   placement?: 'sidebar' | 'topbar';
 }
 
+function resolveHref(category: NotifyCategory): string | null {
+  switch (category) {
+    case 'BAND_APPLICATION':
+    case 'BAND_APPLICATION_RESULT':
+    case 'AUTHORITY_PROMOTION':
+      return ROUTES.BANDS;
+    case 'JAM_UPCOMING':
+      return ROUTES.JAMS;
+    default:
+      return null;
+  }
+}
+
 export function NotificationBell({ collapsed, placement = 'sidebar' }: Props) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
 
-  const { data: unreadData } = useUnreadCount();
   const { data: notifications = [], isLoading } = useMyNotifications();
   const markAsRead = useMarkAsRead();
   const markAllAsRead = useMarkAllAsRead();
 
-  const unreadCount = unreadData?.count ?? 0;
+  const unreadCount = notifications.filter((n) => !n.read).length;
 
   useEffect(() => {
     if (!open) return;
@@ -37,6 +52,19 @@ export function NotificationBell({ collapsed, placement = 'sidebar' }: Props) {
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
+
+  function handleNotificationClick(
+    notificationId: string,
+    category: NotifyCategory,
+    read: boolean,
+  ) {
+    if (!read) markAsRead.mutate(notificationId);
+    const href = resolveHref(category);
+    if (href) {
+      setOpen(false);
+      router.push(href);
+    }
+  }
 
   return (
     <div ref={containerRef} className="relative">
@@ -65,7 +93,7 @@ export function NotificationBell({ collapsed, placement = 'sidebar' }: Props) {
             aria-hidden="true"
           />
           {unreadCount > 0 && (
-            <span className="bg-accent text-accent-foreground absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full px-0.5 text-[10px] leading-none font-bold">
+            <span className="bg-accent absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full px-0.5 text-[10px] leading-none font-bold text-white">
               {unreadCount > 99 ? '99+' : unreadCount}
             </span>
           )}
@@ -110,46 +138,47 @@ export function NotificationBell({ collapsed, placement = 'sidebar' }: Props) {
                 알림이 없습니다.
               </li>
             ) : (
-              notifications.map((n) => (
-                <li
-                  key={n.notificationId}
-                  className={cn(
-                    'border-border flex items-start gap-3 border-b px-4 py-3 last:border-b-0',
-                    !n.isRead && 'bg-surface',
-                  )}
-                >
-                  <div className="mt-0.5 shrink-0">
-                    {!n.isRead && (
-                      <span className="bg-accent block h-2 w-2 rounded-full" aria-hidden="true" />
-                    )}
-                    {n.isRead && <span className="block h-2 w-2" aria-hidden="true" />}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p
-                      className={cn(
-                        'text-sm leading-snug',
-                        n.isRead ? 'text-foreground-muted' : 'text-foreground',
-                      )}
-                    >
-                      {n.message}
-                    </p>
-                    <p className="text-foreground-muted mt-0.5 text-xs">
-                      {formatRelative(new Date(n.createdAt))}
-                    </p>
-                  </div>
-                  {!n.isRead && (
+              notifications.map((n) => {
+                const href = resolveHref(n.category);
+                return (
+                  <li key={n.id}>
                     <button
                       type="button"
-                      onClick={() => markAsRead.mutate(n.notificationId)}
-                      disabled={markAsRead.isPending}
-                      aria-label="읽음 처리"
-                      className="text-foreground-muted hover:text-foreground mt-0.5 shrink-0 transition-colors disabled:opacity-50"
+                      onClick={() => handleNotificationClick(n.id, n.category, n.read)}
+                      className={cn(
+                        'border-border flex w-full items-start gap-3 border-b px-4 py-3 text-left last:border-b-0',
+                        'hover:bg-card-hover transition-colors',
+                        !n.read && 'bg-surface',
+                        href ? 'cursor-pointer' : 'cursor-default',
+                      )}
                     >
-                      <Check className="h-3.5 w-3.5" />
+                      <div className="mt-1.5 shrink-0">
+                        {!n.read ? (
+                          <span
+                            className="bg-accent block h-2 w-2 rounded-full"
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <span className="block h-2 w-2" aria-hidden="true" />
+                        )}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p
+                          className={cn(
+                            'text-sm leading-snug',
+                            n.read ? 'text-foreground-muted' : 'text-foreground',
+                          )}
+                        >
+                          {n.message}
+                        </p>
+                        <p className="text-foreground-muted mt-0.5 text-xs">
+                          {formatRelative(new Date(n.createdAt))}
+                        </p>
+                      </div>
                     </button>
-                  )}
-                </li>
-              ))
+                  </li>
+                );
+              })
             )}
           </ul>
         </div>

--- a/src/domain/notification/hooks/useMarkAllAsRead.ts
+++ b/src/domain/notification/hooks/useMarkAllAsRead.ts
@@ -4,13 +4,44 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { queryKeys } from '@/global/config/queryKeys';
 
+import type { NotificationResponse, UnreadNotificationCountResponse } from '../types/res';
 import { markAllAsRead } from '../api/markAllAsRead';
 
 export function useMarkAllAsRead() {
   const queryClient = useQueryClient();
   return useMutation<void, Error, void>({
     mutationFn: markAllAsRead,
-    onSuccess: () => {
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.notification.list() });
+      await queryClient.cancelQueries({ queryKey: queryKeys.notification.unreadCount() });
+
+      const prevList = queryClient.getQueryData<NotificationResponse[]>(
+        queryKeys.notification.list(),
+      );
+      const prevCount = queryClient.getQueryData<UnreadNotificationCountResponse>(
+        queryKeys.notification.unreadCount(),
+      );
+
+      queryClient.setQueryData<NotificationResponse[]>(queryKeys.notification.list(), (prev) =>
+        prev?.map((n) => ({ ...n, read: true })),
+      );
+      queryClient.setQueryData<UnreadNotificationCountResponse>(
+        queryKeys.notification.unreadCount(),
+        { count: 0 },
+      );
+
+      return { prevList, prevCount };
+    },
+    onError: (_err, _vars, context) => {
+      const ctx = context as
+        | { prevList?: NotificationResponse[]; prevCount?: UnreadNotificationCountResponse }
+        | undefined;
+      if (ctx?.prevList !== undefined)
+        queryClient.setQueryData(queryKeys.notification.list(), ctx.prevList);
+      if (ctx?.prevCount !== undefined)
+        queryClient.setQueryData(queryKeys.notification.unreadCount(), ctx.prevCount);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.notification.list() });
       queryClient.invalidateQueries({ queryKey: queryKeys.notification.unreadCount() });
     },

--- a/src/domain/notification/hooks/useMarkAsRead.ts
+++ b/src/domain/notification/hooks/useMarkAsRead.ts
@@ -4,13 +4,44 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { queryKeys } from '@/global/config/queryKeys';
 
+import type { NotificationResponse, UnreadNotificationCountResponse } from '../types/res';
 import { markAsRead } from '../api/markAsRead';
 
 export function useMarkAsRead() {
   const queryClient = useQueryClient();
-  return useMutation<void, Error, number>({
+  return useMutation<void, Error, string>({
     mutationFn: markAsRead,
-    onSuccess: () => {
+    onMutate: async (notificationId) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.notification.list() });
+      await queryClient.cancelQueries({ queryKey: queryKeys.notification.unreadCount() });
+
+      const prevList = queryClient.getQueryData<NotificationResponse[]>(
+        queryKeys.notification.list(),
+      );
+      const prevCount = queryClient.getQueryData<UnreadNotificationCountResponse>(
+        queryKeys.notification.unreadCount(),
+      );
+
+      queryClient.setQueryData<NotificationResponse[]>(queryKeys.notification.list(), (prev) =>
+        prev?.map((n) => (n.id === notificationId ? { ...n, read: true } : n)),
+      );
+      queryClient.setQueryData<UnreadNotificationCountResponse>(
+        queryKeys.notification.unreadCount(),
+        (prev) => (prev ? { count: Math.max(0, prev.count - 1) } : prev),
+      );
+
+      return { prevList, prevCount };
+    },
+    onError: (_err, _id, context) => {
+      const ctx = context as
+        | { prevList?: NotificationResponse[]; prevCount?: UnreadNotificationCountResponse }
+        | undefined;
+      if (ctx?.prevList !== undefined)
+        queryClient.setQueryData(queryKeys.notification.list(), ctx.prevList);
+      if (ctx?.prevCount !== undefined)
+        queryClient.setQueryData(queryKeys.notification.unreadCount(), ctx.prevCount);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.notification.list() });
       queryClient.invalidateQueries({ queryKey: queryKeys.notification.unreadCount() });
     },

--- a/src/domain/notification/hooks/useMyNotifications.ts
+++ b/src/domain/notification/hooks/useMyNotifications.ts
@@ -15,5 +15,6 @@ export function useMyNotifications() {
     queryFn: getMyNotifications,
     enabled: authenticated,
     staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
   });
 }

--- a/src/domain/notification/types/res.ts
+++ b/src/domain/notification/types/res.ts
@@ -1,10 +1,18 @@
-export type NotificationType = string;
+export type NotifyCategory =
+  | 'BAND_APPLICATION'
+  | 'BAND_APPLICATION_RESULT'
+  | 'AUTHORITY_PROMOTION'
+  | 'JAM_UPCOMING'
+  | (string & {});
 
 export interface NotificationResponse {
-  notificationId: number;
-  type: NotificationType;
+  id: string;
+  category: NotifyCategory;
+  title: string;
   message: string;
-  isRead: boolean;
+  referenceId: string;
+  read: boolean;
+  readAt: string | null;
   createdAt: string;
 }
 


### PR DESCRIPTION
## 🛠️ Issue Number

### closes [BD-126](https://sunwoo1137.atlassian.net/browse/BD-126)

📌 **작업 내용 및 특이사항**

**알림 API 연동**
- `NotificationResponse` 타입을 실서버 응답 기준으로 수정 (`id: string` UUID, `read: boolean`)
- 알림 클릭 시 읽음 처리 (`PATCH /api/v1/notifications/{id}/read`) 및 카테고리별 페이지 이동
  - `BAND_APPLICATION` → `/bands/{id}?tab=applications` (신청 현황 탭)
  - `AUTHORITY_PROMOTION` → `/bands/{id}?tab=members` (멤버 탭)
  - `BAND_APPLICATION_RESULT` → `/bands/{id}` (정보 탭)
  - `JAM_UPCOMING` → `/jams/{id}`
- 전체 읽음 처리 (`PATCH /api/v1/notifications/read-all`)
- 읽음/전체읽음 Optimistic update 적용 (`cancelQueries` + `onError` rollback + `onSettled` 동기화)
- `useUnreadCount` 별도 API 호출 제거 → 알림 목록 `read: false` 카운트로 파생하여 배지와 목록 동기화
- 알림 목록 1분 주기 폴링 추가 (`refetchInterval: 60_000`)

**밴드/합주 상세 모달 개선**
- 모달(슬라이드 패널·바텀시트) 상단에 펼치기(Maximize2) 버튼 추가 → 상세 페이지 URL로 이동
- 밴드/합주 상세 페이지 진입 시 상단에 목록으로 돌아가는 뒤로가기 링크 추가
- 합주 목록 페이지에서 상세 진입 시 사이드 목록 패널 제거 (상세 단독 표시)
- 합주 상세 페이지 패딩을 밴드 상세와 동일하게 통일 (`px-5 py-4 lg:px-8 lg:py-6`)

**알림 탭 이동**
- `BandDetailContent`에 `useSearchParams` 적용 → URL `?tab=` 파라미터로 초기 탭 설정
- 같은 페이지에서 알림 클릭 시에도 탭이 올바르게 전환되도록 `useEffect` 동기화 추가

📚 **참고사항**

- 기존 `isRead` 필드가 실서버에서 `read`로 반환되어 수정 (타입 불일치로 읽음 상태 미반영되던 버그 수정)
- `BAND_APPLICATION`·`AUTHORITY_PROMOTION` 탭 이동은 리더에게만 오는 알림이므로 권한 없는 경우 예외 처리 불필요

[BD-126]: https://sunwoo1137.atlassian.net/browse/BD-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ