### PR TITLE
[BD-175] feat: 공연 초대 및 셋리스트 관리 UI

### DIFF
--- a/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
+++ b/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
@@ -32,6 +32,7 @@ import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { PerformanceDday } from '@/domain/performance/components/PerformanceDday';
+import { PerformanceInvitationsPanel } from '@/domain/performance/components/PerformanceInvitationsPanel.client';
 import { SetlistSelectorSheet } from '@/domain/performance/components/SetlistSelectorSheet.client';
 import { useBatchAddPerformanceSetlists } from '@/domain/performance/hooks/useBatchAddPerformanceSetlists';
 import { useDeletePerformance } from '@/domain/performance/hooks/useDeletePerformance';
@@ -259,7 +260,7 @@ export function PerformanceDetailContent({
               셋리스트
             </TabsTrigger>
             <TabsTrigger value="invitations" className={outerTriggerCls}>
-              초대 목록
+              {isManager ? '초대 목록' : '초대 요청'}
             </TabsTrigger>
             {isManager && (
               <TabsTrigger value="settings" className={outerTriggerCls}>
@@ -396,9 +397,9 @@ export function PerformanceDetailContent({
             </Dialog>
           </TabsContent>
 
-          {/* 초대 목록 탭 */}
+          {/* 초대 목록/초대 요청 탭 */}
           <TabsContent value="invitations" className="mt-0">
-            <EmptyState title="초대 목록이 없습니다" compact />
+            <PerformanceInvitationsPanel performanceId={performanceId} isManager={isManager} />
           </TabsContent>
 
           {/* 설정 탭 (매니저 전용) */}

--- a/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
+++ b/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
@@ -6,9 +6,11 @@ import {
   ChevronDown,
   ChevronUp,
   ImagePlus,
+  ListPlus,
   Loader2,
   MapPin,
   Music,
+  Trash2,
   X,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -18,12 +20,23 @@ import { useForm } from 'react-hook-form';
 import { EmptyState } from '@/components/feedback/empty-state';
 import { ErrorState } from '@/components/feedback/error-state';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { PerformanceDday } from '@/domain/performance/components/PerformanceDday';
+import { SetlistSelectorSheet } from '@/domain/performance/components/SetlistSelectorSheet.client';
+import { useBatchAddPerformanceSetlists } from '@/domain/performance/hooks/useBatchAddPerformanceSetlists';
 import { useDeletePerformance } from '@/domain/performance/hooks/useDeletePerformance';
 import { usePerformanceDetail } from '@/domain/performance/hooks/usePerformanceDetail';
+import { useRemovePerformanceSetlist } from '@/domain/performance/hooks/useRemovePerformanceSetlist';
 import { useUpdatePerformance } from '@/domain/performance/hooks/useUpdatePerformance';
 import { updatePerformanceSchema, type UpdatePerformanceSchema } from '@/domain/performance/types';
 import {
@@ -77,6 +90,9 @@ export function PerformanceDetailContent({
   const [posterUploading, setPosterUploading] = useState(false);
   const [posterDescription, setPosterDescription] = useState('');
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
+  const [setlistSelectorOpen, setSetlistSelectorOpen] = useState(false);
+  const [pendingRemoveSetlist, setPendingRemoveSetlist] =
+    useState<PerformanceSetlistSummary | null>(null);
 
   const editForm = useForm<UpdatePerformanceSchema>({
     resolver: zodResolver(updatePerformanceSchema),
@@ -183,6 +199,23 @@ export function PerformanceDetailContent({
     onError: (err) => toast.error(err.message || '삭제에 실패했습니다.'),
   });
 
+  const addSetlistsMutation = useBatchAddPerformanceSetlists(performanceId, {
+    onSuccess: () => toast.success('셋리스트를 추가했습니다.'),
+    onError: (err) => toast.error(err.message || '셋리스트 추가에 실패했습니다.'),
+  });
+
+  const removeSetlistMutation = useRemovePerformanceSetlist(performanceId, {
+    onSuccess: () => toast.success('셋리스트를 제거했습니다.'),
+    onError: (err) => toast.error(err.message || '셋리스트 제거에 실패했습니다.'),
+  });
+
+  function handleRemoveSetlist() {
+    if (!pendingRemoveSetlist) return;
+    removeSetlistMutation.mutate(pendingRemoveSetlist.setlistId, {
+      onSettled: () => setPendingRemoveSetlist(null),
+    });
+  }
+
   if (isLoading) {
     return (
       <div className="space-y-3">
@@ -221,6 +254,9 @@ export function PerformanceDetailContent({
           <TabsList aria-label="공연 상세 탭">
             <TabsTrigger value="info" className={outerTriggerCls}>
               정보
+            </TabsTrigger>
+            <TabsTrigger value="setlists" className={outerTriggerCls}>
+              셋리스트
             </TabsTrigger>
             <TabsTrigger value="invitations" className={outerTriggerCls}>
               초대 목록
@@ -270,19 +306,94 @@ export function PerformanceDetailContent({
                 </span>
               )}
             </div>
+          </TabsContent>
 
-            <div className="space-y-s-2">
-              <p className="text-foreground pt-s-2 text-base font-semibold">참여 셋리스트</p>
-              {perf.setlists.length === 0 ? (
-                <EmptyState title="연결된 셋리스트가 없습니다" compact />
-              ) : (
-                <div className="space-y-s-2">
-                  {perf.setlists.map((s) => (
-                    <SetlistCard key={s.setlistId} setlist={s} />
-                  ))}
-                </div>
+          {/* 셋리스트 탭 */}
+          <TabsContent value="setlists" className="space-y-s-3 mt-0">
+            <div className="flex items-center justify-between">
+              <p className="text-foreground text-base font-semibold">참여 셋리스트</p>
+              {isManager && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 gap-1 rounded-[5px] px-2"
+                  onClick={() => setSetlistSelectorOpen(true)}
+                >
+                  <ListPlus className="h-4 w-4" aria-hidden="true" />
+                  추가
+                </Button>
               )}
             </div>
+
+            {perf.setlists.length === 0 ? (
+              <EmptyState title="연결된 셋리스트가 없습니다" compact />
+            ) : (
+              <div className="space-y-s-2">
+                {perf.setlists.map((s) => (
+                  <div key={s.setlistId} className="flex items-center gap-2">
+                    <SetlistCard setlist={s} />
+                    {isManager && (
+                      <button
+                        type="button"
+                        onClick={() => setPendingRemoveSetlist(s)}
+                        aria-label={`${s.title} 셋리스트 제거`}
+                        className="text-foreground-muted hover:text-danger shrink-0 rounded p-1 transition-colors"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <SetlistSelectorSheet
+              open={setlistSelectorOpen}
+              onOpenChange={setSetlistSelectorOpen}
+              excludeIds={perf.setlists.map((s) => s.setlistId)}
+              onConfirm={(selected) => {
+                if (selected.length === 0) return;
+                addSetlistsMutation.mutate({
+                  setlistIds: selected.map((s) => s.setlistId),
+                });
+              }}
+            />
+
+            <Dialog
+              open={pendingRemoveSetlist !== null}
+              onOpenChange={(o) => {
+                if (!o) setPendingRemoveSetlist(null);
+              }}
+            >
+              <DialogContent srOnlyTitle="셋리스트 제거">
+                <DialogHeader className="border-b-0 pb-2">
+                  <DialogTitle>셋리스트를 제거하시겠어요?</DialogTitle>
+                </DialogHeader>
+                <DialogBody>
+                  <p className="text-foreground-sub text-sm">
+                    <strong className="text-foreground">{pendingRemoveSetlist?.title}</strong>{' '}
+                    셋리스트를 공연에서 제거합니다.
+                  </p>
+                </DialogBody>
+                <DialogFooter className="border-t-0">
+                  <Button
+                    variant="ghost"
+                    className="h-8 rounded-[5px]"
+                    onClick={() => setPendingRemoveSetlist(null)}
+                  >
+                    취소
+                  </Button>
+                  <Button
+                    variant="danger"
+                    className="h-8 rounded-[5px] px-2"
+                    loading={removeSetlistMutation.isPending}
+                    onClick={handleRemoveSetlist}
+                  >
+                    제거
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
           </TabsContent>
 
           {/* 초대 목록 탭 */}
@@ -496,7 +607,7 @@ function SetlistCard({ setlist }: { setlist: PerformanceSetlistSummary }) {
   const tracks = data?.content ?? [];
 
   return (
-    <div className="border-border overflow-hidden rounded-[5px] border">
+    <div className="border-border min-w-0 flex-1 overflow-hidden rounded-[5px] border">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}

--- a/src/components/ui/entity-picker-modal.tsx
+++ b/src/components/ui/entity-picker-modal.tsx
@@ -12,6 +12,7 @@ import {
   ResponsiveSheetTitle,
 } from '@/components/ui/responsive-sheet';
 import { useDebounce } from '@/hooks/useDebounce';
+import { cn } from '@/lib/cn';
 
 import { Button } from './button';
 
@@ -35,6 +36,12 @@ export interface EntityPickerModalProps<T> {
   debounceMs?: number;
   /** 사전 선택값 (수정 모드 등). */
   initialSelection?: T[];
+  /** 확인 버튼에 추가할 className (스타일 커스텀용). */
+  confirmButtonClassName?: string;
+  /** 취소 버튼에 추가할 className (스타일 커스텀용). */
+  cancelButtonClassName?: string;
+  /** 푸터 영역에 추가할 className (스타일 커스텀용). */
+  footerClassName?: string;
 }
 
 /**
@@ -45,8 +52,30 @@ export interface EntityPickerModalProps<T> {
  * - 확인 시 onConfirm 호출, 취소/오버레이 시 onOpenChange(false)
  *
  * 사용 예: BandPickerModal, MemberPickerModal, PracticePickerModal
+ *
+ * 열릴 때마다 내부 검색 상태(query/debounce/결과)를 완전히 새로 마운트해 리셋한다.
+ * useEffect 리셋만으로는 debounce 값이 새 open 시점까지 이전 검색어를 들고 있어
+ * 이전 결과가 잠깐 다시 보이는 현상이 생기므로, key 를 바꿔 통째로 재마운트한다.
  */
-export function EntityPickerModal<T>({
+export function EntityPickerModal<T>(props: EntityPickerModalProps<T>) {
+  const { open } = props;
+  const [prevOpen, setPrevOpen] = useState(open);
+  const [sessionId, setSessionId] = useState(0);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setSessionId((id) => id + 1);
+  }
+
+  return (
+    <ResponsiveSheet open={props.open} onOpenChange={props.onOpenChange}>
+      <ResponsiveSheetContent>
+        <EntityPickerModalBody key={sessionId} {...props} />
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}
+
+function EntityPickerModalBody<T>({
   open,
   onOpenChange,
   title,
@@ -58,6 +87,9 @@ export function EntityPickerModal<T>({
   onConfirm,
   debounceMs = 250,
   initialSelection = [],
+  confirmButtonClassName,
+  cancelButtonClassName,
+  footerClassName,
 }: EntityPickerModalProps<T>) {
   const [query, setQuery] = useState('');
   const debounced = useDebounce(query, debounceMs);
@@ -65,17 +97,6 @@ export function EntityPickerModal<T>({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selection, setSelection] = useState<T[]>(initialSelection);
-
-  // 모달 오픈 시 상태 리셋.
-  useEffect(() => {
-    if (open) {
-      setQuery('');
-      setResults([]);
-      setError(null);
-      setSelection(initialSelection);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
 
   // 검색.
   useEffect(() => {
@@ -122,68 +143,72 @@ export function EntityPickerModal<T>({
   }
 
   return (
-    <ResponsiveSheet open={open} onOpenChange={onOpenChange}>
-      <ResponsiveSheetContent>
-        <ResponsiveSheetHeader>
-          <ResponsiveSheetTitle>{title}</ResponsiveSheetTitle>
-        </ResponsiveSheetHeader>
-        <ResponsiveSheetBody>
-          <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 mb-s-3 flex items-center rounded-md border">
-            <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
-            <input
-              autoFocus
-              type="search"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder={placeholder}
-              className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
-              aria-label={`${title} 검색`}
-            />
-          </div>
-          <div
-            className="max-h-[420px] overflow-y-auto"
-            data-slot="entity-picker-results"
-            aria-busy={loading}
-          >
-            {!debounced.trim() ? (
-              <p className="text-foreground-muted p-s-4 text-caption">{placeholder}</p>
-            ) : loading ? (
-              <p className="text-foreground-muted p-s-4 text-caption">검색 중…</p>
-            ) : error ? (
-              <p className="text-foreground-muted p-s-4 text-caption">{error}</p>
-            ) : results.length === 0 ? (
-              <p className="text-foreground-muted p-s-4 text-caption">검색 결과가 없습니다.</p>
-            ) : (
-              <ul className="gap-s-2 flex flex-col">
-                {results.map((item) => {
-                  const k = getKey(item);
-                  const sel = selection.some((s) => getKey(s) === k);
-                  return (
-                    <li key={k}>
-                      <button
-                        type="button"
-                        onClick={() => toggle(item)}
-                        aria-pressed={sel}
-                        className="w-full text-left"
-                      >
-                        {renderItem(item, sel)}
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </div>
-        </ResponsiveSheetBody>
-        <ResponsiveSheetFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
-            취소
-          </Button>
-          <Button onClick={confirm} disabled={selection.length === 0}>
-            {multiple ? `선택 (${selection.length})` : '확인'}
-          </Button>
-        </ResponsiveSheetFooter>
-      </ResponsiveSheetContent>
-    </ResponsiveSheet>
+    <>
+      <ResponsiveSheetHeader>
+        <ResponsiveSheetTitle>{title}</ResponsiveSheetTitle>
+      </ResponsiveSheetHeader>
+      <ResponsiveSheetBody>
+        <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 mb-s-3 flex items-center rounded-md border">
+          <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
+          <input
+            autoFocus
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={placeholder}
+            className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+            aria-label={`${title} 검색`}
+          />
+        </div>
+        <div
+          className="max-h-[420px] overflow-y-auto"
+          data-slot="entity-picker-results"
+          aria-busy={loading}
+        >
+          {!debounced.trim() ? null : loading ? (
+            <p className="text-foreground-muted p-s-4 text-caption">검색 중…</p>
+          ) : error ? (
+            <p className="text-foreground-muted p-s-4 text-caption">{error}</p>
+          ) : results.length === 0 ? (
+            <p className="text-foreground-muted p-s-4 text-caption">검색 결과가 없습니다.</p>
+          ) : (
+            <ul className="gap-s-2 flex flex-col">
+              {results.map((item) => {
+                const k = getKey(item);
+                const sel = selection.some((s) => getKey(s) === k);
+                return (
+                  <li key={k}>
+                    <button
+                      type="button"
+                      onClick={() => toggle(item)}
+                      aria-pressed={sel}
+                      className="w-full text-left"
+                    >
+                      {renderItem(item, sel)}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </ResponsiveSheetBody>
+      <ResponsiveSheetFooter className={cn(footerClassName)}>
+        <Button
+          variant="ghost"
+          className={cn(cancelButtonClassName)}
+          onClick={() => onOpenChange(false)}
+        >
+          취소
+        </Button>
+        <Button
+          onClick={confirm}
+          disabled={selection.length === 0}
+          className={cn(confirmButtonClassName)}
+        >
+          {multiple ? `선택 (${selection.length})` : '확인'}
+        </Button>
+      </ResponsiveSheetFooter>
+    </>
   );
 }

--- a/src/domain/performance/components/InviteManagerModal.client.tsx
+++ b/src/domain/performance/components/InviteManagerModal.client.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Avatar } from '@/components/ui/avatar';
+import { EntityPickerModal } from '@/components/ui/entity-picker-modal';
+import { searchMembers } from '@/domain/member/api/searchMembers';
+import type { MemberSearchItemResponse } from '@/domain/member/types';
+import { cn } from '@/lib/cn';
+
+export interface InviteManagerModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (member: MemberSearchItemResponse) => void;
+}
+
+export function InviteManagerModal({ open, onOpenChange, onConfirm }: InviteManagerModalProps) {
+  return (
+    <EntityPickerModal<MemberSearchItemResponse>
+      open={open}
+      onOpenChange={onOpenChange}
+      title="매니저 초대"
+      placeholder="이름 · 이메일로 검색"
+      fetcher={searchMembers}
+      getKey={(m) => String(m.memberId)}
+      footerClassName="border-t-0"
+      cancelButtonClassName="h-8 rounded-[5px]"
+      confirmButtonClassName="h-8 rounded-[5px] bg-white px-3 text-neutral-900 hover:bg-neutral-100 active:bg-neutral-200 disabled:bg-white/30"
+      onConfirm={(selection) => {
+        const member = selection[0];
+        if (member) onConfirm(member);
+      }}
+      renderItem={(m, selected) => (
+        <div
+          className={cn(
+            'border-border bg-card hover:bg-card-hover gap-s-3 px-s-4 py-s-3 flex items-center rounded-md border transition-colors',
+            selected && 'border-white/60',
+          )}
+        >
+          <Avatar size="md" src={m.profileImg ?? undefined} fallback={m.name} />
+          <div className="min-w-0 flex-1">
+            <div className="text-body truncate font-semibold">{m.name}</div>
+            <div className="text-foreground-muted text-caption truncate">{m.email}</div>
+          </div>
+        </div>
+      )}
+    />
+  );
+}

--- a/src/domain/performance/components/PerformanceInvitationsPanel.client.tsx
+++ b/src/domain/performance/components/PerformanceInvitationsPanel.client.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { UserPlus } from 'lucide-react';
+import { useState } from 'react';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { Avatar } from '@/components/ui/avatar';
+import { Badge, type BadgeVariant } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { InviteManagerModal } from '@/domain/performance/components/InviteManagerModal.client';
+import { useDecidePerformanceInvitation } from '@/domain/performance/hooks/useDecidePerformanceInvitation';
+import { useMyPerformanceInvitations } from '@/domain/performance/hooks/useMyPerformanceInvitations';
+import { usePerformanceInvitations } from '@/domain/performance/hooks/usePerformanceInvitations';
+import { useSendPerformanceInvitation } from '@/domain/performance/hooks/useSendPerformanceInvitation';
+import type {
+  PerformanceInvitationResponse,
+  PerformanceInvitationStatus,
+} from '@/domain/performance/types/res';
+import { useToast } from '@/hooks/useToast';
+
+const STATUS_LABEL: Record<PerformanceInvitationStatus, string> = {
+  PENDING: '대기중',
+  ACCEPTED: '수락됨',
+  REJECTED: '거절됨',
+  CANCELED: '취소됨',
+};
+
+const STATUS_VARIANT: Record<PerformanceInvitationStatus, BadgeVariant> = {
+  PENDING: 'warn',
+  ACCEPTED: 'success',
+  REJECTED: 'danger',
+  CANCELED: 'muted',
+};
+
+function formatInvitedAt(createdAt: string) {
+  // 백엔드가 초 이하 자릿수가 가변인 ISO 문자열(예: 2026-07-05T05:23:04.628454)을 내려줘
+  // date-fns 고정 패턴 파싱이 깨지므로, 표시에 필요한 시:분까지만 직접 추출한다.
+  const match = createdAt.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/);
+  return match ? `${match[1]} ${match[2]}` : createdAt;
+}
+
+export function PerformanceInvitationsPanel({
+  performanceId,
+  isManager,
+}: {
+  performanceId: string;
+  isManager: boolean;
+}) {
+  const toast = useToast();
+  const [inviteOpen, setInviteOpen] = useState(false);
+
+  const { data: sentInvitations = [] } = usePerformanceInvitations(performanceId, {
+    enabled: isManager,
+  });
+  const { data: myInvitations = [] } = useMyPerformanceInvitations({ enabled: !isManager });
+
+  const sendMutation = useSendPerformanceInvitation(performanceId, {
+    onSuccess: () => toast.success('초대를 보냈습니다.'),
+    onError: (err) => toast.error(err.message || '초대 전송에 실패했습니다.'),
+  });
+
+  if (isManager) {
+    return (
+      <div className="space-y-s-3">
+        <div className="flex items-center justify-between">
+          <p className="text-foreground text-base font-semibold">보낸 초대</p>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-8 gap-1 rounded-[5px] px-2"
+            onClick={() => setInviteOpen(true)}
+          >
+            <UserPlus className="h-4 w-4" aria-hidden="true" />
+            매니저 초대
+          </Button>
+        </div>
+
+        {sentInvitations.length === 0 ? (
+          <EmptyState title="보낸 초대가 없습니다" compact />
+        ) : (
+          <ul className="space-y-s-2">
+            {sentInvitations.map((inv) => (
+              <SentInvitationRow key={inv.invitationId} invitation={inv} />
+            ))}
+          </ul>
+        )}
+
+        <InviteManagerModal
+          open={inviteOpen}
+          onOpenChange={setInviteOpen}
+          onConfirm={(member) => sendMutation.mutate({ memberId: member.memberId })}
+        />
+      </div>
+    );
+  }
+
+  const myInvitationsForPerformance = myInvitations.filter(
+    (inv) => inv.performanceId === performanceId,
+  );
+
+  return myInvitationsForPerformance.length === 0 ? (
+    <EmptyState title="받은 초대 요청이 없습니다" compact />
+  ) : (
+    <ul className="space-y-s-2">
+      {myInvitationsForPerformance.map((inv) => (
+        <MyInvitationRow key={inv.invitationId} performanceId={performanceId} invitation={inv} />
+      ))}
+    </ul>
+  );
+}
+
+function SentInvitationRow({ invitation }: { invitation: PerformanceInvitationResponse }) {
+  const name = invitation.invitedMemberName ?? `멤버 #${invitation.invitedMemberId}`;
+  return (
+    <li className="bg-card border-border gap-s-3 p-s-3 flex items-center rounded-md border">
+      <Avatar size="lg" src={invitation.invitedMemberProfileImg ?? undefined} fallback={name} />
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-sm font-semibold">{name}</p>
+        <p className="text-foreground-muted text-caption mt-0.5">
+          {formatInvitedAt(invitation.createdAt)}
+        </p>
+      </div>
+      <Badge variant={STATUS_VARIANT[invitation.status]}>{STATUS_LABEL[invitation.status]}</Badge>
+    </li>
+  );
+}
+
+function MyInvitationRow({
+  performanceId,
+  invitation,
+}: {
+  performanceId: string;
+  invitation: PerformanceInvitationResponse;
+}) {
+  const toast = useToast();
+  const decideMutation = useDecidePerformanceInvitation(performanceId, {
+    onError: (err) => toast.error(err.message || '처리에 실패했습니다.'),
+  });
+
+  function decide(status: 'ACCEPTED' | 'REJECTED') {
+    decideMutation.mutate(
+      { invitationId: invitation.invitationId, status },
+      {
+        onSuccess: () =>
+          toast.success(status === 'ACCEPTED' ? '초대를 수락했습니다.' : '초대를 거절했습니다.'),
+      },
+    );
+  }
+
+  return (
+    <li className="bg-card border-border gap-s-3 p-s-3 flex items-center rounded-md border">
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-sm font-semibold">
+          {invitation.performanceTitle}
+        </p>
+        <p className="text-foreground-muted text-caption mt-0.5">
+          {formatInvitedAt(invitation.createdAt)}
+        </p>
+      </div>
+      {invitation.status === 'PENDING' ? (
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            className="bg-success hover:bg-success/90 rounded-[5px]"
+            loading={decideMutation.isPending}
+            onClick={() => decide('ACCEPTED')}
+          >
+            수락
+          </Button>
+          <Button
+            size="sm"
+            variant="danger"
+            className="rounded-[5px]"
+            loading={decideMutation.isPending}
+            onClick={() => decide('REJECTED')}
+          >
+            거절
+          </Button>
+        </div>
+      ) : (
+        <Badge variant={STATUS_VARIANT[invitation.status]}>{STATUS_LABEL[invitation.status]}</Badge>
+      )}
+    </li>
+  );
+}

--- a/src/domain/performance/components/SetlistSelectorSheet.client.tsx
+++ b/src/domain/performance/components/SetlistSelectorSheet.client.tsx
@@ -20,6 +20,8 @@ export interface SetlistSelectorSheetProps {
   onOpenChange: (open: boolean) => void;
   initialSelection?: SetlistResponse[];
   onConfirm: (setlists: SetlistResponse[]) => void;
+  /** 이미 연결되어 선택 대상에서 제외할 setlistId 목록 */
+  excludeIds?: string[];
 }
 
 export function SetlistSelectorSheet({
@@ -27,9 +29,13 @@ export function SetlistSelectorSheet({
   onOpenChange,
   initialSelection = [],
   onConfirm,
+  excludeIds = [],
 }: SetlistSelectorSheetProps) {
   const { data, isLoading, isError } = useMySetlists();
-  const setlists = data?.content ?? [];
+  const setlists = useMemo(
+    () => (data?.content ?? []).filter((s) => !excludeIds.includes(s.setlistId)),
+    [data, excludeIds],
+  );
 
   const [selection, setSelection] = useState<SetlistResponse[]>(initialSelection);
   const [query, setQuery] = useState('');

--- a/src/domain/performance/hooks/useBatchAddPerformanceSetlists.ts
+++ b/src/domain/performance/hooks/useBatchAddPerformanceSetlists.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { batchAddPerformanceSetlists } from '../api/batchAddPerformanceSetlists';
+import type { PerformanceSetlistAddRequest } from '../types/req';
+import type { PerformanceSetlistResponse } from '../types/res';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useBatchAddPerformanceSetlists(performanceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+
+  return useMutation<PerformanceSetlistResponse[], Error, PerformanceSetlistAddRequest>({
+    mutationFn: (req) => batchAddPerformanceSetlists(performanceId, req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.performance.detail(performanceId)] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/performance/hooks/useDecidePerformanceInvitation.ts
+++ b/src/domain/performance/hooks/useDecidePerformanceInvitation.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { decidePerformanceInvitation } from '../api/decidePerformanceInvitation';
+import type { PerformanceInvitationStatus } from '../types/res';
+
+type DecideVars = {
+  invitationId: string;
+  status: Extract<PerformanceInvitationStatus, 'ACCEPTED' | 'REJECTED'>;
+};
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useDecidePerformanceInvitation(performanceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, DecideVars>({
+    mutationFn: ({ invitationId, status }) =>
+      decidePerformanceInvitation(performanceId, invitationId, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.performanceInvitation.my()] });
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.performance.detail(performanceId)] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/performance/hooks/useMyPerformanceInvitations.ts
+++ b/src/domain/performance/hooks/useMyPerformanceInvitations.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+
+import { getMyPerformanceInvitations } from '../api/getMyPerformanceInvitations';
+import type { PerformanceInvitationResponse } from '../types/res';
+
+export function useMyPerformanceInvitations(options?: { enabled?: boolean }) {
+  const authenticated = useIsAuthenticated();
+  return useQuery<PerformanceInvitationResponse[], Error>({
+    queryKey: [...queryKeys.performanceInvitation.my()],
+    queryFn: () => getMyPerformanceInvitations(),
+    enabled: (options?.enabled ?? true) && authenticated,
+  });
+}

--- a/src/domain/performance/hooks/usePerformanceInvitations.ts
+++ b/src/domain/performance/hooks/usePerformanceInvitations.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getPerformanceInvitations } from '../api/getPerformanceInvitations';
+import type { PerformanceInvitationResponse } from '../types/res';
+
+export function usePerformanceInvitations(performanceId: string, options?: { enabled?: boolean }) {
+  return useQuery<PerformanceInvitationResponse[], Error>({
+    queryKey: [...queryKeys.performanceInvitation.sent(performanceId)],
+    queryFn: () => getPerformanceInvitations(performanceId),
+    enabled: (options?.enabled ?? true) && !!performanceId,
+  });
+}

--- a/src/domain/performance/hooks/useRemovePerformanceSetlist.ts
+++ b/src/domain/performance/hooks/useRemovePerformanceSetlist.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { removePerformanceSetlist } from '../api/removePerformanceSetlist';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useRemovePerformanceSetlist(performanceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: (setlistId) => removePerformanceSetlist(performanceId, setlistId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...queryKeys.performance.detail(performanceId)] });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/domain/performance/hooks/useSendPerformanceInvitation.ts
+++ b/src/domain/performance/hooks/useSendPerformanceInvitation.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { sendPerformanceInvitation } from '../api/sendPerformanceInvitation';
+import type { PerformanceInvitationCreateRequest } from '../types/req';
+import type { PerformanceInvitationResponse } from '../types/res';
+
+type Options = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+export function useSendPerformanceInvitation(performanceId: string, options?: Options) {
+  const queryClient = useQueryClient();
+
+  return useMutation<PerformanceInvitationResponse, Error, PerformanceInvitationCreateRequest>({
+    mutationFn: (req) => sendPerformanceInvitation(performanceId, req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [...queryKeys.performanceInvitation.sent(performanceId)],
+      });
+      options?.onSuccess?.();
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/global/config/queryKeys.ts
+++ b/src/global/config/queryKeys.ts
@@ -65,6 +65,12 @@ export const queryKeys = {
     list: (performanceId: string) => [...queryKeys.performancePoster.all, performanceId] as const,
     detail: (posterId: string) => [...queryKeys.performancePoster.all, 'detail', posterId] as const,
   },
+  performanceInvitation: {
+    all: ['performance-invitation'] as const,
+    sent: (performanceId: string) =>
+      [...queryKeys.performanceInvitation.all, 'sent', performanceId] as const,
+    my: () => [...queryKeys.performanceInvitation.all, 'my'] as const,
+  },
 } as const;
 
 export type QueryKeys = typeof queryKeys;


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-175](https://sunwoo1137.atlassian.net/browse/BD-175)

📌 **작업 내용 및 특이사항**

- 공연 상세 2번째 탭에 참여 셋리스트 탭 신설 (기존 정보 탭에서 분리)
  - `POST /performances/{id}/setlists/batch` 연동 `useBatchAddPerformanceSetlists` 훅 추가
  - `DELETE /performances/{id}/setlists/{setlistId}` 연동 `useRemovePerformanceSetlist` 훅 추가
  - `SetlistSelectorSheet`에 `excludeIds` prop 추가해 이미 연결된 셋리스트는 선택지에서 제외
  - 셋리스트 삭제 확인 다이얼로그 및 개별 제거 버튼 UI 추가
- 공연 초대 요청/목록 기능 추가
  - `GET/POST /performances/{id}/invitations`, `GET /performances/invitations/me`, `PATCH /performances/{id}/invitations/{invitationId}` 연동 훅 4종 추가
  - 초대 탭: owner는 매니저 초대 발송 + 발신 목록, 초대받은 사람은 수락/거절 UI로 분기 표시
  - `EntityPickerModal`을 재사용해 매니저 초대용 멤버 검색 모달(`InviteManagerModal`) 구현
- UI/버그 수정
  - `EntityPickerModal` 재오픈 시 debounce 지연으로 이전 검색 결과가 잠깐 다시 보이던 버그 수정 (세션 키로 내부 상태 통째 재마운트)
  - 초대 시간 표시: 백엔드가 내려주는 가변 자릿수 ISO 문자열(`2026-07-05T05:23:04.628454`) 파싱 실패로 원본 문자열이 그대로 노출되던 버그 수정 (시:분까지만 표시)
  - 매니저 초대 모달 버튼 사이즈/색상, 수락 버튼 색상 등 스타일 다듬기

📚 **참고사항**

- 공연 owner와 일반 manager를 구분하는 `ownerId` 필드가 현재 벤더링된 API 스펙에 없어(둘 다 `managerIds`로만 노출), "초대 목록/매니저 초대는 owner만 가능"하도록 하는 후속 작업은 백엔드 확인 후 별도 진행 예정
- MCP 영향평가(`performance` 영역) 확인 결과 breaking 변경 없음

[BD-175]: https://sunwoo1137.atlassian.net/browse/BD-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ