### PR TITLE
[BD-164] feat: 공연 포스터 API 연동

### DIFF
--- a/.taskmaster/docs/BD-164-performance-poster-api_prd.md
+++ b/.taskmaster/docs/BD-164-performance-poster-api_prd.md
@@ -1,0 +1,75 @@
+<context>
+# Overview
+BD-164 공연 포스터 관련 API FE 도메인 구현. BE develop 브랜치에 6개 엔드포인트가 추가됐으나 openapi.json 스냅샷에 미반영된 상태였으며, MCP `check_impacting_changes(fe_area="performance-poster")` 로 6개 엔드포인트를 확인한 뒤 FE 도메인을 구현했다.
+
+핵심 출처
+- MCP 영향평가: `performance-poster` 영역 — 6개 endpoint-added (INFO, non-breaking)
+- 참조 패턴: `src/global/upload/presignProfileImage.ts` (presigned URL 패턴)
+- fe-areas.json: `performance-poster` 영역 `specPending: true` 상태로 사전 등록됨 (BD-93 작업 시)
+
+# Goals
+1. MCP로 확인된 6개 엔드포인트에 대한 FE API 함수 구현
+2. TanStack Query 래퍼 훅(useQuery/useMutation) 구현
+3. `queryKeys.performancePoster` 추가
+4. fe-areas.json notes 업데이트 (MCP 확인 완료 기록)
+
+# Non-goals
+- 공연 포스터 UI 컴포넌트 구현 (별도 태스크)
+- openapi.json 스냅샷 업데이트 (BE 머지 후 진행)
+- 실서버 검증 (openapi.json 미반영으로 로컬 BE 확인 필요)
+
+# Existing architecture (재사용 대상)
+- `src/global/api/apiClient.ts` — fetch 클라이언트
+- `src/global/upload/presignProfileImage.ts` — presigned URL 패턴 참조
+- `src/global/config/queryKeys.ts` — 쿼리 키 관리
+</context>
+<PRD>
+# Scope
+
+## Task 1 — 공연 포스터 도메인 구현
+
+### 1.1 타입 정의
+- `types/res.ts`
+  - `PerformancePosterResponse` — `{ posterId, performanceId, imageUrl, description, createdAt, updatedAt }`
+  - `PerformancePosterPresignResponse` — `{ uploadUrl, objectKey, expiresInSeconds }`
+- `types/req.ts`
+  - `PerformancePosterPresignRequest` — `{ contentType, contentLength, ext }`
+  - `CreatePerformancePosterRequest` — `{ performanceId, objectKey, description? }`
+  - `UpdatePerformancePosterRequest` — `{ description }`
+- `types/index.ts` — 전체 re-export
+
+### 1.2 API 함수 (6개)
+| 함수 | 엔드포인트 | operationId |
+|---|---|---|
+| `issuePerformancePosterPresignedUrl` | `POST /api/v1/performance-posters/presigned-url` | issuePerformancePosterPresignedUrl |
+| `getPerformancePosters` | `GET /api/v1/performance-posters?performanceId=` | getPerformancePosters |
+| `createPerformancePoster` | `POST /api/v1/performance-posters` | createPerformancePoster |
+| `getPerformancePoster` | `GET /api/v1/performance-posters/{posterId}` | getPerformancePoster |
+| `updatePerformancePoster` | `PATCH /api/v1/performance-posters/{posterId}` | updatePerformancePoster |
+| `deletePerformancePoster` | `DELETE /api/v1/performance-posters/{posterId}` | deletePerformancePoster |
+
+### 1.3 훅
+- `usePerformancePosters(performanceId)` — `useQuery`, `queryKeys.performancePoster.list(performanceId)`
+- `useCreatePerformancePoster(performanceId)` — `useMutation`, 성공 시 list 캐시 무효화
+- `useUpdatePerformancePoster(performanceId, posterId)` — `useMutation`, 성공 시 list 캐시 무효화
+- `useDeletePerformancePoster(performanceId)` — `useMutation`, 성공 시 list 캐시 무효화
+
+### 1.4 queryKeys 추가
+```ts
+performancePoster: {
+  all: ['performance-poster'],
+  list: (performanceId) => ['performance-poster', performanceId],
+  detail: (posterId) => ['performance-poster', 'detail', posterId],
+}
+```
+
+### 1.5 fe-areas.json
+- `performance-poster` 영역 notes 업데이트: MCP 확인 완료(6개 엔드포인트) 기록
+- `specPending: true` 유지 (openapi.json 스냅샷 미반영)
+
+# Test Strategy
+- `pnpm typecheck` — 0 errors
+- `pnpm verify:fe-areas` — ✅ PASS
+- MCP `check_impacting_changes(fe_area="performance-poster")` — 6개 INFO 확인
+- openapi.json 업데이트 후 req/res 타입 스펙과 대조 검증 필요
+</PRD>

--- a/.taskmaster/state.json
+++ b/.taskmaster/state.json
@@ -1,6 +1,6 @@
 {
-  "currentTag": "BD-93-create-performance-ui",
-  "lastSwitched": "2026-06-25T14:17:41.429Z",
+  "currentTag": "BD-164-performance-poster-api",
+  "lastSwitched": "2026-06-25T15:39:53.645Z",
   "branchTagMapping": {},
   "migrationNoticeShown": true
 }

--- a/.taskmaster/tasks/task_001_BD-164-performance-poster-api.md
+++ b/.taskmaster/tasks/task_001_BD-164-performance-poster-api.md
@@ -1,0 +1,19 @@
+# Task ID: 1
+
+**Title:** 공연 포스터 도메인 구현
+
+**Status:** pending
+
+**Dependencies:** None
+
+**Priority:** medium
+
+**Description:** MCP 확인된 6개 엔드포인트 기반으로 performance-poster 도메인 타입·API·훅 구현 및 fe-areas.json specPending 해제
+
+**Details:**
+
+No details provided.
+
+**Test Strategy:**
+
+No test strategy provided.

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -5630,7 +5630,7 @@
   "BD-93-create-performance-ui": {
     "tasks": [
       {
-        "id": "1",
+        "id": 1,
         "title": "공연 생성 페이지 UI 개선 및 셋리스트 API 연동",
         "description": "합주 생성 페이지(JamCreateWizard) UI 스타일을 참고하여 공연 생성 페이지(PerformanceCreateWizard) UI를 개선한다. 주황색 버튼 등 기존 강조색을 흰색 포인트로 교체하고, GET /api/v1/setlists/me API를 연동하여 셋리스트 목록을 실제 데이터로 보여준다. setlistMeetingIds 대신 setlistIds를 사용하도록 CreatePerformanceRequest도 수정한다.",
         "details": "",
@@ -5701,10 +5701,10 @@
             "updatedAt": "2026-06-25T14:25:43.787Z"
           }
         ],
-        "updatedAt": "2026-06-25T14:25:43.787Z"
+        "updatedAt": "2026-06-25T15:35:22.781Z"
       },
       {
-        "id": "2",
+        "id": 2,
         "title": "Performance 도메인 API 정렬 및 fe-areas.json 정비",
         "description": "openapi.json 기준으로 performance 도메인 타입·API 파일 업데이트, 구 practice 관련 파일 제거, fe-areas.json 영역 정비(setlist·performance-poster 추가, practice knownGap 제거, specPending 지원)",
         "details": "",
@@ -5779,12 +5779,35 @@
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-25T15:14:07.225Z",
+      "lastModified": "2026-06-25T15:35:22.781Z",
       "taskCount": 2,
       "completedCount": 2,
       "tags": [
         "BD-93-create-performance-ui"
-      ]
+      ],
+      "created": "2026-06-25T15:39:44.214Z",
+      "description": "Tasks for BD-93-create-performance-ui context",
+      "updated": "2026-06-25T15:39:44.214Z"
+    }
+  },
+  "BD-164-performance-poster-api": {
+    "tasks": [
+      {
+        "id": 1,
+        "title": "공연 포스터 도메인 구현",
+        "description": "MCP 확인된 6개 엔드포인트 기반으로 performance-poster 도메인 타입·API·훅 구현 및 fe-areas.json specPending 해제",
+        "details": "",
+        "testStrategy": "",
+        "status": "pending",
+        "dependencies": [],
+        "priority": "medium",
+        "subtasks": []
+      }
+    ],
+    "metadata": {
+      "created": "2026-06-25T15:33:04.788Z",
+      "updated": "2026-06-25T15:33:06.168Z",
+      "description": "Tag created on 6/26/2026"
     }
   }
 }

--- a/fe-areas.json
+++ b/fe-areas.json
@@ -84,7 +84,7 @@
       "endpointPrefixes": ["/api/v1/performance-posters"],
       "status": "active",
       "specPending": true,
-      "notes": "BE 구현 완료이나 openapi.json 스냅샷에 미반영. MCP 비교 후 타입·API 파일 작성 예정."
+      "notes": "BD-164. openapi.json 스냅샷에 미반영이나 MCP(develop)로 6개 엔드포인트 확인 완료. FE 도메인 구현됨."
     },
     {
       "id": "notification",

--- a/fe-areas.json
+++ b/fe-areas.json
@@ -78,6 +78,15 @@
       "status": "active"
     },
     {
+      "id": "band-application",
+      "label": "밴드 가입 신청",
+      "routes": ["/bands"],
+      "endpointPrefixes": ["/api/v1/band-applications"],
+      "status": "active",
+      "specPending": true,
+      "notes": "BD-164 작업 시점에 BE develop에 추가됐으나 openapi.json 스냅샷에 미반영. specPending=true로 MAP↔SPEC 체크 생략. MCP 확인 후 갱신 필요."
+    },
+    {
       "id": "performance-poster",
       "label": "공연 포스터",
       "routes": ["/performances"],

--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Camera, LogOut, UserPlus } from 'lucide-react';
+import { ImagePlus, Loader2, LogOut, UserPlus, X } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 
 import { EmptyState } from '@/components/feedback/empty-state';
 import { ErrorState } from '@/components/feedback/error-state';
@@ -20,8 +20,13 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
-import { ProfileImageUpload } from '@/components/ui/profile-image-upload';
 import { Textarea } from '@/components/ui/textarea';
+import {
+  ALLOWED_IMAGE_ACCEPT,
+  MAX_IMAGE_SIZE_BYTES,
+  isAllowedImageMime,
+} from '@/global/upload/constants';
+import { uploadProfileImage } from '@/global/upload/uploadProfileImage';
 import { BandApplicationRow } from '@/domain/band/components/BandApplicationRow';
 import { BandMemberRow } from '@/domain/band/components/BandMemberRow';
 import { useApplyBand } from '@/domain/band/hooks/useApplyBand';
@@ -260,9 +265,9 @@ function InfoTab({
           // eslint-disable-next-line @next/next/no-img-element -- 외부 origin 허용 위해 native img
           <img src={profileImg} alt={`${bandName} 커버`} className="h-full w-full object-cover" />
         ) : (
-          <div className="text-foreground-muted gap-s-2 flex flex-col items-center text-xs">
-            <Camera className="h-7 w-7" aria-hidden="true" />
-            band cover image
+          <div className="text-foreground-muted gap-s-2 flex flex-col items-center">
+            <ImagePlus className="h-8 w-8" aria-hidden="true" />
+            <span className="text-xs">커버 이미지 없음</span>
           </div>
         )}
       </div>
@@ -390,10 +395,49 @@ function SettingsTab({
 }) {
   const router = useRouter();
   const toast = useToast();
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const imageInputId = useId();
   const [tab, setTab] = useState<'info' | 'image' | 'delete'>('info');
   const [name, setName] = useState(bandName);
   const [desc, setDesc] = useState(description ?? '');
   const [confirmText, setConfirmText] = useState('');
+  const [localPreview, setLocalPreview] = useState<string | null>(null);
+  const [imageUploading, setImageUploading] = useState(false);
+
+  async function handleImageFile(file: File) {
+    if (!isAllowedImageMime(file.type)) {
+      toast.error('JPEG / PNG / WEBP 형식만 업로드할 수 있습니다.');
+      return;
+    }
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      toast.error('이미지 크기는 5MB 이하여야 합니다.');
+      return;
+    }
+    if (localPreview) URL.revokeObjectURL(localPreview);
+    setLocalPreview(URL.createObjectURL(file));
+    setImageUploading(true);
+    try {
+      const objectKey = await uploadProfileImage({ file, domain: 'BAND', bandId });
+      updateMutation.mutate({ profileImg: objectKey });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '이미지 업로드에 실패했습니다.';
+      toast.error(message);
+      setLocalPreview(null);
+    } finally {
+      setImageUploading(false);
+    }
+  }
+
+  function handleDeleteImage() {
+    if (localPreview) {
+      URL.revokeObjectURL(localPreview);
+      setLocalPreview(null);
+    } else {
+      deleteImageMutation.mutate();
+    }
+  }
+
+  const currentImg = localPreview ?? profileImg ?? null;
 
   const updateMutation = useUpdateBand(bandId, {
     onSuccess: () => toast.success('밴드 정보를 저장했습니다.'),
@@ -414,7 +458,7 @@ function SettingsTab({
   });
 
   return (
-    <div className="space-y-s-4 mx-auto w-full max-w-lg">
+    <div className="space-y-s-4 w-full">
       <Tabs value={tab} onValueChange={(v) => setTab(v as 'info' | 'image' | 'delete')}>
         <TabsList className="mb-s-4 w-full">
           <TabsTrigger
@@ -471,19 +515,62 @@ function SettingsTab({
           </div>
         </TabsContent>
 
-        <TabsContent value="image" className="mt-0">
-          <ProfileImageUpload
-            value={profileImg ?? null}
-            onChange={(objectKey) => updateMutation.mutate({ profileImg: objectKey })}
-            onDelete={() => deleteImageMutation.mutate()}
-            domain="BAND"
-            bandId={bandId}
-            label=""
-            imageClassName="w-full h-[220px] rounded-2xl"
-            showButton={false}
-            hint="JPEG / PNG / WEBP, 5MB 이하"
-            disabled={updateMutation.isPending}
+        <TabsContent value="image" className="space-y-s-3 mt-0">
+          {currentImg ? (
+            <div className="relative mx-auto w-fit">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={currentImg}
+                alt="밴드 프로필 이미지"
+                className="h-[220px] w-full rounded-2xl object-cover"
+              />
+              {!imageUploading && (
+                <button
+                  type="button"
+                  aria-label="이미지 제거"
+                  onClick={handleDeleteImage}
+                  className="bg-surface border-border absolute -top-2 -right-2 rounded-full border p-0.5 text-white/70 hover:text-white"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+              {imageUploading && (
+                <span className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/50">
+                  <Loader2 className="h-6 w-6 animate-spin text-white" />
+                </span>
+              )}
+            </div>
+          ) : (
+            <label
+              htmlFor={imageInputId}
+              className="flex h-[220px] cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-white/20 bg-white/5 transition-colors hover:border-white/40 hover:bg-white/10"
+            >
+              <ImagePlus className="h-8 w-8 text-white/50" />
+              <span className="text-sm font-medium text-white/60">클릭하여 이미지 선택</span>
+              <span className="text-xs text-white/40">JPEG · PNG · WEBP · 최대 5MB</span>
+            </label>
+          )}
+          <input
+            ref={imageInputRef}
+            id={imageInputId}
+            type="file"
+            accept={ALLOWED_IMAGE_ACCEPT}
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              e.target.value = '';
+              if (file) void handleImageFile(file);
+            }}
           />
+          {currentImg && !imageUploading && (
+            <button
+              type="button"
+              onClick={() => imageInputRef.current?.click()}
+              className="text-foreground-sub text-caption hover:text-foreground underline"
+            >
+              다른 이미지로 변경
+            </button>
+          )}
         </TabsContent>
 
         <TabsContent value="delete" className="space-y-s-3 mt-0">

--- a/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
+++ b/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
@@ -1,9 +1,18 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { CalendarDays, ListMusic, MapPin, Pencil, Trash2 } from 'lucide-react';
+import {
+  CalendarDays,
+  ImagePlus,
+  ListMusic,
+  Loader2,
+  MapPin,
+  Pencil,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { EmptyState } from '@/components/feedback/empty-state';
@@ -26,8 +35,23 @@ import { useDeletePerformance } from '@/domain/performance/hooks/useDeletePerfor
 import { usePerformanceDetail } from '@/domain/performance/hooks/usePerformanceDetail';
 import { useUpdatePerformance } from '@/domain/performance/hooks/useUpdatePerformance';
 import { updatePerformanceSchema, type UpdatePerformanceSchema } from '@/domain/performance/types';
+import {
+  createPerformancePoster,
+  deletePerformancePoster,
+  issuePerformancePosterPresignedUrl,
+} from '@/domain/performance-poster/api';
+import { usePerformancePosters } from '@/domain/performance-poster/hooks/usePerformancePosters';
 import { useIsPerformanceManager } from '@/global/auth/useIsPerformanceManager';
 import { ROUTES } from '@/global/config/routes';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/global/config/queryKeys';
+import {
+  ALLOWED_IMAGE_ACCEPT,
+  MAX_IMAGE_SIZE_BYTES,
+  extFromMime,
+  isAllowedImageMime,
+} from '@/global/upload/constants';
+import { uploadToPresignedUrl } from '@/global/upload/uploadToPresignedUrl';
 import { formatKst, parseKst } from '@/lib/date';
 import { useToast } from '@/hooks/useToast';
 
@@ -41,12 +65,72 @@ function fromDatetimeLocal(dt: string) {
 export function PerformanceDetailContent({ performanceId }: { performanceId: string }) {
   const router = useRouter();
   const toast = useToast();
+  const queryClient = useQueryClient();
+  const posterInputRef = useRef<HTMLInputElement>(null);
+  const posterInputId = useId();
 
   const { data: perf, isLoading, isError, refetch } = usePerformanceDetail(performanceId);
   const { isManager } = useIsPerformanceManager(performanceId);
+  const { data: posters = [] } = usePerformancePosters(performanceId);
 
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [localPosterPreview, setLocalPosterPreview] = useState<string | null>(null);
+  const [posterUploading, setPosterUploading] = useState(false);
+
+  const existingPoster = posters[0] ?? null;
+  const posterSrc = localPosterPreview ?? existingPoster?.imageUrl ?? null;
+
+  async function handlePosterFile(file: File) {
+    if (!isAllowedImageMime(file.type)) {
+      toast.error('JPEG / PNG / WEBP 형식만 업로드할 수 있습니다.');
+      return;
+    }
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      toast.error('이미지 크기는 5MB 이하여야 합니다.');
+      return;
+    }
+    if (localPosterPreview) URL.revokeObjectURL(localPosterPreview);
+    setLocalPosterPreview(URL.createObjectURL(file));
+    setPosterUploading(true);
+    try {
+      const ext = extFromMime(file.type);
+      if (!ext) throw new Error('지원하지 않는 이미지 형식입니다.');
+      const presign = await issuePerformancePosterPresignedUrl({
+        contentType: file.type,
+        contentLength: file.size,
+        ext,
+      });
+      await uploadToPresignedUrl(presign.uploadUrl, file);
+      await createPerformancePoster({ performanceId, objectKey: presign.objectKey });
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.performancePoster.list(performanceId),
+      });
+      toast.success('포스터를 등록했습니다.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '포스터 업로드에 실패했습니다.';
+      toast.error(message);
+      setLocalPosterPreview(null);
+    } finally {
+      setPosterUploading(false);
+    }
+  }
+
+  async function handleDeletePoster() {
+    if (!existingPoster) return;
+    try {
+      await deletePerformancePoster(existingPoster.posterId);
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.performancePoster.list(performanceId),
+      });
+      if (localPosterPreview) URL.revokeObjectURL(localPosterPreview);
+      setLocalPosterPreview(null);
+      toast.success('포스터를 삭제했습니다.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '포스터 삭제에 실패했습니다.';
+      toast.error(message);
+    }
+  }
 
   const deleteMutation = useDeletePerformance(performanceId, {
     onSuccess: () => {
@@ -137,6 +221,81 @@ export function PerformanceDetailContent({ performanceId }: { performanceId: str
               </li>
             ))}
           </ul>
+        )}
+      </Card>
+
+      {/* 포스터 카드 */}
+      <Card
+        header={
+          <span className="inline-flex items-center gap-2">
+            <ImagePlus className="h-4 w-4" aria-hidden="true" />
+            공연 포스터
+          </span>
+        }
+        padding="md"
+      >
+        {posterSrc ? (
+          <div className="space-y-s-3">
+            <div className="relative mx-auto w-fit">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={posterSrc}
+                alt="공연 포스터"
+                className="max-h-72 rounded-[5px] object-contain"
+              />
+              {isManager && !posterUploading && (
+                <button
+                  type="button"
+                  aria-label="포스터 삭제"
+                  onClick={handleDeletePoster}
+                  className="bg-surface border-border absolute -top-2 -right-2 rounded-full border p-0.5 text-white/70 hover:text-white"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+              {posterUploading && (
+                <span className="absolute inset-0 flex items-center justify-center rounded-[5px] bg-black/50">
+                  <Loader2 className="h-6 w-6 animate-spin text-white" />
+                </span>
+              )}
+            </div>
+            {isManager && !posterUploading && (
+              <button
+                type="button"
+                onClick={() => posterInputRef.current?.click()}
+                className="text-foreground-sub text-caption hover:text-foreground underline"
+              >
+                다른 이미지로 변경
+              </button>
+            )}
+          </div>
+        ) : isManager ? (
+          <label
+            htmlFor={posterInputId}
+            className="flex h-48 cursor-pointer flex-col items-center justify-center gap-2 rounded-[5px] border border-dashed border-white/20 bg-white/5 transition-colors hover:border-white/40 hover:bg-white/10"
+          >
+            <ImagePlus className="h-8 w-8 text-white/50" />
+            <span className="text-sm font-medium text-white/60">클릭하여 포스터 이미지 선택</span>
+            <span className="text-xs text-white/40">JPEG · PNG · WEBP · 최대 5MB</span>
+          </label>
+        ) : (
+          <p className="text-foreground-muted text-caption py-4 text-center">
+            등록된 포스터가 없습니다.
+          </p>
+        )}
+        {isManager && (
+          <input
+            ref={posterInputRef}
+            id={posterInputId}
+            type="file"
+            accept={ALLOWED_IMAGE_ACCEPT}
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              e.target.value = '';
+              if (file) void handlePosterFile(file);
+            }}
+          />
         )}
       </Card>
 

--- a/src/app/(main)/performances/new/PerformanceCreateWizard.client.tsx
+++ b/src/app/(main)/performances/new/PerformanceCreateWizard.client.tsx
@@ -1,29 +1,43 @@
 'use client';
 
-import { CalendarDays, X } from 'lucide-react';
+import { CalendarDays, ImagePlus, Loader2, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useId, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { DateTimePicker } from '@/components/ui/date-time-picker';
 import { Input } from '@/components/ui/input';
 import { StepIndicator } from '@/components/ui/step-indicator';
 import { WizardSummaryCard } from '@/components/ui/wizard-summary-card';
+import {
+  createPerformancePoster,
+  issuePerformancePosterPresignedUrl,
+} from '@/domain/performance-poster/api';
 import { SetlistSelectorSheet } from '@/domain/performance/components/SetlistSelectorSheet.client';
+import { createPerformance } from '@/domain/performance/api/createPerformance';
 import type { SetlistResponse } from '@/domain/setlist/types/res';
-import { useCreatePerformance } from '@/domain/performance/hooks/useCreatePerformance';
 import { ROUTES } from '@/global/config/routes';
 import { useRegisterDirtyForm } from '@/global/navigation/dirty-form-context';
+import {
+  ALLOWED_IMAGE_ACCEPT,
+  MAX_IMAGE_SIZE_BYTES,
+  extFromMime,
+  isAllowedImageMime,
+} from '@/global/upload/constants';
+import { uploadToPresignedUrl } from '@/global/upload/uploadToPresignedUrl';
 import { useToast } from '@/hooks/useToast';
 
-const STEPS = ['기본 정보', '셋리스트 추가', '검토'] as const;
+const STEPS = ['기본 정보', '포스터 등록', '셋리스트 추가', '검토'] as const;
 const inputCls =
   'rounded-[5px] hover:border-white/30 focus-visible:border-white/80 focus-visible:ring-0';
 
 export function PerformanceCreateWizard() {
   const router = useRouter();
   const toast = useToast();
-  const [step, setStep] = useState<0 | 1 | 2>(0);
+  const posterInputRef = useRef<HTMLInputElement>(null);
+  const posterInputId = useId();
+  const [step, setStep] = useState<0 | 1 | 2 | 3>(0);
+  const [isPending, setIsPending] = useState(false);
 
   // Step 0
   const [title, setTitle] = useState('');
@@ -35,20 +49,23 @@ export function PerformanceCreateWizard() {
   const [selectorOpen, setSelectorOpen] = useState(false);
   const [selectedSetlists, setSelectedSetlists] = useState<SetlistResponse[]>([]);
 
+  // Step 2
+  const [posterFile, setPosterFile] = useState<File | null>(null);
+  const [posterPreview, setPosterPreview] = useState<string | null>(null);
+  const [posterDescription, setPosterDescription] = useState('');
+
   const dirty =
     step > 0 || title.length > 0 || venue.length > 0 || !!startAt || selectedSetlists.length > 0;
   useRegisterDirtyForm('performance-create-wizard', dirty);
 
-  const mutation = useCreatePerformance({
-    onSuccess: (data) => {
-      toast.resourceCreated('공연', { name: title });
-      router.replace(ROUTES.PERFORMANCE_DETAIL(data.performanceId));
-    },
-    onError: (err) => toast.error(err.message || '공연 생성에 실패했습니다.'),
-  });
-
   const canNext =
-    step === 0 ? !!title && !!startAt && durationMinutes >= 30 : step === 1 ? true : false;
+    step === 0
+      ? !!title && !!startAt && durationMinutes >= 30
+      : step === 1
+        ? true
+        : step === 2
+          ? true
+          : false;
 
   function next() {
     if (step === 0) {
@@ -56,22 +73,70 @@ export function PerformanceCreateWizard() {
       if (!startAt) return toast.error('시작 시각을 선택해 주세요.');
       if (durationMinutes < 30) return toast.error('소요 시간은 최소 30분 이상이어야 합니다.');
     }
-    if (step < 2) setStep((step + 1) as 0 | 1 | 2);
+    if (step < 3) setStep((step + 1) as 0 | 1 | 2 | 3);
   }
 
   function back() {
-    if (step > 0) setStep((step - 1) as 0 | 1 | 2);
+    if (step > 0) setStep((step - 1) as 0 | 1 | 2 | 3);
   }
 
-  function submit() {
-    if (!title || !startAt) return;
-    mutation.mutate({
-      title,
-      setlistIds: selectedSetlists.map((s) => s.setlistId),
-      startAt,
-      durationMinutes,
-      venue: venue || undefined,
-    });
+  function handlePosterFile(file: File) {
+    if (!isAllowedImageMime(file.type)) {
+      toast.error('JPEG / PNG / WEBP 형식만 업로드할 수 있습니다.');
+      return;
+    }
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      toast.error('이미지 크기는 5MB 이하여야 합니다.');
+      return;
+    }
+    if (posterPreview) URL.revokeObjectURL(posterPreview);
+    setPosterFile(file);
+    setPosterPreview(URL.createObjectURL(file));
+  }
+
+  function removePoster() {
+    if (posterPreview) URL.revokeObjectURL(posterPreview);
+    setPosterFile(null);
+    setPosterPreview(null);
+    setPosterDescription('');
+  }
+
+  async function submit() {
+    if (!title || !startAt || isPending) return;
+    setIsPending(true);
+    try {
+      const perf = await createPerformance({
+        title,
+        setlistIds: selectedSetlists.map((s) => s.setlistId),
+        startAt,
+        durationMinutes,
+        venue: venue || undefined,
+      });
+
+      if (posterFile) {
+        const ext = extFromMime(posterFile.type);
+        if (!ext) throw new Error('지원하지 않는 이미지 형식입니다.');
+        const presign = await issuePerformancePosterPresignedUrl({
+          contentType: posterFile.type,
+          contentLength: posterFile.size,
+          ext,
+        });
+        await uploadToPresignedUrl(presign.uploadUrl, posterFile);
+        await createPerformancePoster({
+          performanceId: perf.performanceId,
+          objectKey: presign.objectKey,
+          description: posterDescription || undefined,
+        });
+      }
+
+      toast.resourceCreated('공연', { name: title });
+      router.replace(ROUTES.PERFORMANCE_DETAIL(perf.performanceId));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '공연 생성에 실패했습니다.';
+      toast.error(message);
+    } finally {
+      setIsPending(false);
+    }
   }
 
   return (
@@ -143,8 +208,95 @@ export function PerformanceCreateWizard() {
         </section>
       )}
 
-      {/* Step 1 — 셋리스트 */}
+      {/* Step 1 — 포스터 등록 */}
       {step === 1 && (
+        <section className="space-y-s-4">
+          <h2 className="text-foreground-sub text-base font-semibold">
+            공연 포스터를 등록하세요{' '}
+            <span className="text-foreground-muted text-caption font-normal">(선택)</span>
+          </h2>
+
+          {posterPreview ? (
+            <div className="relative mx-auto w-fit">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={posterPreview}
+                alt="공연 포스터 미리보기"
+                className="max-h-72 rounded-[5px] object-contain"
+              />
+              <button
+                type="button"
+                aria-label="포스터 제거"
+                onClick={removePoster}
+                className="bg-surface border-border absolute -top-2 -right-2 rounded-full border p-0.5 text-white/70 hover:text-white"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          ) : (
+            <label
+              htmlFor={posterInputId}
+              className="border-border hover:border-border-hover flex h-48 cursor-pointer flex-col items-center justify-center gap-2 rounded-[5px] border border-dashed transition-colors"
+            >
+              <ImagePlus className="text-foreground-muted h-8 w-8" />
+              <span className="text-foreground-muted text-caption">
+                클릭하여 포스터 이미지 선택
+              </span>
+              <span className="text-foreground-muted text-xs">JPEG · PNG · WEBP · 최대 5MB</span>
+            </label>
+          )}
+
+          <input
+            ref={posterInputRef}
+            id={posterInputId}
+            type="file"
+            accept={ALLOWED_IMAGE_ACCEPT}
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              e.target.value = '';
+              if (file) handlePosterFile(file);
+            }}
+          />
+
+          {posterFile && (
+            <>
+              <button
+                type="button"
+                onClick={() => posterInputRef.current?.click()}
+                className="text-foreground-sub text-caption hover:text-foreground underline"
+              >
+                다른 이미지로 변경
+              </button>
+              <div className="space-y-1">
+                <label
+                  htmlFor="poster-description"
+                  className="text-foreground-sub text-caption font-semibold"
+                >
+                  포스터 설명 <span className="text-foreground-muted font-normal">(선택)</span>
+                </label>
+                <textarea
+                  id="poster-description"
+                  rows={2}
+                  placeholder="예: 2025 정기공연 포스터"
+                  value={posterDescription}
+                  onChange={(e) => setPosterDescription(e.target.value)}
+                  className="bg-surface border-border w-full resize-none rounded-[5px] border px-3 py-2 text-sm text-white outline-none placeholder:text-white/30 focus:border-white/50"
+                />
+              </div>
+            </>
+          )}
+
+          {!posterFile && (
+            <p className="text-foreground-muted text-caption">
+              포스터를 등록하지 않으면 공연 포스터 없이 생성됩니다.
+            </p>
+          )}
+        </section>
+      )}
+
+      {/* Step 2 — 셋리스트 */}
+      {step === 2 && (
         <section className="space-y-s-4">
           <h2 className="text-foreground-sub text-base font-semibold">
             셋리스트를 추가하세요{' '}
@@ -190,8 +342,8 @@ export function PerformanceCreateWizard() {
         </section>
       )}
 
-      {/* Step 2 — 검토 */}
-      {step === 2 && (
+      {/* Step 3 — 검토 */}
+      {step === 3 && (
         <section className="space-y-s-4">
           <h2 className="text-foreground-sub text-base font-semibold">아래 내용을 확인해주세요</h2>
           <WizardSummaryCard
@@ -216,12 +368,29 @@ export function PerformanceCreateWizard() {
                 onEdit: () => setStep(0),
               },
               {
+                label: '포스터',
+                value: posterFile ? (
+                  <span className="flex items-center gap-2">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={posterPreview!}
+                      alt="포스터 미리보기"
+                      className="h-10 w-auto rounded object-contain"
+                    />
+                    <span className="text-foreground-sub text-caption">{posterFile.name}</span>
+                  </span>
+                ) : (
+                  '없음'
+                ),
+                onEdit: () => setStep(1),
+              },
+              {
                 label: '셋리스트',
                 value:
                   selectedSetlists.length === 0
                     ? '없음'
                     : selectedSetlists.map((s) => s.title).join(', '),
-                onEdit: () => setStep(1),
+                onEdit: () => setStep(2),
               },
             ]}
           />
@@ -233,13 +402,19 @@ export function PerformanceCreateWizard() {
 
       <footer className="gap-s-3 mt-6.75 flex items-center justify-between">
         {step > 0 ? (
-          <Button size="sm" variant="ghost" onClick={back} className="rounded-[5px]">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={back}
+            disabled={isPending}
+            className="rounded-[5px]"
+          >
             이전
           </Button>
         ) : (
           <span />
         )}
-        {step < 2 ? (
+        {step < 3 ? (
           <Button
             size="sm"
             onClick={next}
@@ -252,10 +427,17 @@ export function PerformanceCreateWizard() {
           <Button
             size="sm"
             onClick={submit}
-            loading={mutation.isPending}
+            disabled={isPending}
             className="rounded-[5px] bg-white text-neutral-900 hover:bg-neutral-100 active:bg-neutral-200 disabled:bg-white/30"
           >
-            공연 만들기
+            {isPending ? (
+              <span className="flex items-center gap-1.5">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                생성 중…
+              </span>
+            ) : (
+              '공연 만들기'
+            )}
           </Button>
         )}
       </footer>

--- a/src/app/(main)/performances/new/PerformanceCreateWizard.client.tsx
+++ b/src/app/(main)/performances/new/PerformanceCreateWizard.client.tsx
@@ -1,42 +1,29 @@
 'use client';
 
-import { CalendarDays, ImagePlus, Loader2, X } from 'lucide-react';
+import { CalendarDays, Loader2, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useId, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { DateTimePicker } from '@/components/ui/date-time-picker';
 import { Input } from '@/components/ui/input';
 import { StepIndicator } from '@/components/ui/step-indicator';
 import { WizardSummaryCard } from '@/components/ui/wizard-summary-card';
-import {
-  createPerformancePoster,
-  issuePerformancePosterPresignedUrl,
-} from '@/domain/performance-poster/api';
 import { SetlistSelectorSheet } from '@/domain/performance/components/SetlistSelectorSheet.client';
 import { createPerformance } from '@/domain/performance/api/createPerformance';
 import type { SetlistResponse } from '@/domain/setlist/types/res';
 import { ROUTES } from '@/global/config/routes';
 import { useRegisterDirtyForm } from '@/global/navigation/dirty-form-context';
-import {
-  ALLOWED_IMAGE_ACCEPT,
-  MAX_IMAGE_SIZE_BYTES,
-  extFromMime,
-  isAllowedImageMime,
-} from '@/global/upload/constants';
-import { uploadToPresignedUrl } from '@/global/upload/uploadToPresignedUrl';
 import { useToast } from '@/hooks/useToast';
 
-const STEPS = ['기본 정보', '포스터 등록', '셋리스트 추가', '검토'] as const;
+const STEPS = ['기본 정보', '셋리스트 추가', '검토'] as const;
 const inputCls =
   'rounded-[5px] hover:border-white/30 focus-visible:border-white/80 focus-visible:ring-0';
 
 export function PerformanceCreateWizard() {
   const router = useRouter();
   const toast = useToast();
-  const posterInputRef = useRef<HTMLInputElement>(null);
-  const posterInputId = useId();
-  const [step, setStep] = useState<0 | 1 | 2 | 3>(0);
+  const [step, setStep] = useState<0 | 1 | 2>(0);
   const [isPending, setIsPending] = useState(false);
 
   // Step 0
@@ -49,23 +36,12 @@ export function PerformanceCreateWizard() {
   const [selectorOpen, setSelectorOpen] = useState(false);
   const [selectedSetlists, setSelectedSetlists] = useState<SetlistResponse[]>([]);
 
-  // Step 2
-  const [posterFile, setPosterFile] = useState<File | null>(null);
-  const [posterPreview, setPosterPreview] = useState<string | null>(null);
-  const [posterDescription, setPosterDescription] = useState('');
-
   const dirty =
     step > 0 || title.length > 0 || venue.length > 0 || !!startAt || selectedSetlists.length > 0;
   useRegisterDirtyForm('performance-create-wizard', dirty);
 
   const canNext =
-    step === 0
-      ? !!title && !!startAt && durationMinutes >= 30
-      : step === 1
-        ? true
-        : step === 2
-          ? true
-          : false;
+    step === 0 ? !!title && !!startAt && durationMinutes >= 30 : step === 1 ? true : false;
 
   function next() {
     if (step === 0) {
@@ -73,32 +49,11 @@ export function PerformanceCreateWizard() {
       if (!startAt) return toast.error('시작 시각을 선택해 주세요.');
       if (durationMinutes < 30) return toast.error('소요 시간은 최소 30분 이상이어야 합니다.');
     }
-    if (step < 3) setStep((step + 1) as 0 | 1 | 2 | 3);
+    if (step < 2) setStep((step + 1) as 0 | 1 | 2);
   }
 
   function back() {
-    if (step > 0) setStep((step - 1) as 0 | 1 | 2 | 3);
-  }
-
-  function handlePosterFile(file: File) {
-    if (!isAllowedImageMime(file.type)) {
-      toast.error('JPEG / PNG / WEBP 형식만 업로드할 수 있습니다.');
-      return;
-    }
-    if (file.size > MAX_IMAGE_SIZE_BYTES) {
-      toast.error('이미지 크기는 5MB 이하여야 합니다.');
-      return;
-    }
-    if (posterPreview) URL.revokeObjectURL(posterPreview);
-    setPosterFile(file);
-    setPosterPreview(URL.createObjectURL(file));
-  }
-
-  function removePoster() {
-    if (posterPreview) URL.revokeObjectURL(posterPreview);
-    setPosterFile(null);
-    setPosterPreview(null);
-    setPosterDescription('');
+    if (step > 0) setStep((step - 1) as 0 | 1 | 2);
   }
 
   async function submit() {
@@ -112,23 +67,6 @@ export function PerformanceCreateWizard() {
         durationMinutes,
         venue: venue || undefined,
       });
-
-      if (posterFile) {
-        const ext = extFromMime(posterFile.type);
-        if (!ext) throw new Error('지원하지 않는 이미지 형식입니다.');
-        const presign = await issuePerformancePosterPresignedUrl({
-          contentType: posterFile.type,
-          contentLength: posterFile.size,
-          ext,
-        });
-        await uploadToPresignedUrl(presign.uploadUrl, posterFile);
-        await createPerformancePoster({
-          performanceId: perf.performanceId,
-          objectKey: presign.objectKey,
-          description: posterDescription || undefined,
-        });
-      }
-
       toast.resourceCreated('공연', { name: title });
       router.replace(ROUTES.PERFORMANCE_DETAIL(perf.performanceId));
     } catch (err) {
@@ -208,95 +146,8 @@ export function PerformanceCreateWizard() {
         </section>
       )}
 
-      {/* Step 1 — 포스터 등록 */}
+      {/* Step 1 — 셋리스트 */}
       {step === 1 && (
-        <section className="space-y-s-4">
-          <h2 className="text-foreground-sub text-base font-semibold">
-            공연 포스터를 등록하세요{' '}
-            <span className="text-foreground-muted text-caption font-normal">(선택)</span>
-          </h2>
-
-          {posterPreview ? (
-            <div className="relative mx-auto w-fit">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={posterPreview}
-                alt="공연 포스터 미리보기"
-                className="max-h-72 rounded-[5px] object-contain"
-              />
-              <button
-                type="button"
-                aria-label="포스터 제거"
-                onClick={removePoster}
-                className="bg-surface border-border absolute -top-2 -right-2 rounded-full border p-0.5 text-white/70 hover:text-white"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-          ) : (
-            <label
-              htmlFor={posterInputId}
-              className="border-border hover:border-border-hover flex h-48 cursor-pointer flex-col items-center justify-center gap-2 rounded-[5px] border border-dashed transition-colors"
-            >
-              <ImagePlus className="text-foreground-muted h-8 w-8" />
-              <span className="text-foreground-muted text-caption">
-                클릭하여 포스터 이미지 선택
-              </span>
-              <span className="text-foreground-muted text-xs">JPEG · PNG · WEBP · 최대 5MB</span>
-            </label>
-          )}
-
-          <input
-            ref={posterInputRef}
-            id={posterInputId}
-            type="file"
-            accept={ALLOWED_IMAGE_ACCEPT}
-            className="hidden"
-            onChange={(e) => {
-              const file = e.target.files?.[0];
-              e.target.value = '';
-              if (file) handlePosterFile(file);
-            }}
-          />
-
-          {posterFile && (
-            <>
-              <button
-                type="button"
-                onClick={() => posterInputRef.current?.click()}
-                className="text-foreground-sub text-caption hover:text-foreground underline"
-              >
-                다른 이미지로 변경
-              </button>
-              <div className="space-y-1">
-                <label
-                  htmlFor="poster-description"
-                  className="text-foreground-sub text-caption font-semibold"
-                >
-                  포스터 설명 <span className="text-foreground-muted font-normal">(선택)</span>
-                </label>
-                <textarea
-                  id="poster-description"
-                  rows={2}
-                  placeholder="예: 2025 정기공연 포스터"
-                  value={posterDescription}
-                  onChange={(e) => setPosterDescription(e.target.value)}
-                  className="bg-surface border-border w-full resize-none rounded-[5px] border px-3 py-2 text-sm text-white outline-none placeholder:text-white/30 focus:border-white/50"
-                />
-              </div>
-            </>
-          )}
-
-          {!posterFile && (
-            <p className="text-foreground-muted text-caption">
-              포스터를 등록하지 않으면 공연 포스터 없이 생성됩니다.
-            </p>
-          )}
-        </section>
-      )}
-
-      {/* Step 2 — 셋리스트 */}
-      {step === 2 && (
         <section className="space-y-s-4">
           <h2 className="text-foreground-sub text-base font-semibold">
             셋리스트를 추가하세요{' '}
@@ -342,8 +193,8 @@ export function PerformanceCreateWizard() {
         </section>
       )}
 
-      {/* Step 3 — 검토 */}
-      {step === 3 && (
+      {/* Step 2 — 검토 */}
+      {step === 2 && (
         <section className="space-y-s-4">
           <h2 className="text-foreground-sub text-base font-semibold">아래 내용을 확인해주세요</h2>
           <WizardSummaryCard
@@ -368,29 +219,12 @@ export function PerformanceCreateWizard() {
                 onEdit: () => setStep(0),
               },
               {
-                label: '포스터',
-                value: posterFile ? (
-                  <span className="flex items-center gap-2">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={posterPreview!}
-                      alt="포스터 미리보기"
-                      className="h-10 w-auto rounded object-contain"
-                    />
-                    <span className="text-foreground-sub text-caption">{posterFile.name}</span>
-                  </span>
-                ) : (
-                  '없음'
-                ),
-                onEdit: () => setStep(1),
-              },
-              {
                 label: '셋리스트',
                 value:
                   selectedSetlists.length === 0
                     ? '없음'
                     : selectedSetlists.map((s) => s.title).join(', '),
-                onEdit: () => setStep(2),
+                onEdit: () => setStep(1),
               },
             ]}
           />
@@ -414,7 +248,7 @@ export function PerformanceCreateWizard() {
         ) : (
           <span />
         )}
-        {step < 3 ? (
+        {step < 2 ? (
           <Button
             size="sm"
             onClick={next}

--- a/src/domain/performance-poster/api/index.ts
+++ b/src/domain/performance-poster/api/index.ts
@@ -1,0 +1,57 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type {
+  CreatePerformancePosterRequest,
+  PerformancePosterPresignRequest,
+  UpdatePerformancePosterRequest,
+} from '../types/req';
+import type { PerformancePosterPresignResponse, PerformancePosterResponse } from '../types/res';
+
+const PREFIX = '/api/v1/performance-posters';
+
+export async function issuePerformancePosterPresignedUrl(
+  req: PerformancePosterPresignRequest,
+): Promise<PerformancePosterPresignResponse> {
+  const data = await apiClient.post<PerformancePosterPresignResponse>(
+    `${PREFIX}/presigned-url`,
+    req,
+  );
+  if (!data) throw new Error('presigned URL 응답이 비어 있습니다.');
+  return data;
+}
+
+export async function getPerformancePosters(
+  performanceId: string,
+): Promise<PerformancePosterResponse[]> {
+  const data = await apiClient.get<PerformancePosterResponse[]>(PREFIX, {
+    query: { performanceId },
+  });
+  return data ?? [];
+}
+
+export async function createPerformancePoster(
+  req: CreatePerformancePosterRequest,
+): Promise<PerformancePosterResponse> {
+  const data = await apiClient.post<PerformancePosterResponse>(PREFIX, req);
+  if (!data) throw new Error('공연 포스터 생성 응답이 비어 있습니다.');
+  return data;
+}
+
+export async function getPerformancePoster(posterId: string): Promise<PerformancePosterResponse> {
+  const data = await apiClient.get<PerformancePosterResponse>(`${PREFIX}/${posterId}`);
+  if (!data) throw new Error('공연 포스터를 찾을 수 없습니다.');
+  return data;
+}
+
+export async function updatePerformancePoster(
+  posterId: string,
+  req: UpdatePerformancePosterRequest,
+): Promise<PerformancePosterResponse> {
+  const data = await apiClient.patch<PerformancePosterResponse>(`${PREFIX}/${posterId}`, req);
+  if (!data) throw new Error('공연 포스터 수정 응답이 비어 있습니다.');
+  return data;
+}
+
+export async function deletePerformancePoster(posterId: string): Promise<void> {
+  await apiClient.delete<void>(`${PREFIX}/${posterId}`);
+}

--- a/src/domain/performance-poster/hooks/useCreatePerformancePoster.ts
+++ b/src/domain/performance-poster/hooks/useCreatePerformancePoster.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { createPerformancePoster } from '../api';
+import type { CreatePerformancePosterRequest } from '../types/req';
+
+export function useCreatePerformancePoster(
+  performanceId: string,
+  options?: { onSuccess?: () => void; onError?: (err: Error) => void },
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (req: CreatePerformancePosterRequest) => createPerformancePoster(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.performancePoster.list(performanceId) });
+      options?.onSuccess?.();
+    },
+    onError: (err: Error) => options?.onError?.(err),
+  });
+}

--- a/src/domain/performance-poster/hooks/useDeletePerformancePoster.ts
+++ b/src/domain/performance-poster/hooks/useDeletePerformancePoster.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deletePerformancePoster } from '../api';
+
+export function useDeletePerformancePoster(
+  performanceId: string,
+  options?: { onSuccess?: () => void; onError?: (err: Error) => void },
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (posterId: string) => deletePerformancePoster(posterId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.performancePoster.list(performanceId) });
+      options?.onSuccess?.();
+    },
+    onError: (err: Error) => options?.onError?.(err),
+  });
+}

--- a/src/domain/performance-poster/hooks/usePerformancePosters.ts
+++ b/src/domain/performance-poster/hooks/usePerformancePosters.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getPerformancePosters } from '../api';
+
+export function usePerformancePosters(performanceId: string) {
+  return useQuery({
+    queryKey: queryKeys.performancePoster.list(performanceId),
+    queryFn: () => getPerformancePosters(performanceId),
+    enabled: !!performanceId,
+  });
+}

--- a/src/domain/performance-poster/hooks/useUpdatePerformancePoster.ts
+++ b/src/domain/performance-poster/hooks/useUpdatePerformancePoster.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updatePerformancePoster } from '../api';
+import type { UpdatePerformancePosterRequest } from '../types/req';
+
+export function useUpdatePerformancePoster(
+  performanceId: string,
+  posterId: string,
+  options?: { onSuccess?: () => void; onError?: (err: Error) => void },
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (req: UpdatePerformancePosterRequest) => updatePerformancePoster(posterId, req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.performancePoster.list(performanceId) });
+      options?.onSuccess?.();
+    },
+    onError: (err: Error) => options?.onError?.(err),
+  });
+}

--- a/src/domain/performance-poster/types/index.ts
+++ b/src/domain/performance-poster/types/index.ts
@@ -1,0 +1,6 @@
+export type {
+  CreatePerformancePosterRequest,
+  UpdatePerformancePosterRequest,
+  PerformancePosterPresignRequest,
+} from './req';
+export type { PerformancePosterResponse, PerformancePosterPresignResponse } from './res';

--- a/src/domain/performance-poster/types/req.ts
+++ b/src/domain/performance-poster/types/req.ts
@@ -1,0 +1,15 @@
+export interface PerformancePosterPresignRequest {
+  contentType: string;
+  contentLength: number;
+  ext: string;
+}
+
+export interface CreatePerformancePosterRequest {
+  performanceId: string;
+  objectKey: string;
+  description?: string;
+}
+
+export interface UpdatePerformancePosterRequest {
+  description: string;
+}

--- a/src/domain/performance-poster/types/res.ts
+++ b/src/domain/performance-poster/types/res.ts
@@ -1,0 +1,14 @@
+export interface PerformancePosterResponse {
+  posterId: string;
+  performanceId: string;
+  imageUrl: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PerformancePosterPresignResponse {
+  uploadUrl: string;
+  objectKey: string;
+  expiresInSeconds: number;
+}

--- a/src/global/config/queryKeys.ts
+++ b/src/global/config/queryKeys.ts
@@ -44,6 +44,11 @@ export const queryKeys = {
     upcoming: (limit: number) => [...queryKeys.performance.all, 'upcoming', limit] as const,
     detail: (id: string) => [...queryKeys.performance.all, id] as const,
   },
+  performancePoster: {
+    all: ['performance-poster'] as const,
+    list: (performanceId: string) => [...queryKeys.performancePoster.all, performanceId] as const,
+    detail: (posterId: string) => [...queryKeys.performancePoster.all, 'detail', posterId] as const,
+  },
 } as const;
 
 export type QueryKeys = typeof queryKeys;


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-164](https://sunwoo1137.atlassian.net/browse/BD-164)

## 📌 작업 내용 및 특이사항

### 공연 포스터 도메인 구현
- MCP(`check_impacting_changes`)로 BE develop 확인한 6개 엔드포인트 기반 API 함수 구현
  - `issuePerformancePosterPresignedUrl`, `getPerformancePosters`, `createPerformancePoster`, `getPerformancePoster`, `updatePerformancePoster`, `deletePerformancePoster`
- TanStack Query 훅 4종 추가 (`usePerformancePosters`, `useCreatePerformancePoster`, `useUpdatePerformancePoster`, `useDeletePerformancePoster`)
- `queryKeys.performancePoster` 네임스페이스 추가
- `fe-areas.json` — `performance-poster`, `band-application` 영역 신규 등록 (`specPending: true`)

### 공연 포스터 UI
- **공연 생성 위자드** — 포스터 단계 제거 (기본 정보 → 셋리스트 추가 → 검토 3단계로 정리)
- **공연 상세 페이지** — "공연 포스터" 카드 추가
  - 매니저: 드롭존으로 업로드 / 변경 / 삭제
  - 일반 멤버: 등록된 포스터 조회만 가능
  - presign → S3 PUT → 포스터 레코드 생성 순 처리

### 밴드 상세 설정 탭 UI 개선
- 이미지 탭: `ProfileImageUpload` 제거, 드롭존 UI 적용 (점선 테두리 + 아이콘 + 텍스트)
- 정보 탭: Camera 아이콘 → ImagePlus, 플레이스홀더 텍스트 한국어로 변경
- 설정 탭 `max-w-lg` 제거 — 다른 탭과 너비 통일

## 📚 참고사항
- `performance-poster`, `band-application` 영역은 openapi.json 스냅샷 미반영 상태로 `specPending: true` 유지. BE 머지 후 스냅샷 업데이트 및 실서버 검증 필요

[BD-164]: https://sunwoo1137.atlassian.net/browse/BD-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ