### PR TITLE
[BD-169] feat: 밴드 가입 신청 철회 및 신청 내역 UI 구현

### DIFF
--- a/src/app/(main)/bands/BandsListPane.client.tsx
+++ b/src/app/(main)/bands/BandsListPane.client.tsx
@@ -11,6 +11,7 @@ import { MyItemMarker, myItemBorder } from '@/components/ui/my-item-marker';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BandCreateModal } from '@/domain/band/components/BandCreateModal.client';
 import { BandRoleBadge } from '@/domain/band/components/BandRoleBadge';
+import { MyBandApplicationsSheet } from '@/domain/band/components/MyBandApplicationsSheet.client';
 import { useBandList } from '@/domain/band/hooks/useBandList';
 import { useBandSearch } from '@/domain/band/hooks/useBandSearch';
 import { useMyBands } from '@/domain/band/hooks/useMyBands';
@@ -123,8 +124,8 @@ export function BandsListPane() {
         onValueChange={onTabChange}
         className="flex flex-1 flex-col overflow-hidden"
       >
-        <div className="border-border px-s-4 py-s-3 border-b">
-          <TabsList className="w-full">
+        <div className="border-border px-s-4 py-s-3 gap-s-2 flex items-center border-b">
+          <TabsList className="flex-1">
             <TabsTrigger value="mine" className="flex-1">
               내 밴드
             </TabsTrigger>
@@ -132,6 +133,13 @@ export function BandsListPane() {
               탐색
             </TabsTrigger>
           </TabsList>
+          <MyBandApplicationsSheet
+            trigger={
+              <Button size="sm" variant="ghost" className="shrink-0">
+                가입 신청 내역
+              </Button>
+            }
+          />
         </div>
 
         <TabsContent value="mine" className="px-s-2 py-s-2 flex-1 overflow-y-auto">

--- a/src/app/(main)/bands/BandsMobileShell.client.tsx
+++ b/src/app/(main)/bands/BandsMobileShell.client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Root, Portal, Overlay, Content, Title, Close } from '@radix-ui/react-dialog';
-import { Maximize2, Plus, Search, Users, X } from 'lucide-react';
+import { ClipboardList, Maximize2, Plus, Search, Users, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -18,6 +18,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BandCreateModal } from '@/domain/band/components/BandCreateModal.client';
 import { BandRoleBadge } from '@/domain/band/components/BandRoleBadge';
+import { MyBandApplicationsSheet } from '@/domain/band/components/MyBandApplicationsSheet.client';
 import { useBandList } from '@/domain/band/hooks/useBandList';
 import { useBandSearch } from '@/domain/band/hooks/useBandSearch';
 import { useMyBands } from '@/domain/band/hooks/useMyBands';
@@ -126,6 +127,13 @@ export function BandsMobileShell() {
                 탐색
               </TabsTrigger>
             </TabsList>
+            <MyBandApplicationsSheet
+              trigger={
+                <Button size="sm" variant="ghost" className="hidden lg:inline-flex">
+                  가입 신청 내역
+                </Button>
+              }
+            />
           </div>
           <BandCreateModal
             trigger={
@@ -141,9 +149,9 @@ export function BandsMobileShell() {
           />
         </div>
 
-        {/* 모바일: 헤더 아래 풀너비 토글 */}
-        <div className="mb-s-3 lg:hidden">
-          <TabsList className="w-full">
+        {/* 모바일: 헤더 아래 탭 + 가입 신청 내역 버튼 */}
+        <div className="gap-s-2 mb-s-3 flex items-center lg:hidden">
+          <TabsList className="flex-1">
             <TabsTrigger
               value="mine"
               className="text-foreground flex-1 transition-all active:scale-95 data-[state=active]:bg-neutral-100 data-[state=active]:text-neutral-900"
@@ -157,6 +165,13 @@ export function BandsMobileShell() {
               탐색
             </TabsTrigger>
           </TabsList>
+          <MyBandApplicationsSheet
+            trigger={
+              <Button size="sm" variant="ghost" className="shrink-0" aria-label="가입 신청 내역">
+                <ClipboardList className="h-4 w-4" />
+              </Button>
+            }
+          />
         </div>
 
         <TabsContent value="mine">

--- a/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
+++ b/src/app/(main)/bands/[bandId]/BandDetailContent.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ImagePlus, Loader2, LogOut, UserPlus, X } from 'lucide-react';
+import { ImagePlus, Loader2, LogOut, UserMinus, UserPlus, X } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useId, useRef, useState } from 'react';
 
@@ -31,6 +31,8 @@ import { BandApplicationRow } from '@/domain/band/components/BandApplicationRow'
 import { BandMemberRow } from '@/domain/band/components/BandMemberRow';
 import { useApplyBand } from '@/domain/band/hooks/useApplyBand';
 import { useBandApplications } from '@/domain/band/hooks/useBandApplications';
+import { useMyApplicationForBand } from '@/domain/band/hooks/useMyApplicationForBand';
+import { useWithdrawApplication } from '@/domain/band/hooks/useWithdrawApplication';
 import { useBandDetail } from '@/domain/band/hooks/useBandDetail';
 import { useBandMembers } from '@/domain/band/hooks/useBandMembers';
 import { useDeleteBand } from '@/domain/band/hooks/useDeleteBand';
@@ -65,6 +67,13 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
     onError: (err) => toast.error(err.message || '가입 신청에 실패했습니다.'),
   });
 
+  const { data: myApplication } = useMyApplicationForBand(bandId);
+
+  const withdrawMutation = useWithdrawApplication(bandId, {
+    onSuccess: () => toast.success('가입 신청을 철회했습니다.'),
+    onError: (err) => toast.error(err.message || '가입 신청 철회에 실패했습니다.'),
+  });
+
   const leaveMutation = useLeaveBand(bandId, {
     onSuccess: () => {
       toast.success('밴드에서 탈퇴했습니다.');
@@ -92,6 +101,7 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
 
   const isMember = myRole !== null && myRole !== undefined;
   const isLeader = hasRole(myRole, 'LEADER'); // ADMIN 역할은 현재 BE 미정의 — LEADER 만 관리 권한
+  const isPendingApplicant = !isMember && myApplication?.status === 'PENDING';
 
   return (
     <div data-slot="band-detail">
@@ -106,7 +116,19 @@ export function BandDetailContent({ bandId }: { bandId: string }) {
           </h1>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {!isMember && (
+          {isPendingApplicant && (
+            <Button
+              size="sm"
+              variant="secondary"
+              className="rounded-[5px] border-white/50 text-white/70 hover:border-transparent hover:bg-white/10 active:bg-white/20"
+              onClick={() => withdrawMutation.mutate()}
+              loading={withdrawMutation.isPending}
+            >
+              <UserMinus className="h-4 w-4" />
+              가입 철회
+            </Button>
+          )}
+          {!isMember && !isPendingApplicant && (
             <Button
               size="sm"
               variant="secondary"

--- a/src/domain/band/api/getMyApplicationForBand.ts
+++ b/src/domain/band/api/getMyApplicationForBand.ts
@@ -1,0 +1,12 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { BandApplicationInfoResponse } from '../types';
+
+/** GET /api/v1/bands/{bandId}/applications/me — 내 가입 신청 단건 조회 (없으면 null) */
+export async function getMyApplicationForBand(
+  bandId: string,
+): Promise<BandApplicationInfoResponse | null> {
+  return apiClient.get<BandApplicationInfoResponse | null>(
+    `/api/v1/bands/${bandId}/applications/me`,
+  );
+}

--- a/src/domain/band/api/getMyBandApplications.ts
+++ b/src/domain/band/api/getMyBandApplications.ts
@@ -1,0 +1,28 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { ApplicationStatus } from '@/global/types';
+import type { CursorResponse } from '@/global/types';
+
+import type { MyBandApplicationResponse } from '../types/res';
+
+type Params = {
+  status?: ApplicationStatus;
+  lastId?: string;
+  pageSize: number;
+};
+
+/** GET /api/v1/band-applications/me — 내 밴드 가입 신청 목록 (status 미지정 시 전체) */
+export async function getMyBandApplications(
+  params: Params,
+): Promise<CursorResponse<MyBandApplicationResponse, string>> {
+  const data = await apiClient.get<CursorResponse<MyBandApplicationResponse, string> | null>(
+    '/api/v1/band-applications/me',
+    {
+      query: {
+        status: params.status,
+        lastId: params.lastId,
+        pageSize: params.pageSize,
+      },
+    },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/band/components/MyBandApplicationsSheet.client.tsx
+++ b/src/domain/band/components/MyBandApplicationsSheet.client.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { formatInTimeZone } from 'date-fns-tz';
+import { Users } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  BottomSheet,
+  BottomSheetContent,
+  BottomSheetTitle,
+  BottomSheetTrigger,
+} from '@/components/ui/bottom-sheet';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { IconTile } from '@/components/ui/icon-tile';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { ApplicationStatus } from '@/global/types';
+import { useIsDesktop } from '@/hooks/use-media-query';
+import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/cn';
+import { DOMAIN_TONES } from '@/lib/domain-icons';
+
+import { useMyBandApplications } from '../hooks/useMyBandApplications';
+import { useWithdrawApplication } from '../hooks/useWithdrawApplication';
+import type { MyBandApplicationResponse } from '../types/res';
+
+const STATUS_FILTERS: { label: string; value: ApplicationStatus | undefined }[] = [
+  { label: '전체', value: undefined },
+  { label: '대기중', value: 'PENDING' },
+  { label: '승인됨', value: 'APPROVED' },
+  { label: '거절됨', value: 'REJECTED' },
+];
+
+const STATUS_LABEL: Record<ApplicationStatus, string> = {
+  PENDING: '대기중',
+  APPROVED: '승인됨',
+  REJECTED: '거절됨',
+  WITHDRAWN: '철회됨',
+  LEAVED: '탈퇴됨',
+};
+
+const STATUS_COLOR: Record<ApplicationStatus, string> = {
+  PENDING: 'text-yellow-400 bg-yellow-400/10',
+  APPROVED: 'bg-blue-dim text-blue',
+  REJECTED: 'text-red-400 bg-red-400/10',
+  WITHDRAWN: 'text-foreground-muted bg-white/5',
+  LEAVED: 'text-foreground-muted bg-white/5',
+};
+
+function ApplicationRow({ item }: { item: MyBandApplicationResponse }) {
+  const toast = useToast();
+  const withdrawMutation = useWithdrawApplication(item.bandId, {
+    onSuccess: () => toast.success('가입 신청을 철회했습니다.'),
+    onError: (err) => toast.error(err.message || '철회에 실패했습니다.'),
+  });
+
+  const appliedAt = item.appliedAt
+    ? formatInTimeZone(new Date(item.appliedAt), 'Asia/Seoul', 'yyyy-MM-dd')
+    : null;
+
+  return (
+    <li className="gap-s-3 px-s-4 py-s-3 flex items-center">
+      {item.bandProfileImg ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={item.bandProfileImg}
+          alt={item.bandName}
+          className="h-10 w-10 shrink-0 rounded-md object-cover"
+        />
+      ) : (
+        <IconTile icon={<Users />} size="sm" tone={DOMAIN_TONES.band} />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="gap-s-2 flex items-center">
+          <span className="text-caption truncate font-semibold">{item.bandName}</span>
+          <span
+            className={cn(
+              'text-micro rounded px-1.5 py-0.5 font-medium',
+              STATUS_COLOR[item.status],
+            )}
+          >
+            {STATUS_LABEL[item.status]}
+          </span>
+        </div>
+        {appliedAt && <p className="text-foreground-muted text-micro mt-0.5">{appliedAt} 신청</p>}
+      </div>
+      {item.status === 'PENDING' && (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-foreground-muted hover:text-foreground shrink-0 rounded-[5px] hover:bg-white/10"
+          onClick={() => withdrawMutation.mutate()}
+          loading={withdrawMutation.isPending}
+        >
+          철회
+        </Button>
+      )}
+    </li>
+  );
+}
+
+function SheetInner({
+  status,
+  setStatus,
+  items,
+  isLoading,
+}: {
+  status: ApplicationStatus | undefined;
+  setStatus: (v: ApplicationStatus | undefined) => void;
+  items: MyBandApplicationResponse[];
+  isLoading: boolean;
+}) {
+  return (
+    <>
+      <div className="gap-s-2 px-s-4 py-s-3 flex shrink-0 flex-wrap">
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.label}
+            type="button"
+            onClick={() => setStatus(f.value)}
+            className={cn(
+              'rounded-full px-3 py-1 text-sm transition-colors',
+              status === f.value
+                ? 'bg-white font-medium text-neutral-900'
+                : 'text-foreground-sub hover:bg-white/10',
+            )}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="px-s-4 space-y-s-2 py-2">
+            <Skeleton className="h-14 w-full" rounded="md" />
+            <Skeleton className="h-14 w-full" rounded="md" />
+            <Skeleton className="h-14 w-full" rounded="md" />
+          </div>
+        ) : items.length === 0 ? (
+          <p className="text-foreground-muted py-s-8 text-center text-sm">신청 내역이 없습니다.</p>
+        ) : (
+          <ul className="divide-border divide-y">
+            {items.map((item) => (
+              <ApplicationRow key={item.bandApplicationId} item={item} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+}
+
+export function MyBandApplicationsSheet({ trigger }: { trigger: React.ReactNode }) {
+  const isDesktop = useIsDesktop();
+  const [status, setStatus] = useState<ApplicationStatus | undefined>(undefined);
+  const { data, isLoading } = useMyBandApplications(status, 30);
+  const items = data?.pages.flatMap((p) => p.content) ?? [];
+
+  if (isDesktop) {
+    return (
+      <Dialog>
+        <DialogTrigger asChild>{trigger}</DialogTrigger>
+        <DialogContent className="flex max-h-[85dvh] w-full max-w-md flex-col" hideCloseButton>
+          <div className="border-border px-s-4 py-s-4 shrink-0 border-b">
+            <DialogTitle className="text-foreground text-base font-bold">
+              가입 신청 내역
+            </DialogTitle>
+          </div>
+          <SheetInner status={status} setStatus={setStatus} items={items} isLoading={isLoading} />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <BottomSheet>
+      <BottomSheetTrigger asChild>{trigger}</BottomSheetTrigger>
+      <BottomSheetContent
+        style={{ height: 'calc(100dvh - 3rem)', maxHeight: 'calc(100dvh - 3rem)' }}
+      >
+        <BottomSheetTitle className="sr-only">가입 신청 내역</BottomSheetTitle>
+        <div className="border-border px-s-4 py-s-3 shrink-0 border-b">
+          <span className="text-foreground text-base font-bold">가입 신청 내역</span>
+        </div>
+        <SheetInner status={status} setStatus={setStatus} items={items} isLoading={isLoading} />
+      </BottomSheetContent>
+    </BottomSheet>
+  );
+}

--- a/src/domain/band/hooks/useApplyBand.ts
+++ b/src/domain/band/hooks/useApplyBand.ts
@@ -18,6 +18,7 @@ export function useApplyBand(bandId: string, options?: UseApplyBandOptions) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
       queryClient.invalidateQueries({ queryKey: queryKeys.band.myApplication(bandId) });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.all, 'my-applications'] });
       options?.onSuccess?.();
     },
     onError: options?.onError,

--- a/src/domain/band/hooks/useApplyBand.ts
+++ b/src/domain/band/hooks/useApplyBand.ts
@@ -17,6 +17,7 @@ export function useApplyBand(bandId: string, options?: UseApplyBandOptions) {
     mutationFn: () => applyBand(bandId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.band.myApplication(bandId) });
       options?.onSuccess?.();
     },
     onError: options?.onError,

--- a/src/domain/band/hooks/useDecideApplication.ts
+++ b/src/domain/band/hooks/useDecideApplication.ts
@@ -22,9 +22,8 @@ export function useDecideApplication(bandId: string, options?: UseDecideApplicat
   return useMutation<void, Error, Variables>({
     mutationFn: ({ applicationId, decision }) => decideApplication(bandId, applicationId, decision),
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: [...queryKeys.band.detail(bandId), 'applications'],
-      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.band.applications(bandId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.band.myApplication(bandId) });
       queryClient.invalidateQueries({ queryKey: [...queryKeys.band.members(bandId)] });
       options?.onSuccess?.(variables);
     },

--- a/src/domain/band/hooks/useMyApplicationForBand.ts
+++ b/src/domain/band/hooks/useMyApplicationForBand.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getMyApplicationForBand } from '../api/getMyApplicationForBand';
+import type { BandApplicationInfoResponse } from '../types';
+
+export function useMyApplicationForBand(bandId: string) {
+  return useQuery<BandApplicationInfoResponse | null>({
+    queryKey: queryKeys.band.myApplication(bandId),
+    queryFn: () => getMyApplicationForBand(bandId),
+    enabled: !!bandId,
+  });
+}

--- a/src/domain/band/hooks/useMyBandApplications.ts
+++ b/src/domain/band/hooks/useMyBandApplications.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import type { ApplicationStatus } from '@/global/types';
+import { useInfiniteCursor } from '@/hooks/useInfiniteCursor';
+
+import { getMyBandApplications } from '../api/getMyBandApplications';
+import type { MyBandApplicationResponse } from '../types/res';
+
+export function useMyBandApplications(status?: ApplicationStatus, pageSize: number = 20) {
+  return useInfiniteCursor<MyBandApplicationResponse, string>(
+    [...queryKeys.band.myApplications(status), pageSize],
+    ({ lastId, pageSize: size }) => getMyBandApplications({ status, lastId, pageSize: size }),
+    pageSize,
+  );
+}

--- a/src/domain/band/hooks/useWithdrawApplication.ts
+++ b/src/domain/band/hooks/useWithdrawApplication.ts
@@ -18,6 +18,7 @@ export function useWithdrawApplication(bandId: string, options?: UseWithdrawAppl
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
       queryClient.invalidateQueries({ queryKey: queryKeys.band.myApplication(bandId) });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.band.all, 'my-applications'] });
       options?.onSuccess?.();
     },
     onError: options?.onError,

--- a/src/domain/band/hooks/useWithdrawApplication.ts
+++ b/src/domain/band/hooks/useWithdrawApplication.ts
@@ -17,6 +17,7 @@ export function useWithdrawApplication(bandId: string, options?: UseWithdrawAppl
     mutationFn: () => withdrawApplication(bandId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...queryKeys.band.detail(bandId)] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.band.myApplication(bandId) });
       options?.onSuccess?.();
     },
     onError: options?.onError,

--- a/src/domain/band/types/index.ts
+++ b/src/domain/band/types/index.ts
@@ -5,6 +5,7 @@ export type {
   MyBandInfoResponse,
   BandMemberInfoResponse,
   BandApplicationInfoResponse,
+  MyBandApplicationResponse,
 } from './res';
 export { createBandSchema } from './schema';
 export type { CreateBandSchema } from './schema';

--- a/src/domain/band/types/res.ts
+++ b/src/domain/band/types/res.ts
@@ -37,3 +37,13 @@ export interface BandApplicationInfoResponse {
   /** 신청 일시. 동일 사유. */
   appliedAt?: string;
 }
+
+/** GET /api/v1/band-applications/me 응답 항목 — 내 밴드 가입 신청 목록 */
+export interface MyBandApplicationResponse {
+  bandApplicationId: string;
+  bandId: string;
+  bandName: string;
+  bandProfileImg?: string;
+  status: ApplicationStatus;
+  appliedAt?: string;
+}

--- a/src/global/config/queryKeys.ts
+++ b/src/global/config/queryKeys.ts
@@ -18,6 +18,8 @@ export const queryKeys = {
     applications: (id: string, status?: string) =>
       [...queryKeys.band.all, id, 'applications', status ?? null] as const,
     myApplication: (id: string) => [...queryKeys.band.all, id, 'my-application'] as const,
+    myApplications: (status?: string) =>
+      [...queryKeys.band.all, 'my-applications', status ?? null] as const,
   },
   jam: {
     all: ['jam'] as const,

--- a/src/global/config/queryKeys.ts
+++ b/src/global/config/queryKeys.ts
@@ -17,6 +17,7 @@ export const queryKeys = {
     members: (id: string) => [...queryKeys.band.all, id, 'members'] as const,
     applications: (id: string, status?: string) =>
       [...queryKeys.band.all, id, 'applications', status ?? null] as const,
+    myApplication: (id: string) => [...queryKeys.band.all, id, 'my-application'] as const,
   },
   jam: {
     all: ['jam'] as const,


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-169](https://sunwoo1137.atlassian.net/browse/BD-169)

📌 **작업 내용 및 특이사항**

- 밴드 상세 화면에서 대기중인 가입 신청 건에 대해 **가입 철회** 버튼 노출 (`UserMinus` 아이콘)
- `GET /api/v1/bands/{bandId}/applications/me` API 연동 (`useMyApplicationForBand`)
- 밴드 목록(내밴드/탐색 탭) 옆 **가입 신청 내역** 버튼 추가
  - PC: 텍스트 버튼 → Dialog (`max-h-[85dvh]`)
  - 모바일: 아이콘 버튼 → BottomSheet (상단 여백 포함 전체화면)
- `GET /api/v1/band-applications/me` API 연동, 상태 필터(전체/대기중/승인됨/거절됨) 지원
- 가입 신청 및 철회 성공 시 `myApplications` 쿼리 즉시 무효화 → 내역 실시간 반영
- `useDecideApplication` queryKey 버그 수정 (`band.applications(bandId)` 정상 참조)

📚 **참고사항**

- `domain-icons.tsx`의 `setlist-meeting` → `track-selection` 리네임은 별도 커밋 예정
- `src/middleware.ts` 변경은 본 PR에 미포함

[BD-169]: https://sunwoo1137.atlassian.net/browse/BD-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ