### PR TITLE
[BD-146] fix: 멤버 글로벌 가용성 UI 개선 및 API 연동

### DIFF
--- a/src/app/(main)/me/MeContent.client.tsx
+++ b/src/app/(main)/me/MeContent.client.tsx
@@ -89,7 +89,7 @@ export function MeContent() {
       exceptions,
       note,
       effectiveFrom,
-      effectiveTo: effectiveTo || null,
+      effectiveTo,
     });
   };
 

--- a/src/domain/member/api/getMyAvailabilitySlots.ts
+++ b/src/domain/member/api/getMyAvailabilitySlots.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { ScheduleSlotResponse } from '../types';
+
+export async function getMyAvailabilitySlots(
+  from: string,
+  to: string,
+): Promise<ScheduleSlotResponse[]> {
+  const data = await apiClient.get<ScheduleSlotResponse[] | null>('/api/v1/me/availability/slots', {
+    query: { from, to },
+  });
+  return data ?? [];
+}

--- a/src/domain/member/components/ScheduleManagerModal.client.tsx
+++ b/src/domain/member/components/ScheduleManagerModal.client.tsx
@@ -3,7 +3,7 @@
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import { Check, Plus, Trash2, X } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { DatePicker } from '@/components/ui/date-picker';
@@ -63,7 +63,6 @@ function emptyGrid(): GridState {
 function availabilityToGrid(availability: MemberAvailabilityResponse | undefined): GridState {
   const grid = emptyGrid();
   if (!availability) return grid;
-
   for (const rule of availability.weeklyRules) {
     const dayIdx = DAY_OF_WEEK_KEYS.indexOf(rule.dayOfWeek);
     if (dayIdx === -1) continue;
@@ -99,6 +98,15 @@ function hasAnySelected(grid: GridState): boolean {
   return grid.some((day) => day.some(Boolean));
 }
 
+type Tab = 'period' | 'schedule' | 'exception' | 'note';
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: 'period', label: '기간' },
+  { key: 'schedule', label: '시간대' },
+  { key: 'exception', label: '예외 날짜 (선택)' },
+  { key: 'note', label: '특이사항 (선택)' },
+];
+
 type Props = {
   open: boolean;
   onClose: () => void;
@@ -115,8 +123,9 @@ type Props = {
 
 export function ScheduleManagerModal({ open, onClose, availability, onSave, isSaving }: Props) {
   const today = format(toZonedTime(new Date(), KST), 'yyyy-MM-dd');
+  const isNew = !availability?.updatedAt;
 
-  const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
+  const [activeTab, setActiveTab] = useState<Tab>('period');
   const [effectiveFrom, setEffectiveFrom] = useState(today);
   const [effectiveTo, setEffectiveTo] = useState('');
   const [grid, setGrid] = useState<GridState>(emptyGrid);
@@ -129,19 +138,21 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
   const [newExcStartTime, setNewExcStartTime] = useState('09:00');
   const [newExcEndTime, setNewExcEndTime] = useState('18:00');
 
-  const dragState = useRef<{
-    active: boolean;
-    dayIdx: number;
-    painting: boolean;
-  } | null>(null);
+  const dragState = {
+    current: null as { active: boolean; dayIdx: number; painting: boolean } | null,
+  };
 
   useEffect(() => {
     if (open) {
-      setStep(1);
+      setActiveTab('period');
       const firstRule = availability?.weeklyRules[0];
       setEffectiveFrom(firstRule?.effectiveFrom ?? today);
       setEffectiveTo(firstRule?.effectiveTo ?? '');
-      setGrid(availabilityToGrid(availability));
+      setGrid(
+        isNew
+          ? Array.from({ length: 7 }, () => Array(SLOT_COUNT).fill(true))
+          : availabilityToGrid(availability),
+      );
       setExceptions(availability?.exceptions ?? []);
       setNote(availability?.note ?? '');
       setNewExcDate('');
@@ -188,7 +199,10 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
     setNewExcDate('');
   };
 
+  const canSave = !!effectiveFrom && !!effectiveTo && hasAnySelected(grid);
+
   const handleSave = () => {
+    if (!canSave) return;
     onSave(gridToWeeklyRules(grid), note, exceptions, effectiveFrom, effectiveTo);
   };
 
@@ -208,31 +222,52 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
         style={{ maxHeight: '90vh' }}
       >
         {/* 헤더 */}
-        <div className="shrink-0 px-5 pt-5">
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-foreground-sub hover:text-foreground absolute top-4 right-4"
-            aria-label="닫기"
-          >
-            <X className="h-5 w-5" />
-          </button>
-          <h3 className="text-foreground mb-1 text-[17px] font-bold">
-            나의 스케줄 관리{' '}
-            <span className="text-foreground-muted text-caption font-normal">({step}/4)</span>
-          </h3>
+        <div className="border-border shrink-0 border-b px-5 pt-5 pb-0">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-foreground text-[17px] font-bold">나의 스케줄 관리</h3>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-foreground-sub hover:text-foreground"
+              aria-label="닫기"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          {/* 탭 바 */}
+          <div className="flex">
+            {TABS.map(({ key, label }) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setActiveTab(key)}
+                className={cn(
+                  'px-3 pb-2 text-[13px] font-medium transition-colors',
+                  activeTab === key
+                    ? 'text-foreground border-foreground border-b-2'
+                    : 'text-foreground-muted hover:text-foreground-sub',
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
 
-        {/* Step 1: 기간 선택 */}
-        {step === 1 && (
-          <>
-            <div className="flex-1 overflow-y-auto px-5 pt-1 pb-2">
-              <p className="text-foreground-sub mb-4 text-[12px]">
+        {/* 탭 콘텐츠 */}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {/* 기간 탭 */}
+          {activeTab === 'period' && (
+            <div className="space-y-3 px-5 py-4">
+              <p className="text-foreground-sub text-[12px]">
                 이 스케줄이 적용될 기간을 선택해주세요
               </p>
               <div className="space-y-3">
                 <div className="grid grid-cols-[64px_1fr] items-center gap-3">
-                  <span className="text-foreground-sub text-[13px]">시작일</span>
+                  <span className="text-foreground-sub text-[13px]">
+                    시작일 <span className="text-red-400">*</span>
+                  </span>
                   <DatePicker
                     value={effectiveFrom}
                     min={today}
@@ -241,54 +276,51 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                   />
                 </div>
                 <div className="grid grid-cols-[64px_1fr] items-center gap-3">
-                  <span className="text-foreground-sub text-[13px]">종료일</span>
+                  <span className="text-foreground-sub text-[13px]">
+                    종료일 <span className="text-red-400">*</span>
+                  </span>
                   <DatePicker
                     value={effectiveTo}
                     min={effectiveFrom || today}
                     onChange={setEffectiveTo}
-                    placeholder="종료일 선택 (선택)"
+                    placeholder="종료일 선택"
                   />
                 </div>
                 <p className="text-foreground-muted text-micro">
                   {effectiveTo
                     ? `* ${effectiveFrom} ~ ${effectiveTo} 기간에 적용됩니다`
-                    : '* 종료일 미입력 시 무기한 적용됩니다'}
+                    : '* 종료일을 선택해주세요'}
                 </p>
               </div>
             </div>
-            <div className="flex shrink-0 justify-end px-5 pt-3 pb-5">
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setStep(2)}
-                disabled={!effectiveFrom}
-                className="rounded-[5px]"
-              >
-                다음
-              </Button>
-            </div>
-          </>
-        )}
+          )}
 
-        {/* Step 2: 주간 타임테이블 */}
-        {step === 2 && (
-          <>
-            <div className="shrink-0 px-5 pt-1">
-              <p className="text-foreground-sub mb-3 text-[12px]">
-                주간 가능 시간대를 모두 채워주세요
-              </p>
-              <div className="mb-2 flex justify-end">
-                <button
-                  type="button"
-                  onClick={() => setGrid(emptyGrid())}
-                  className="text-foreground-sub border-border text-micro rounded border px-2 py-0.5"
-                >
-                  스케줄 초기화
-                </button>
+          {/* 시간대 탭 */}
+          {activeTab === 'schedule' && (
+            <div className="px-5 py-4">
+              <div className="mb-3 flex items-center justify-between">
+                <p className="text-foreground-sub text-[12px]">
+                  주간 가능 시간대를 모두 표시해주세요 <span className="text-red-400">*</span>
+                </p>
+                <div className="flex items-center gap-3">
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-3 w-3 rounded-sm bg-[#e8856a]" />
+                    <span className="text-foreground-muted text-micro">가능</span>
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-3 w-3 rounded-full border border-white/40" />
+                    <span className="text-foreground-muted text-micro">불가</span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setGrid(emptyGrid())}
+                    className="text-foreground-sub border-border text-micro rounded border px-2 py-0.5"
+                  >
+                    초기화
+                  </button>
+                </div>
               </div>
-            </div>
 
-            <div className="min-h-0 flex-1 overflow-y-auto px-5">
               <div className="overflow-x-auto select-none" onPointerLeave={handlePointerUp}>
                 <div className="min-w-[320px]">
                   <div className="grid" style={{ gridTemplateColumns: '36px repeat(7, 1fr)' }}>
@@ -359,45 +391,17 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                   </div>
                 </div>
               </div>
-            </div>
-
-            <div className="shrink-0 px-5 pb-5">
               <p className="text-foreground-muted text-micro mt-2.5">* 셀 1칸 당 30분 단위입니다</p>
-              <p className="text-foreground-muted text-micro">
-                * 입력한 주간 가능 시간대는 향후 전 주 동일 적용됩니다
-              </p>
-              <div className="mt-4 flex justify-between">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setStep(1)}
-                  className="rounded-[5px]"
-                >
-                  이전
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => setStep(3)}
-                  disabled={!hasAnySelected(grid)}
-                  className="rounded-[5px]"
-                >
-                  다음
-                </Button>
-              </div>
             </div>
-          </>
-        )}
+          )}
 
-        {/* Step 3: 예외 날짜 */}
-        {step === 3 && (
-          <>
-            <div className="flex-1 space-y-4 overflow-y-auto px-5 pt-1 pb-2">
+          {/* 예외 날짜 탭 */}
+          {activeTab === 'exception' && (
+            <div className="space-y-4 px-5 py-4">
               <p className="text-foreground-sub text-[12px]">
-                위 규칙과 다른 날짜가 있으면 추가해주세요 (선택)
+                위 규칙과 다른 날짜가 있으면 추가해주세요
               </p>
 
-              {/* 추가 폼 */}
               <div className="border-border space-y-3 rounded-md border p-3">
                 <div className="grid grid-cols-[52px_1fr] items-center gap-2">
                   <span className="text-foreground-sub text-[12px]">날짜</span>
@@ -531,7 +535,6 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                 </div>
               </div>
 
-              {/* 예외 목록 */}
               {exceptions.length > 0 && (
                 <ul className="space-y-2">
                   {exceptions.map((exc) => (
@@ -570,32 +573,11 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
                 </ul>
               )}
             </div>
+          )}
 
-            <div className="flex shrink-0 justify-between px-5 pt-3 pb-5">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setStep(2)}
-                className="rounded-[5px]"
-              >
-                이전
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setStep(4)}
-                className="rounded-[5px]"
-              >
-                다음
-              </Button>
-            </div>
-          </>
-        )}
-
-        {/* Step 4: 특이사항 */}
-        {step === 4 && (
-          <>
-            <div className="px-5 pb-5">
+          {/* 메모 탭 */}
+          {activeTab === 'note' && (
+            <div className="px-5 py-4">
               <p className="text-foreground-sub mb-3 text-[12px]">특이사항을 적어주세요</p>
               <Textarea
                 value={note}
@@ -607,28 +589,23 @@ export function ScheduleManagerModal({ open, onClose, availability, onSave, isSa
               <p className="text-foreground-muted mt-1 text-right text-[12px]">
                 {note.length}/500자
               </p>
-              <div className="mt-3 flex justify-between">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setStep(3)}
-                  className="rounded-[5px]"
-                >
-                  이전
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={handleSave}
-                  loading={isSaving}
-                  className="rounded-[5px]"
-                >
-                  완료
-                </Button>
-              </div>
             </div>
-          </>
-        )}
+          )}
+        </div>
+
+        {/* 푸터 */}
+        <div className="flex shrink-0 justify-end px-5 py-4">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleSave}
+            loading={isSaving}
+            disabled={!canSave}
+            className="rounded-[5px]"
+          >
+            {isNew ? '등록' : '수정'}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/domain/member/components/WeeklyTimetable.client.tsx
+++ b/src/domain/member/components/WeeklyTimetable.client.tsx
@@ -20,9 +20,187 @@ const SLOT_COUNT = END_SLOT - START_SLOT;
 const CELL_HEIGHT = 20; // px per 30-min slot
 
 const DAY_SHORT = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+const DAY_KO = ['월', '화', '수', '목', '금', '토', '일'];
+
+const DAY_OF_WEEK_ORDER = [
+  'MONDAY',
+  'TUESDAY',
+  'WEDNESDAY',
+  'THURSDAY',
+  'FRIDAY',
+  'SATURDAY',
+  'SUNDAY',
+] as const;
 
 function slotToHourLabel(slot: number): string {
   return `${Math.floor(slot / 2)}:00`;
+}
+
+function slotToTimeStr(slot: number): string {
+  const h = Math.floor(slot / 2)
+    .toString()
+    .padStart(2, '0');
+  const m = slot % 2 === 0 ? '00' : '30';
+  return `${h}:${m}`;
+}
+
+type SummaryTab = 'weekly' | 'exception' | 'schedule';
+
+function ScheduleSummaryTabs({
+  availability,
+  practices,
+  performances,
+}: {
+  availability: MemberAvailabilityResponse | undefined;
+  practices: JamListItemResponse[];
+  performances: PerformanceListItemResponse[];
+}) {
+  const [tab, setTab] = useState<SummaryTab>('weekly');
+
+  const TABS: { key: SummaryTab; label: string }[] = [
+    { key: 'weekly', label: '위클리 규칙' },
+    { key: 'exception', label: '예외 날짜' },
+    { key: 'schedule', label: '일정' },
+  ];
+
+  const weeklyRules = availability?.weeklyRules ?? [];
+  const exceptions = availability?.exceptions ?? [];
+
+  const allEvents = [
+    ...practices.map((p) => ({ title: p.title, startAt: p.startAt, type: 'practice' as const })),
+    ...performances.map((p) => ({
+      title: p.title,
+      startAt: p.startAt,
+      type: 'performance' as const,
+    })),
+  ].sort((a, b) => a.startAt.localeCompare(b.startAt));
+
+  type DayKey = (typeof DAY_OF_WEEK_ORDER)[number];
+  const rulesByDay = DAY_OF_WEEK_ORDER.reduce(
+    (acc, day) => {
+      acc[day] = weeklyRules.filter((r) => r.dayOfWeek === day);
+      return acc;
+    },
+    {} as Record<DayKey, typeof weeklyRules>,
+  );
+
+  return (
+    <div className="border-border mb-[50px] rounded-md border">
+      {/* 탭 헤더 */}
+      <div className="border-border flex border-b">
+        {TABS.map(({ key, label }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setTab(key)}
+            className={cn(
+              'px-4 py-2 text-sm font-medium transition-colors',
+              tab === key
+                ? 'text-foreground border-foreground border-b-2'
+                : 'text-foreground-muted hover:text-foreground-sub',
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* 탭 콘텐츠 — 위클리는 스크롤 없이 7행 전체 표시 */}
+      <div
+        className="divide-border divide-y"
+        style={tab !== 'weekly' ? { maxHeight: 180, overflowY: 'auto' } : undefined}
+      >
+        {/* 위클리 규칙 — 월~일 7행 고정 */}
+        {tab === 'weekly' &&
+          DAY_OF_WEEK_ORDER.map((day, i) => {
+            const rules = rulesByDay[day] ?? [];
+            return (
+              <div key={day} className="flex items-center gap-3 px-4 py-2 text-sm">
+                <span
+                  className={cn(
+                    'w-5 shrink-0 font-medium',
+                    i === 5 ? 'text-[#60a5fa]' : i === 6 ? 'text-[#f87171]' : 'text-foreground',
+                  )}
+                >
+                  {DAY_KO[i]}
+                </span>
+                <span className="text-foreground-sub flex-1">
+                  {rules.length === 0 ? (
+                    <span className="text-foreground-muted">-</span>
+                  ) : (
+                    rules.map((r, ri) => (
+                      <span key={ri}>
+                        {ri > 0 && <span className="text-foreground-muted mx-1.5">·</span>}
+                        {slotToTimeStr(r.startSlot)}~{slotToTimeStr(r.endSlot)}
+                      </span>
+                    ))
+                  )}
+                </span>
+                {rules.length > 0 && (
+                  <span className="text-foreground-muted shrink-0 text-xs">
+                    {rules[0]!.effectiveFrom}
+                    {rules[0]!.effectiveTo ? ` ~ ${rules[0]!.effectiveTo}` : ' ~'}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+
+        {/* 예외 날짜 */}
+        {tab === 'exception' &&
+          (exceptions.length === 0 ? (
+            <p className="text-foreground-muted px-4 py-3 text-sm">등록된 예외 날짜가 없습니다.</p>
+          ) : (
+            exceptions.map((exc, i) => (
+              <div key={i} className="flex items-center gap-3 px-4 py-2 text-sm">
+                <span className="text-foreground w-24 shrink-0 font-medium">{exc.date}</span>
+                <span
+                  className={cn(
+                    'shrink-0 font-medium',
+                    exc.kind === 'AVAILABLE' ? 'text-foreground' : 'text-foreground-muted',
+                  )}
+                >
+                  {exc.kind === 'AVAILABLE' ? '가능' : '불가'}
+                </span>
+                <span className="text-foreground-muted flex-1 text-right">
+                  {exc.startSlot != null && exc.endSlot != null
+                    ? `${slotToTimeStr(exc.startSlot)} ~ ${slotToTimeStr(exc.endSlot)}`
+                    : '하루 종일'}
+                </span>
+              </div>
+            ))
+          ))}
+
+        {/* 일정 */}
+        {tab === 'schedule' &&
+          (allEvents.length === 0 ? (
+            <p className="text-foreground-muted px-4 py-3 text-sm">등록된 일정이 없습니다.</p>
+          ) : (
+            allEvents.map((ev, i) => {
+              const [date, time] = ev.startAt.split(' ');
+              return (
+                <div key={i} className="flex items-center gap-3 px-4 py-2 text-sm">
+                  <span
+                    className={cn(
+                      'shrink-0 rounded px-1.5 py-0.5 text-xs font-medium',
+                      ev.type === 'practice'
+                        ? 'bg-[#4ade80]/10 text-[#4ade80]'
+                        : 'bg-[#60a5fa]/10 text-[#60a5fa]',
+                    )}
+                  >
+                    {ev.type === 'practice' ? '합주' : '공연'}
+                  </span>
+                  <span className="text-foreground min-w-0 flex-1 truncate">{ev.title}</span>
+                  <span className="text-foreground-muted shrink-0">
+                    {date} {time?.slice(0, 5)}
+                  </span>
+                </div>
+              );
+            })
+          ))}
+      </div>
+    </div>
+  );
 }
 
 function startAtToSlot(startAt: string): number {
@@ -156,33 +334,68 @@ export function WeeklyTimetable({
 
   return (
     <section className="mt-15">
-      <div className="mb-s-3 relative flex items-center justify-center">
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => setWeekOffset((o) => o - 1)}
-            className="text-foreground-sub hover:text-foreground"
-            aria-label="이전 주"
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </button>
-          <p className="text-foreground-sub text-sm">{weekLabel}</p>
-          <button
-            type="button"
-            onClick={() => setWeekOffset((o) => o + 1)}
-            className="text-foreground-sub hover:text-foreground"
-            aria-label="다음 주"
-          >
-            <ChevronRight className="h-4 w-4" />
-          </button>
-        </div>
+      <div className="mb-s-3 relative flex min-h-8 items-center">
+        <h2 className="text-foreground-sub text-title flex-1 font-bold">스케줄 정보</h2>
         <button
           type="button"
           onClick={onManageSchedule}
-          className="text-foreground border-border absolute right-0 shrink-0 rounded-[5px] border px-3 py-1 text-sm font-medium"
+          className="text-foreground border-border shrink-0 rounded-[5px] border px-3 py-1 text-sm font-medium"
         >
           나의 스케줄 관리
         </button>
+      </div>
+
+      <ScheduleSummaryTabs
+        availability={availability}
+        practices={practices}
+        performances={performances}
+      />
+
+      {/* 주간 네비 + 합주/공연 토글 */}
+      <div className="mb-s-3 relative flex items-center justify-center">
+        <button
+          type="button"
+          onClick={() => setWeekOffset((o) => o - 1)}
+          className="text-foreground-sub hover:text-foreground"
+          aria-label="이전 주"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <p className="text-foreground-sub mx-2 text-sm">{weekLabel}</p>
+        <button
+          type="button"
+          onClick={() => setWeekOffset((o) => o + 1)}
+          className="text-foreground-sub hover:text-foreground"
+          aria-label="다음 주"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+        <div className="absolute right-0 flex gap-2">
+          <button
+            type="button"
+            onClick={() => setShowPractice((v) => !v)}
+            className={cn(
+              'rounded-full border px-3 py-0.5 text-sm font-medium transition-colors',
+              showPractice
+                ? 'border-[#4ade80] bg-[#4ade80]/10 text-[#4ade80]'
+                : 'border-border text-foreground-muted',
+            )}
+          >
+            합주 표시
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowPerformance((v) => !v)}
+            className={cn(
+              'rounded-full border px-3 py-0.5 text-sm font-medium transition-colors',
+              showPerformance
+                ? 'border-[#60a5fa] bg-[#60a5fa]/10 text-[#60a5fa]'
+                : 'border-border text-foreground-muted',
+            )}
+          >
+            공연 표시
+          </button>
+        </div>
       </div>
 
       <div className="border-border rounded-md border">
@@ -281,33 +494,6 @@ export function WeeklyTimetable({
             </div>
           ))}
         </div>
-      </div>
-
-      <div className="mt-4 flex items-center gap-3">
-        <button
-          type="button"
-          onClick={() => setShowPractice((v) => !v)}
-          className={cn(
-            'rounded-full border px-3.5 py-1 text-sm font-medium transition-colors',
-            showPractice
-              ? 'border-[#4ade80] bg-[#4ade80]/10 text-[#4ade80]'
-              : 'border-border text-foreground-muted',
-          )}
-        >
-          합주 표시
-        </button>
-        <button
-          type="button"
-          onClick={() => setShowPerformance((v) => !v)}
-          className={cn(
-            'rounded-full border px-3.5 py-1 text-sm font-medium transition-colors',
-            showPerformance
-              ? 'border-[#60a5fa] bg-[#60a5fa]/10 text-[#60a5fa]'
-              : 'border-border text-foreground-muted',
-          )}
-        >
-          공연 표시
-        </button>
       </div>
     </section>
   );

--- a/src/domain/member/components/WeeklyTimetable.client.tsx
+++ b/src/domain/member/components/WeeklyTimetable.client.tsx
@@ -4,29 +4,21 @@ import { addDays, format, startOfWeek } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { toZonedTime } from 'date-fns-tz';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 import type { PerformanceListItemResponse } from '@/domain/performance/types';
 import type { JamListItemResponse } from '@/domain/jam/types';
 import { cn } from '@/lib/cn';
 import { KST } from '@/lib/date';
 
-import type { DayOfWeek, MemberAvailabilityResponse } from '../types';
+import { useMyAvailabilitySlots } from '../hooks/useMyAvailabilitySlots';
+import type { MemberAvailabilityResponse, ScheduleSlotResponse } from '../types';
 
 const START_SLOT = 18; // 9:00
 const END_SLOT = 44; // 22:00
 const SLOT_COUNT = END_SLOT - START_SLOT;
 const CELL_HEIGHT = 20; // px per 30-min slot
 
-const DAY_OF_WEEK_KEYS: DayOfWeek[] = [
-  'MONDAY',
-  'TUESDAY',
-  'WEDNESDAY',
-  'THURSDAY',
-  'FRIDAY',
-  'SATURDAY',
-  'SUNDAY',
-];
 const DAY_SHORT = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 
 function slotToHourLabel(slot: number): string {
@@ -42,65 +34,22 @@ function startAtToSlot(startAt: string): number {
   return h * 2 + (m >= 30 ? 1 : 0);
 }
 
-function buildAvailabilityMatrix(
-  rules: MemberAvailabilityResponse['weeklyRules'],
-  exceptions: MemberAvailabilityResponse['exceptions'],
-  weekDates: Date[],
-): boolean[][] {
+function slotsToMatrix(slots: ScheduleSlotResponse[], weekDates: Date[]): boolean[][] {
   const matrix: boolean[][] = Array.from({ length: 7 }, () =>
     new Array<boolean>(SLOT_COUNT).fill(false),
   );
-
   const weekDateStrs = weekDates.map((d) => format(d, 'yyyy-MM-dd'));
 
-  // effectiveFrom 이전 날짜는 빈 셀(가능/미설정)로 표시
-  const earliestFrom = rules.reduce<string | null>(
-    (min, r) =>
-      r.effectiveFrom && (min === null || r.effectiveFrom < min) ? r.effectiveFrom : min,
-    null,
-  );
-  if (earliestFrom) {
-    for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
-      const dateStr = weekDateStrs[dayIdx];
-      if (dateStr && dateStr < earliestFrom) matrix[dayIdx]!.fill(true);
-    }
-  }
-
-  // weeklyRules 적용
-  for (const rule of rules) {
-    const dayIdx = DAY_OF_WEEK_KEYS.indexOf(rule.dayOfWeek);
+  for (const slot of slots) {
+    if (slot.type !== 'AVAILABLE') continue;
+    const dayIdx = weekDateStrs.indexOf(slot.date);
     if (dayIdx === -1) continue;
-    const dateStr = weekDateStrs[dayIdx];
-    if (!dateStr) continue;
-    if (!rule.effectiveFrom || dateStr < rule.effectiveFrom) continue;
-    if (rule.effectiveTo && dateStr > rule.effectiveTo) continue;
-
     const row = matrix[dayIdx]!;
-    for (let s = rule.startSlot; s < rule.endSlot; s++) {
+    for (let s = slot.startSlot; s < slot.endSlot; s++) {
       const idx = s - START_SLOT;
       if (idx >= 0 && idx < SLOT_COUNT) row[idx] = true;
     }
   }
-
-  // exceptions 적용 (weeklyRules 위에 덮어쓰기)
-  for (const exc of exceptions) {
-    const dayIdx = weekDateStrs.indexOf(exc.date);
-    if (dayIdx === -1) continue;
-
-    const row = matrix[dayIdx]!;
-    const isAvailable = exc.kind === 'AVAILABLE';
-    const isAllDay = exc.startSlot == null || exc.endSlot == null || exc.startSlot >= exc.endSlot;
-
-    if (isAllDay) {
-      row.fill(isAvailable);
-    } else {
-      for (let s = exc.startSlot!; s < exc.endSlot!; s++) {
-        const idx = s - START_SLOT;
-        if (idx >= 0 && idx < SLOT_COUNT) row[idx] = isAvailable;
-      }
-    }
-  }
-
   return matrix;
 }
 
@@ -110,14 +59,6 @@ type TimetableEvent = {
   startSlot: number;
   slotSpan: number;
   dayIdx: number;
-};
-
-type MockEvent = {
-  id: number;
-  type: 'practice' | 'performance';
-  dayIdx: number;
-  startSlot: number;
-  slotSpan: number;
 };
 
 function buildEvents(
@@ -180,50 +121,32 @@ export function WeeklyTimetable({
   onManageSchedule,
 }: Props) {
   const [weekOffset, setWeekOffset] = useState(0);
-  const [paintPractice, setPaintPractice] = useState(false);
-  const [paintPerformance, setPaintPerformance] = useState(false);
-  const [mockEvents, setMockEvents] = useState<MockEvent[]>([]);
-  const mockIdRef = useRef(0);
-
-  const handleCellClick = (dayIdx: number, e: React.MouseEvent<HTMLDivElement>) => {
-    if (!paintPractice && !paintPerformance) return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    const slot = Math.floor((e.clientY - rect.top) / CELL_HEIGHT);
-    if (slot < 0 || slot >= SLOT_COUNT) return;
-    setMockEvents((prev) => {
-      let next = [...prev];
-      for (const type of (['practice', 'performance'] as const).filter(
-        (t) => (t === 'practice' && paintPractice) || (t === 'performance' && paintPerformance),
-      )) {
-        const existing = next.find(
-          (m) => m.dayIdx === dayIdx && m.startSlot === slot && m.type === type,
-        );
-        if (existing) {
-          next = next.filter((m) => m.id !== existing.id);
-        } else {
-          next = [...next, { id: mockIdRef.current++, type, dayIdx, startSlot: slot, slotSpan: 1 }];
-        }
-      }
-      return next;
-    });
-  };
+  const [showPractice, setShowPractice] = useState(false);
+  const [showPerformance, setShowPerformance] = useState(false);
 
   const now = toZonedTime(new Date(), KST);
   const monday = addDays(startOfWeek(now, { weekStartsOn: 1 }), weekOffset * 7);
   const weekDates: Date[] = Array.from({ length: 7 }, (_, i) => addDays(monday, i));
+
+  const from = format(weekDates[0]!, 'yyyy-MM-dd');
+  const to = format(weekDates[6]!, 'yyyy-MM-dd');
+  const { data: slots } = useMyAvailabilitySlots(from, to);
 
   const weekLabel =
     format(weekDates[0]!, 'yyyy-MM-dd (EEE)', { locale: ko }) +
     ' ~ ' +
     format(weekDates[6]!, 'MM-dd (EEE)', { locale: ko });
 
-  // updatedAt이 null이거나 availability 미로드 시 한 번도 설정한 적 없는 상태 → 전 슬롯 공백
   const neverSet = !availability || availability.updatedAt === null;
   const availMatrix = neverSet
     ? Array.from({ length: 7 }, () => new Array<boolean>(SLOT_COUNT).fill(true))
-    : buildAvailabilityMatrix(availability.weeklyRules, availability.exceptions, weekDates);
-  const events = buildEvents(practices, performances, weekDates);
+    : slotsToMatrix(slots ?? [], weekDates);
 
+  const events = buildEvents(
+    showPractice ? practices : [],
+    showPerformance ? performances : [],
+    weekDates,
+  );
   const eventsByDay: TimetableEvent[][] = Array.from({ length: 7 }, () => []);
   for (const ev of events) eventsByDay[ev.dayIdx]!.push(ev);
 
@@ -263,140 +186,110 @@ export function WeeklyTimetable({
       </div>
 
       <div className="border-border rounded-md border">
-        <div>
-          {/* 요일 헤더 */}
-          <div
-            className="border-border grid border-b"
-            style={{ gridTemplateColumns: '40px repeat(7, 1fr)' }}
-          >
-            <div className="border-border border-r" />
-            {weekDates.map((d, i) => (
-              <div
-                key={i}
-                className="border-border flex flex-col items-center border-r py-1 last:border-r-0"
-              >
-                <span className="text-foreground-sub text-[10px] font-medium">{DAY_SHORT[i]}</span>
-                <span className="text-foreground-muted text-[10px]">{format(d, 'MM-dd')}</span>
-              </div>
-            ))}
-          </div>
-
-          {/* 시간 그리드 */}
-          <div className="relative grid" style={{ gridTemplateColumns: '40px repeat(7, 1fr)' }}>
-            {/* 시간 레이블 */}
-            <div className="border-border relative border-r">
-              {hourSlots.map((slotIdx) => (
-                <span
-                  key={slotIdx}
-                  className="text-foreground-muted absolute right-2 text-right text-[9px] leading-none"
-                  style={{
-                    top: slotIdx * CELL_HEIGHT + (slotIdx === 0 ? 7 : 0),
-                    transform: 'translateY(-50%)',
-                  }}
-                >
-                  {slotToHourLabel(slotIdx + START_SLOT)}
-                </span>
-              ))}
-              <span
-                className="text-foreground-muted absolute right-2 text-right text-[9px] leading-none"
-                style={{ top: SLOT_COUNT * CELL_HEIGHT - 7, transform: 'translateY(-50%)' }}
-              >
-                22:00
-              </span>
-              <div style={{ height: SLOT_COUNT * CELL_HEIGHT }} />
+        {/* 요일 헤더 */}
+        <div
+          className="border-border grid border-b"
+          style={{ gridTemplateColumns: '40px repeat(7, 1fr)' }}
+        >
+          <div className="border-border border-r" />
+          {weekDates.map((d, i) => (
+            <div
+              key={i}
+              className="border-border flex flex-col items-center border-r py-1 last:border-r-0"
+            >
+              <span className="text-foreground-sub text-[10px] font-medium">{DAY_SHORT[i]}</span>
+              <span className="text-foreground-muted text-[10px]">{format(d, 'MM-dd')}</span>
             </div>
+          ))}
+        </div>
 
-            {/* 요일별 컬럼 */}
-            {weekDates.map((_, dayIdx) => (
-              <div
-                key={dayIdx}
-                className={cn(
-                  'border-border relative border-r last:border-r-0',
-                  paintPractice || paintPerformance ? 'cursor-crosshair' : 'cursor-default',
-                )}
-                style={{ height: SLOT_COUNT * CELL_HEIGHT }}
-                onClick={(e) => handleCellClick(dayIdx, e)}
+        {/* 시간 그리드 */}
+        <div className="relative grid" style={{ gridTemplateColumns: '40px repeat(7, 1fr)' }}>
+          {/* 시간 레이블 */}
+          <div className="border-border relative border-r">
+            {hourSlots.map((slotIdx) => (
+              <span
+                key={slotIdx}
+                className="text-foreground-muted absolute right-2 text-right text-[9px] leading-none"
+                style={{
+                  top: slotIdx * CELL_HEIGHT + (slotIdx === 0 ? 7 : 0),
+                  transform: 'translateY(-50%)',
+                }}
               >
-                {hourSlots.map((slotIdx) => (
-                  <div
-                    key={slotIdx}
-                    className="border-border absolute right-0 left-0 border-t"
-                    style={{ top: slotIdx * CELL_HEIGHT }}
-                  />
-                ))}
-
-                {/* 불가 시간대 — 회색 블록 */}
-                {buildUnavailableBlocks(availMatrix[dayIdx]!).map((block, bi) => (
-                  <div
-                    key={bi}
-                    className="bg-foreground-sub/80 absolute right-0 left-0"
-                    style={{
-                      top: block.start * CELL_HEIGHT,
-                      height: block.length * CELL_HEIGHT,
-                    }}
-                  />
-                ))}
-
-                {/* 이벤트 블록 */}
-                {eventsByDay[dayIdx]!.map((ev, ei) => {
-                  const clippedStart = Math.max(0, ev.startSlot);
-                  const clippedEnd = Math.min(SLOT_COUNT, ev.startSlot + ev.slotSpan);
-                  const height = Math.max(CELL_HEIGHT, (clippedEnd - clippedStart) * CELL_HEIGHT);
-                  return (
-                    <div
-                      key={ei}
-                      onClick={(e) => e.stopPropagation()}
-                      className={cn(
-                        'absolute right-0 left-0 overflow-hidden rounded-sm px-1 py-0.5',
-                        ev.type === 'practice'
-                          ? 'bg-[#4ade80]/20 text-[#4ade80]'
-                          : 'bg-[#60a5fa]/20 text-[#60a5fa]',
-                      )}
-                      style={{ top: clippedStart * CELL_HEIGHT, height }}
-                    >
-                      <p className="text-[9px] leading-tight font-semibold">
-                        {ev.type === 'practice' ? '합주' : '공연'}
-                      </p>
-                      <p className="truncate text-[9px] leading-tight">{ev.title}</p>
-                    </div>
-                  );
-                })}
-
-                {/* 임시 이벤트 블록 */}
-                {mockEvents
-                  .filter(
-                    (me) =>
-                      me.dayIdx === dayIdx &&
-                      ((me.type === 'practice' && paintPractice) ||
-                        (me.type === 'performance' && paintPerformance)),
-                  )
-                  .map((me) => (
-                    <div
-                      key={me.id}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setMockEvents((prev) => prev.filter((m) => m.id !== me.id));
-                      }}
-                      className={cn(
-                        'absolute right-0 left-0 cursor-pointer overflow-hidden',
-                        me.type === 'practice' ? 'bg-[#4ade80]/60' : 'bg-[#60a5fa]/60',
-                      )}
-                      style={{ top: me.startSlot * CELL_HEIGHT, height: me.slotSpan * CELL_HEIGHT }}
-                    />
-                  ))}
-              </div>
+                {slotToHourLabel(slotIdx + START_SLOT)}
+              </span>
             ))}
+            <span
+              className="text-foreground-muted absolute right-2 text-right text-[9px] leading-none"
+              style={{ top: SLOT_COUNT * CELL_HEIGHT - 7, transform: 'translateY(-50%)' }}
+            >
+              22:00
+            </span>
+            <div style={{ height: SLOT_COUNT * CELL_HEIGHT }} />
           </div>
+
+          {/* 요일별 컬럼 */}
+          {weekDates.map((_, dayIdx) => (
+            <div
+              key={dayIdx}
+              className="border-border relative border-r last:border-r-0"
+              style={{ height: SLOT_COUNT * CELL_HEIGHT }}
+            >
+              {hourSlots.map((slotIdx) => (
+                <div
+                  key={slotIdx}
+                  className="border-border absolute right-0 left-0 border-t"
+                  style={{ top: slotIdx * CELL_HEIGHT }}
+                />
+              ))}
+
+              {/* 불가 시간대 — 회색 블록 */}
+              {buildUnavailableBlocks(availMatrix[dayIdx]!).map((block, bi) => (
+                <div
+                  key={bi}
+                  className="bg-foreground-sub/80 absolute right-0 left-0"
+                  style={{
+                    top: block.start * CELL_HEIGHT,
+                    height: block.length * CELL_HEIGHT,
+                  }}
+                />
+              ))}
+
+              {/* 합주/공연 이벤트 블록 */}
+              {eventsByDay[dayIdx]!.map((ev, ei) => {
+                const clippedStart = Math.max(0, ev.startSlot);
+                const clippedEnd = Math.min(SLOT_COUNT, ev.startSlot + ev.slotSpan);
+                const height = Math.max(CELL_HEIGHT, (clippedEnd - clippedStart) * CELL_HEIGHT);
+                return (
+                  <div
+                    key={ei}
+                    className={cn(
+                      'absolute right-0 left-0 overflow-hidden rounded-sm px-1 py-0.5',
+                      ev.type === 'practice'
+                        ? 'bg-[#4ade80]/20 text-[#4ade80]'
+                        : 'bg-[#60a5fa]/20 text-[#60a5fa]',
+                    )}
+                    style={{ top: clippedStart * CELL_HEIGHT, height }}
+                  >
+                    <p className="text-[9px] leading-tight font-semibold">
+                      {ev.type === 'practice' ? '합주' : '공연'}
+                    </p>
+                    <p className="truncate text-[9px] leading-tight">{ev.title}</p>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
         </div>
       </div>
 
       <div className="mt-4 flex items-center gap-3">
         <button
           type="button"
-          onClick={() => setPaintPractice((v) => !v)}
+          onClick={() => setShowPractice((v) => !v)}
           className={cn(
             'rounded-full border px-3.5 py-1 text-sm font-medium transition-colors',
-            paintPractice
+            showPractice
               ? 'border-[#4ade80] bg-[#4ade80]/10 text-[#4ade80]'
               : 'border-border text-foreground-muted',
           )}
@@ -405,10 +298,10 @@ export function WeeklyTimetable({
         </button>
         <button
           type="button"
-          onClick={() => setPaintPerformance((v) => !v)}
+          onClick={() => setShowPerformance((v) => !v)}
           className={cn(
             'rounded-full border px-3.5 py-1 text-sm font-medium transition-colors',
-            paintPerformance
+            showPerformance
               ? 'border-[#60a5fa] bg-[#60a5fa]/10 text-[#60a5fa]'
               : 'border-border text-foreground-muted',
           )}

--- a/src/domain/member/hooks/useMyAvailabilitySlots.ts
+++ b/src/domain/member/hooks/useMyAvailabilitySlots.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+
+import { getMyAvailabilitySlots } from '../api/getMyAvailabilitySlots';
+import type { ScheduleSlotResponse } from '../types';
+
+export function useMyAvailabilitySlots(from: string, to: string) {
+  const authenticated = useIsAuthenticated();
+  return useQuery<ScheduleSlotResponse[], Error>({
+    queryKey: queryKeys.member.myAvailabilitySlots(from, to),
+    queryFn: () => getMyAvailabilitySlots(from, to),
+    enabled: authenticated && !!from && !!to,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/domain/member/types/index.ts
+++ b/src/domain/member/types/index.ts
@@ -15,6 +15,7 @@ export type {
   WeeklyRuleResponse,
   AvailabilityExceptionResponse,
   MemberAvailabilityResponse,
+  ScheduleSlotResponse,
 } from './res';
 export { joinSchema, updateMeSchema } from './schema';
 export type { JoinSchema, UpdateMeSchema } from './schema';

--- a/src/domain/member/types/req.ts
+++ b/src/domain/member/types/req.ts
@@ -23,11 +23,11 @@ export interface AvailabilityExceptionRequest {
   endSlot?: number | null;
 }
 
-/** API_SPEC §2-8 — 가용성 등록/수정. weeklyRules·exceptions 전체 교체 방식. */
+/** API_SPEC §2-8 — 가용성 등록/수정. weeklyRules·exceptions 전체 교체 방식. effectiveTo는 필수. */
 export interface UpdateMyAvailabilityRequest {
   weeklyRules: WeeklyRuleRequest[];
   exceptions: AvailabilityExceptionRequest[];
   note?: string | null;
   effectiveFrom: string;
-  effectiveTo?: string | null;
+  effectiveTo: string;
 }

--- a/src/domain/member/types/res.ts
+++ b/src/domain/member/types/res.ts
@@ -66,3 +66,13 @@ export interface MemberAvailabilityResponse {
   note: string | null;
   updatedAt: string | null;
 }
+
+/** GET /api/v1/me/availability/slots — 날짜 범위별 가용성 슬롯. slot 0=00:00, 48슬롯, [startSlot, endSlot) */
+export interface ScheduleSlotResponse {
+  date: string;
+  startSlot: number;
+  endSlot: number;
+  type: 'AVAILABLE';
+  title: string | null;
+  refId: string | null;
+}

--- a/src/global/config/queryKeys.ts
+++ b/src/global/config/queryKeys.ts
@@ -6,6 +6,8 @@ export const queryKeys = {
     me: ['member', 'me'] as const,
     myMetrics: ['member', 'me', 'metrics'] as const,
     myAvailability: ['member', 'me', 'availability'] as const,
+    myAvailabilitySlots: (from: string, to: string) =>
+      ['member', 'me', 'availability', 'slots', from, to] as const,
     search: (q: string) => ['member', 'search', q] as const,
   },
   band: {


### PR DESCRIPTION
## 🛠️ Issue Number
closes [BD-146](https://sunwoo1137.atlassian.net/browse/BD-146)

📌 **작업 내용 및 특이사항**

**API 연동**
- `GET /api/v1/me/availability/slots` 신규 연동 (`ScheduleSlotResponse` 타입 추가)
- `UpdateMyAvailabilityRequest.effectiveTo` required 변경 대응 (BE breaking change)
- `useMyAvailabilitySlots` 훅 및 `queryKeys.member.myAvailabilitySlots` 추가

**WeeklyTimetable 개선**
- 클라이언트 측 가용성 매트릭스 계산 → slots API(`slotsToMatrix`) 로 교체, 주 이동 시 자동 refetch
- 합주/공연 표시 버튼: 실제 이벤트 토글로 동작하도록 변경 (시간표에 블록 렌더링)
- `neverSet` 패턴: 한 번도 등록하지 않은 경우 전체 가능 상태로 표시
- **ScheduleSummaryTabs** 추가: 위클리 규칙 / 예외 날짜 / 일정 3탭 요약 표시
  - 위클리 규칙: 월~일 7행 고정, 같은 요일 규칙 2개 이상 시 시간대 한 줄 나열
  - 토/일 요일 파란색/빨간색 강조
- 스케줄 정보 섹션 헤딩 추가
- 나의 스케줄 관리 버튼 → 헤딩 오른쪽으로 이동
- 합주/공연 표시 토글 버튼 → 주간 네비 오른쪽 끝으로 이동

**ScheduleManagerModal 개선**
- 4단계 wizard → 탭(기간 / 시간대 / 예외 날짜(선택) / 특이사항(선택)) 구조로 변경
- 신규 등록 시 버튼 텍스트 "등록", 수정 시 "수정" 분기 (`isNew = !availability?.updatedAt`)
- 신규 등록 시 시간대 그리드 전체 채워진 상태로 초기화
- 필수 입력값 `*` 표시, 필수값 미입력 시 저장 버튼 비활성화

📚 **참고사항**

- `effectiveTo` BE에서 required로 변경됨 — 무기한 옵션 UI 제거

[BD-146]: https://sunwoo1137.atlassian.net/browse/BD-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ