### PR TITLE
chore: fe-areas.json에 member-availability 영역 추가

### DIFF
--- a/fe-areas.json
+++ b/fe-areas.json
@@ -19,6 +19,14 @@
       "status": "active"
     },
     {
+      "id": "member-availability",
+      "label": "멤버 가용성",
+      "routes": ["/me"],
+      "endpointPrefixes": ["/api/v1/me/availability"],
+      "status": "active",
+      "notes": "글로벌 가용성(주간 규칙/예외/슬롯 조회). longest-prefix match로 member 영역보다 우선 귀속."
+    },
+    {
       "id": "band",
       "label": "밴드",
       "routes": ["/bands"],


### PR DESCRIPTION
## 🛠️ Issue Number

📌 **작업 내용 및 특이사항**

- `fe-areas.json`에 `member-availability` 영역 추가
- `endpointPrefixes: ["/api/v1/me/availability"]` 설정으로 `member` 영역(`/api/v1/me`)보다 longest-prefix match 우선 적용
- MCP `check_impacting_changes(fe_area="member-availability")` 호출 시 가용성 관련 BE 변경사항만 격리 조회 가능

📚 **참고사항**

- MCP 서버는 develop 브랜치 기준으로 읽으므로 이 PR 머지 후 `member-availability` 영역 MCP 조회 활성화됨
- `member-availability` UI 작업 브랜치(`feat/BD-94-performance-list-detail-ui` 또는 신규 브랜치)에서 이 PR 머지 후 MCP 영향평가 재수행 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)