### PR TITLE
[BD-97] chore: fe-areas.json에 track-selection 영역 추가

### DIFF
--- a/fe-areas.json
+++ b/fe-areas.json
@@ -86,6 +86,14 @@
       "status": "active"
     },
     {
+      "id": "track-selection",
+      "label": "선곡",
+      "routes": ["/track-selections"],
+      "endpointPrefixes": ["/api/v1/track-selections"],
+      "status": "active",
+      "notes": "setlist-meeting(셋리스트 회의) 도메인에서 선곡 조율 기능을 분리·리네임. BE source of truth는 /api/v1/track-selections. setlist-meeting 영역은 아직 마이그레이션되지 않은 일정 조율(schedules) 기능 전용으로 별도 유지."
+    },
+    {
       "id": "band-application",
       "label": "밴드 가입 신청",
       "routes": ["/bands"],


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-97](https://sunwoo1137.atlassian.net/browse/BD-97)

📌 **작업 내용 및 특이사항**

- `pnpm verify:fe-areas` 실행 결과 `/api/v1/track-selections` prefix가 어느 영역에도 매핑되지 않은 uncovered 상태로 확인됨 (setlist-meeting → track-selection 도메인 리네임이 fe-areas.json에 반영 안 됨)
- `track-selection` 영역 신설: `routes: ["/track-selections"]`, `endpointPrefixes: ["/api/v1/track-selections"]`, `status: "active"`
- `setlist-meeting` 영역은 삭제하지 않고 유지 — 아직 마이그레이션되지 않은 일정 조율(schedules) 기능 전용으로 여전히 사용 중 (`domain/setlist-meeting/api/index.ts`가 `/api/v1/setlist-meetings/{meetingId}/schedules*` 계속 호출)
- `pnpm verify:fe-areas` 재실행 결과 PASS 확인

📚 **참고사항**

- MCP `check_impacting_changes` 툴은 fe-areas.json을 원격(GitHub)에서 읽는 것으로 보여, 이 PR이 머지된 이후부터 `fe_area="track-selection"` 조회가 정상 동작할 것으로 예상
- `setlists`(`/api/v1/setlists`), 공연 시간표 자동배치(`/api/v1/performances/{id}/schedule-boards/...`) 관련 엔드포인트는 각각 기존 `setlist`/`performance` 영역에 longest-prefix match로 이미 커버되어 있어 별도 추가 불필요함을 확인함

[BD-97]: https://sunwoo1137.atlassian.net/browse/BD-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ