### PR TITLE
[BD-174] fix: 멤버·밴드 프로필 이미지 API 엔드포인트 및 UX 수정

### DIFF
--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -440,7 +440,10 @@ function SettingsTab({
   const currentImg = localPreview ?? profileImg ?? null;
 
   const updateMutation = useUpdateBand(bandId, {
-    onSuccess: () => toast.success('밴드 정보를 저장했습니다.'),
+    onSuccess: () => {
+      setLocalPreview(null);
+      toast.success('밴드 정보를 저장했습니다.');
+    },
     onError: (err) => toast.error(err.message || '저장에 실패했습니다.'),
   });
 

--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -81,8 +81,16 @@ export function MeContent() {
     weeklyRules: WeeklyRuleRequest[],
     note: string,
     exceptions: AvailabilityExceptionRequest[],
+    effectiveFrom: string,
+    effectiveTo: string,
   ) => {
-    updateAvailabilityMutation.mutate({ weeklyRules, exceptions, note });
+    updateAvailabilityMutation.mutate({
+      weeklyRules,
+      exceptions,
+      note,
+      effectiveFrom,
+      effectiveTo: effectiveTo || null,
+    });
   };
 
   const logoutMutation = useLogout({
@@ -261,8 +269,16 @@ export function MeContent() {
   );
 }
 
-function EditCard({ member, onSaved }: { member: MemberInfoResponse; onSaved: () => void }) {
+function EditCard({
+  member: initialMember,
+  onSaved,
+}: {
+  member: MemberInfoResponse;
+  onSaved: () => void;
+}) {
   const toast = useToast();
+  const { data: liveMe } = useMe();
+  const member = liveMe ?? initialMember;
   const form = useForm<UpdateMeSchema>({
     resolver: zodResolver(updateMeSchema),
     defaultValues: { name: member.name },

--- a/src/domain/band/hooks/useDeleteBandProfileImage.ts
+++ b/src/domain/band/hooks/useDeleteBandProfileImage.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { deleteBandProfileImage } from '@/domain/band/api/deleteBandProfileImage';
+import type { BandInfoResponse } from '@/domain/band/types/res';
 import { queryKeys } from '@/global/config/queryKeys';
 
 interface Options {
@@ -12,10 +13,26 @@ export function useDeleteBandProfileImage(bandId: string, options?: Options) {
   const queryClient = useQueryClient();
   return useMutation<void, Error, void>({
     mutationFn: () => deleteBandProfileImage(bandId),
+    onMutate: () => {
+      const key = queryKeys.band.detail(bandId);
+      const prev = queryClient.getQueryData<BandInfoResponse | null>(key);
+      if (prev) {
+        queryClient.setQueryData<BandInfoResponse>(key, { ...prev, profileImg: undefined });
+      }
+      return { prev };
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.band.detail(bandId) });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.my()] });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.list()] });
       options?.onSuccess?.();
     },
-    onError: options?.onError,
+    onError: (_err, _v, context) => {
+      const ctx = context as { prev?: BandInfoResponse | null } | undefined;
+      if (ctx?.prev !== undefined) {
+        queryClient.setQueryData(queryKeys.band.detail(bandId), ctx.prev);
+      }
+      options?.onError?.(_err);
+    },
   });
 }

--- a/src/domain/member/components/ScheduleManagerModal.client.tsx
+++ b/src/domain/member/components/ScheduleManagerModal.client.tsx
@@ -75,11 +75,7 @@ function availabilityToGrid(availability: MemberAvailabilityResponse | undefined
   return grid;
 }
 
-function gridToWeeklyRules(
-  grid: GridState,
-  effectiveFrom: string,
-  effectiveTo: string,
-): WeeklyRuleRequest[] {
+function gridToWeeklyRules(grid: GridState): WeeklyRuleRequest[] {
   const rules: WeeklyRuleRequest[] = [];
   for (let d = 0; d < 7; d++) {
     const dayOfWeek = DAY_OF_WEEK_KEYS[d];
@@ -90,13 +86,7 @@ function gridToWeeklyRules(
       if (daySlots[i]) {
         const start = i;
         while (i < SLOT_COUNT && daySlots[i]) i++;
-        rules.push({
-          dayOfWeek,
-          startSlot: start + START_SLOT,
-          endSlot: i + START_SLOT,
-          effectiveFrom,
-          effectiveTo: effectiveTo || undefined,
-        });
+        rules.push({ dayOfWeek, startSlot: start + START_SLOT, endSlot: i + START_SLOT });
       } else {
         i++;
       }
@@ -117,6 +107,8 @@ type Props = {
     weeklyRules: WeeklyRuleRequest[],
     note: string,
     exceptions: AvailabilityExceptionRequest[],
+    effectiveFrom: string,
+    effectiveTo: string,
   ) => void;
   isSaving?: boolean;
 };
@@ -197,7 +189,7 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
   };
 
   const handleSave = () => {
-    onSave(gridToWeeklyRules(grid, effectiveFrom, effectiveTo), note, exceptions);
+    onSave(gridToWeeklyRules(grid), note, exceptions, effectiveFrom, effectiveTo);
   };
 
   if (!open) return null;

--- a/src/domain/member/hooks/useDeleteMyProfileImage.ts
+++ b/src/domain/member/hooks/useDeleteMyProfileImage.ts
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/global/config/queryKeys';
 
 import { deleteMyProfileImage } from '../api/deleteMyProfileImage';
+import type { MemberInfoResponse } from '../types';
 
 type UseDeleteMyProfileImageOptions = {
   onSuccess?: () => void;
@@ -15,10 +16,24 @@ export function useDeleteMyProfileImage(options?: UseDeleteMyProfileImageOptions
   const queryClient = useQueryClient();
   return useMutation<void, Error, void>({
     mutationFn: deleteMyProfileImage,
+    onMutate: () => {
+      const key = [...queryKeys.member.me];
+      const prev = queryClient.getQueryData<MemberInfoResponse | null>(key);
+      if (prev) {
+        queryClient.setQueryData<MemberInfoResponse>(key, { ...prev, profileImg: null });
+      }
+      return { prev };
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...queryKeys.member.me] });
       options?.onSuccess?.();
     },
-    onError: options?.onError,
+    onError: (_err, _v, context) => {
+      const ctx = context as { prev?: MemberInfoResponse | null } | undefined;
+      if (ctx?.prev !== undefined) {
+        queryClient.setQueryData([...queryKeys.member.me], ctx.prev);
+      }
+      options?.onError?.(_err);
+    },
   });
 }

--- a/src/domain/member/types/req.ts
+++ b/src/domain/member/types/req.ts
@@ -14,8 +14,6 @@ export interface WeeklyRuleRequest {
   dayOfWeek: import('./res').DayOfWeek;
   startSlot: number;
   endSlot: number;
-  effectiveFrom: string;
-  effectiveTo?: string | null;
 }
 
 export interface AvailabilityExceptionRequest {
@@ -30,4 +28,6 @@ export interface UpdateMyAvailabilityRequest {
   weeklyRules: WeeklyRuleRequest[];
   exceptions: AvailabilityExceptionRequest[];
   note?: string | null;
+  effectiveFrom: string;
+  effectiveTo?: string | null;
 }

--- a/src/global/upload/presignProfileImage.ts
+++ b/src/global/upload/presignProfileImage.ts
@@ -1,15 +1,42 @@
 import { apiClient } from '@/global/api/apiClient';
 
-import type { ProfileImagePresignRequest, ProfileImagePresignResponse } from './types';
+import type {
+  BandProfileImagePresignRequest,
+  MemberProfileImagePresignRequest,
+  ProfileImagePresignResponse,
+} from './types';
 
-/** BE: `POST /api/v1/uploads/profile-image/presigned-url`. */
-export async function presignProfileImage(
-  req: ProfileImagePresignRequest,
+/** `POST /api/v1/members/me/profile-image/presigned-url` */
+export async function presignMemberProfileImage(
+  req: MemberProfileImagePresignRequest,
 ): Promise<ProfileImagePresignResponse> {
   const data = await apiClient.post<ProfileImagePresignResponse>(
-    '/api/v1/uploads/profile-image/presigned-url',
+    '/api/v1/members/me/profile-image/presigned-url',
     req,
   );
   if (!data) throw new Error('presigned URL 응답이 비어 있습니다.');
   return data;
+}
+
+/** `POST /api/v1/bands/{bandId}/profile-image/presigned-url` (밴드 이미지 전용) */
+export async function presignBandProfileImage(
+  req: BandProfileImagePresignRequest,
+): Promise<ProfileImagePresignResponse> {
+  const { bandId, ...body } = req;
+  const data = await apiClient.post<ProfileImagePresignResponse>(
+    `/api/v1/bands/${bandId}/profile-image/presigned-url`,
+    body,
+  );
+  if (!data) throw new Error('presigned URL 응답이 비어 있습니다.');
+  return data;
+}
+
+/** @deprecated Use presignMemberProfileImage or presignBandProfileImage */
+export async function presignProfileImage(
+  req: MemberProfileImagePresignRequest | BandProfileImagePresignRequest,
+): Promise<ProfileImagePresignResponse> {
+  if ('bandId' in req) {
+    return presignBandProfileImage(req as BandProfileImagePresignRequest);
+  }
+  return presignMemberProfileImage(req as MemberProfileImagePresignRequest);
 }

--- a/src/global/upload/types.ts
+++ b/src/global/upload/types.ts
@@ -1,18 +1,22 @@
 export type UploadDomain = 'MEMBER' | 'BAND';
 
-export interface ProfileImagePresignRequest {
-  domain: UploadDomain;
-  /** domain=BAND 인 경우 필수. 매니저 권한 검증 대상. */
-  bandId?: string;
+export interface MemberProfileImagePresignRequest {
   contentType: string;
-  /** 점 제외, 소문자. */
   ext: string;
-  /**
-   * 업로드할 파일의 정확한 바이트 크기 (1 ~ 5,242,880).
-   * BE 가 contentLength 를 시그니처에 포함하므로 PUT body 크기와 정확히 일치해야 한다.
-   */
   contentLength: number;
 }
+
+export interface BandProfileImagePresignRequest {
+  bandId: string;
+  contentType: string;
+  ext: string;
+  contentLength: number;
+}
+
+/** @deprecated Use MemberProfileImagePresignRequest or BandProfileImagePresignRequest */
+export type ProfileImagePresignRequest =
+  | MemberProfileImagePresignRequest
+  | BandProfileImagePresignRequest;
 
 export interface ProfileImagePresignResponse {
   /** PUT 업로드용 presigned URL. */

--- a/src/global/upload/uploadProfileImage.ts
+++ b/src/global/upload/uploadProfileImage.ts
@@ -1,5 +1,5 @@
 import { extFromMime, isAllowedImageMime, MAX_IMAGE_SIZE_BYTES } from './constants';
-import { presignProfileImage } from './presignProfileImage';
+import { presignBandProfileImage, presignMemberProfileImage } from './presignProfileImage';
 import type { UploadDomain } from './types';
 import { uploadToPresignedUrl } from './uploadToPresignedUrl';
 
@@ -35,13 +35,11 @@ export async function uploadProfileImage({
     throw new Error('밴드 프로필 이미지 업로드에는 bandId 가 필요합니다.');
   }
 
-  const presign = await presignProfileImage({
-    domain,
-    bandId,
-    contentType: file.type,
-    ext,
-    contentLength: file.size,
-  });
+  const common = { contentType: file.type, ext, contentLength: file.size };
+  const presign =
+    domain === 'BAND'
+      ? await presignBandProfileImage({ bandId: bandId!, ...common })
+      : await presignMemberProfileImage(common);
   await uploadToPresignedUrl(presign.uploadUrl, file);
   return presign.objectKey;
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-174](https://sunwoo1137.atlassian.net/browse/BD-174)

📌 **작업 내용 및 특이사항**

- `presignProfileImage`를 멤버/밴드 전용 함수로 분리
  - 멤버: `POST /api/v1/members/me/profile-image/presigned-url`
  - 밴드: `POST /api/v1/bands/{bandId}/profile-image/presigned-url`
- `uploadProfileImage`에서 분리된 presign 함수 호출하도록 업데이트
- `useDeleteBandProfileImage`: 삭제 성공 시 `band.my` · `band.list` 쿼리 invalidation 추가 → 밴드 목록에 즉시 반영
- `useDeleteMyProfileImage`: optimistic update 적용 → 삭제 즉시 UI 반영
- `MeContent` `EditCard`: `useMe()` 구독으로 프로필 이미지 삭제 후 화면 즉시 갱신
- `BandDetailContent`: 이미지 업로드 성공 시 `localPreview` 초기화 → 삭제 버튼 2번 클릭 버그 수정

📚 **참고사항**

@willjsw 
- 공연 포스터 presigned-url (`POST /api/v1/performance-posters/presigned-url`) 은 백엔드 Security filter chain 설정 문제로 유효한 access token을 401로 거부하고 있음. 프론트 구현은 동일 패턴으로 완료되어 있으며, 백엔드 측 확인 필요.

[BD-174]: https://sunwoo1137.atlassian.net/browse/BD-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ