### PR TITLE
[BD-97] feat: track-selection 도메인 신설 및 셋리스트 화면 개선

### DIFF
--- a/src/app/(main)/bands/create/page.tsx
+++ b/src/app/(main)/bands/create/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+
+import { PageTitle } from '@/components/layout/page-title';
+import { BandCreateForm } from '@/domain/band/components/BandCreateForm.client';
+
+export const metadata: Metadata = {
+  title: '밴드 생성 | Bandage',
+};
+
+export default function BandNewPage() {
+  return (
+    <div className="space-y-6">
+      <PageTitle title="밴드 생성" description="새 밴드의 기본 정보를 입력하세요." />
+      <BandCreateForm />
+    </div>
+  );
+}

--- a/src/app/(main)/jams/create/JamCreateWizard.client.tsx
+++ b/src/app/(main)/jams/create/JamCreateWizard.client.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { DateTimePicker } from '@/components/ui/date-time-picker';
+import { Input } from '@/components/ui/input';
+import { StepIndicator } from '@/components/ui/step-indicator';
+import { WizardSummaryCard } from '@/components/ui/wizard-summary-card';
+import { useCreateJam } from '@/domain/jam/hooks/useCreateJam';
+import type { SessionDefDto } from '@/domain/jam/types';
+import { ROUTES } from '@/global/config/routes';
+import { useRegisterDirtyForm } from '@/global/navigation/dirty-form-context';
+import { useToast } from '@/hooks/useToast';
+
+const STEPS = ['곡 정보', '일정 설정', '세션 설정', '검토'] as const;
+const inputCls =
+  'rounded-[5px] hover:border-white/30 focus-visible:border-white/80 focus-visible:ring-0';
+type Step = 0 | 1 | 2 | 3;
+
+export function JamCreateWizard() {
+  const router = useRouter();
+  const toast = useToast();
+  const [step, setStep] = useState<Step>(0);
+
+  // Step 0 — 곡 정보
+  const [trackTitle, setTrackTitle] = useState('');
+  const [trackArtist, setTrackArtist] = useState('');
+  const [trackAlbum, setTrackAlbum] = useState('');
+  const [trackDuration, setTrackDuration] = useState<number>(0);
+
+  // Step 1 — 일정 설정
+  const [title, setTitle] = useState('');
+  const [venue, setVenue] = useState('');
+  const [startAt, setStartAt] = useState('');
+  const [durationMinutes, setDurationMinutes] = useState<number>(60);
+
+  // Step 2 — 세션 설정
+  const [sessions, setSessions] = useState<SessionDefDto[]>([]);
+  const [sessionLabel, setSessionLabel] = useState('');
+  const [sessionShort, setSessionShort] = useState('');
+  const [sessionNeed, setSessionNeed] = useState(1);
+
+  const dirty = trackTitle.length > 0 || trackArtist.length > 0 || !!startAt;
+  useRegisterDirtyForm('jam-create-wizard', dirty);
+
+  const mutation = useCreateJam({
+    onSuccess: () => {
+      toast.resourceCreated('합주', { name: title || '새 합주' });
+      router.replace(ROUTES.JAMS);
+    },
+    onError: (err) => toast.error(err.message || '합주 생성에 실패했습니다.'),
+  });
+
+  const trackReady = !!trackTitle.trim() && !!trackArtist.trim();
+  const scheduleReady = !!startAt && durationMinutes >= 5;
+
+  const canNext =
+    step === 0
+      ? trackReady
+      : step === 1
+        ? scheduleReady
+        : step === 2
+          ? true // 세션은 선택사항
+          : false;
+
+  const canSubmit = step === 3 && trackReady && scheduleReady;
+
+  function next() {
+    if (step === 0 && !trackReady) return toast.error('곡 제목과 아티스트를 입력해 주세요.');
+    if (step === 1 && !startAt) return toast.error('시작 시각을 설정해 주세요.');
+    if (step < 3) setStep((step + 1) as Step);
+  }
+
+  function back() {
+    if (step > 0) setStep((step - 1) as Step);
+  }
+
+  function addSession() {
+    if (!sessionLabel.trim()) return toast.error('세션 이름을 입력해 주세요.');
+    if (!sessionShort.trim()) return toast.error('약어를 입력해 주세요.');
+    const short = sessionShort.toUpperCase().slice(0, 3);
+    if (sessions.some((s) => s.short === short))
+      return toast.error('같은 약어의 세션이 이미 있습니다.');
+    setSessions((prev) => [
+      ...prev,
+      {
+        sessionId: `${short}-${Date.now()}`,
+        label: sessionLabel.trim(),
+        short,
+        need: sessionNeed,
+        custom: true,
+      },
+    ]);
+    setSessionLabel('');
+    setSessionShort('');
+    setSessionNeed(1);
+  }
+
+  function removeSession(sessionId: string) {
+    setSessions((prev) => prev.filter((s) => s.sessionId !== sessionId));
+  }
+
+  function submit() {
+    if (!trackReady || !scheduleReady) return;
+    mutation.mutate({
+      title: title || undefined,
+      track: {
+        title: trackTitle.trim(),
+        artist: trackArtist.trim(),
+        album: trackAlbum.trim() || undefined,
+        duration: trackDuration || undefined,
+      },
+      sessions,
+      venue: venue || undefined,
+      startAt,
+      durationMinutes,
+    });
+  }
+
+  return (
+    <div className="p-s-4 mx-auto w-full max-w-3xl lg:py-10" data-slot="jam-create-wizard">
+      <header className="mb-s-6">
+        <h1 className="text-title font-bold">합주 생성</h1>
+      </header>
+
+      <StepIndicator steps={STEPS} current={step} colorScheme="white" />
+
+      {/* Step 0 — 곡 정보 */}
+      {step === 0 && (
+        <section className="space-y-s-3">
+          <h2 className="text-foreground-sub text-base font-semibold">
+            합주할 곡 정보를 입력하세요
+          </h2>
+          <Input
+            label="곡 제목"
+            required
+            value={trackTitle}
+            onChange={(e) => setTrackTitle(e.target.value)}
+            className={inputCls}
+          />
+          <Input
+            label="아티스트"
+            required
+            value={trackArtist}
+            onChange={(e) => setTrackArtist(e.target.value)}
+            className={inputCls}
+          />
+          <Input
+            label="앨범 (선택)"
+            value={trackAlbum}
+            onChange={(e) => setTrackAlbum(e.target.value)}
+            className={inputCls}
+          />
+          <Input
+            label="재생 시간 (초, 선택)"
+            type="number"
+            min={0}
+            value={trackDuration}
+            onChange={(e) => setTrackDuration(Number(e.target.value) || 0)}
+            className={inputCls}
+          />
+        </section>
+      )}
+
+      {/* Step 1 — 일정 설정 */}
+      {step === 1 && (
+        <section className="space-y-s-4">
+          <h2 className="text-foreground-sub text-base font-semibold">일정을 설정하세요</h2>
+          <Input
+            label="합주 제목 (선택)"
+            placeholder="예: TuNA 정기공연 1주차 합주"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className={inputCls}
+          />
+          <Input
+            label="장소 (선택)"
+            placeholder="예: 홍대 스튜디오"
+            value={venue}
+            onChange={(e) => setVenue(e.target.value)}
+            className={inputCls}
+          />
+          <div className="gap-s-3 grid grid-cols-1 sm:grid-cols-2">
+            <div className="bg-surface px-s-4 pt-s-2 pb-s-3 rounded-[5px] border border-white/20">
+              <label className="text-foreground-sub text-caption font-bold">
+                시작 시각{' '}
+                <span aria-hidden="true" className="text-danger">
+                  *
+                </span>
+              </label>
+              <div className="mt-s-2">
+                <DateTimePicker
+                  value={startAt}
+                  onChange={setStartAt}
+                  aria-label="시작 시각"
+                  required
+                  futureOnly
+                />
+              </div>
+            </div>
+            <div className="bg-surface px-s-4 pt-s-2 pb-s-3 rounded-[5px] border border-white/20">
+              <label className="text-foreground-sub text-caption font-bold">
+                소요 시간 (분){' '}
+                <span aria-hidden="true" className="text-danger">
+                  *
+                </span>
+              </label>
+              <div className="mt-s-2">
+                <input
+                  type="number"
+                  min={5}
+                  max={480}
+                  step={5}
+                  required
+                  value={durationMinutes}
+                  onChange={(e) => setDurationMinutes(Number(e.target.value) || 0)}
+                  className="text-foreground text-title w-full border-0 bg-transparent font-bold outline-none"
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Step 2 — 세션 설정 */}
+      {step === 2 && (
+        <section className="space-y-s-4">
+          <h2 className="text-foreground-sub text-base font-semibold">
+            세션을 설정하세요{' '}
+            <span className="text-foreground-muted text-caption font-normal">(선택)</span>
+          </h2>
+
+          {sessions.length > 0 && (
+            <ul className="border-border divide-border divide-y rounded-md border">
+              {sessions.map((s) => (
+                <li
+                  key={s.sessionId}
+                  className="px-s-4 py-s-3 flex items-center justify-between gap-3"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-caption w-10 rounded bg-white/10 px-1 py-0.5 text-center font-bold text-white">
+                      {s.short}
+                    </span>
+                    <span className="text-body font-medium">{s.label}</span>
+                    <span className="text-foreground-muted text-caption">{s.need}명</span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeSession(s.sessionId)}
+                    aria-label={`${s.label} 세션 삭제`}
+                    className="text-foreground-muted hover:text-danger transition-colors"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="border-border bg-card p-s-4 rounded-md border">
+            <div className="gap-s-3 grid grid-cols-[1fr_auto_auto_auto] items-end">
+              <Input
+                label="세션 이름"
+                placeholder="예: Guitar 2"
+                value={sessionLabel}
+                onChange={(e) => setSessionLabel(e.target.value)}
+                className={inputCls}
+              />
+              <Input
+                label="약어"
+                placeholder="예: G2"
+                value={sessionShort}
+                onChange={(e) => setSessionShort(e.target.value)}
+                className={`${inputCls} w-24`}
+                maxLength={3}
+              />
+              <Input
+                label="정원"
+                type="number"
+                min={1}
+                max={20}
+                value={sessionNeed}
+                onChange={(e) => setSessionNeed(Number(e.target.value) || 1)}
+                className={`${inputCls} w-20`}
+              />
+              <Button
+                type="button"
+                size="sm"
+                onClick={addSession}
+                className="self-end rounded-[5px] bg-white/70 text-neutral-900 transition-transform hover:bg-white/85 active:scale-95 active:bg-white"
+              >
+                추가
+              </Button>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Step 3 — 검토 */}
+      {step === 3 && (
+        <section className="space-y-s-4">
+          <h2 className="text-foreground-sub text-base font-semibold">아래 내용을 확인해주세요</h2>
+          <WizardSummaryCard
+            sections={[
+              {
+                label: '곡',
+                value: trackTitle && trackArtist ? `${trackTitle} — ${trackArtist}` : '—',
+                onEdit: () => setStep(0),
+              },
+              {
+                label: '시작 시각',
+                value: startAt || '—',
+                emphasized: true,
+                onEdit: () => setStep(1),
+              },
+              {
+                label: '소요 시간',
+                value: `${durationMinutes}분`,
+                emphasized: true,
+                onEdit: () => setStep(1),
+              },
+              { label: '제목', value: title || '미지정', onEdit: () => setStep(1) },
+              { label: '장소', value: venue || '미지정', onEdit: () => setStep(1) },
+              {
+                label: '세션',
+                value:
+                  sessions.length > 0
+                    ? sessions.map((s) => `${s.label}(${s.short})×${s.need}`).join(', ')
+                    : '없음',
+                onEdit: () => setStep(2),
+              },
+            ]}
+          />
+          <p className="text-foreground-muted text-caption">
+            확정 버튼을 눌러야 실제로 합주가 생성됩니다.
+          </p>
+        </section>
+      )}
+
+      <footer className="gap-s-3 mt-6.75 flex items-center justify-between">
+        {step > 0 ? (
+          <Button size="sm" variant="ghost" onClick={back} className="rounded-[5px]">
+            이전
+          </Button>
+        ) : (
+          <span />
+        )}
+        {step < 3 ? (
+          <Button
+            size="sm"
+            onClick={next}
+            disabled={!canNext}
+            className="rounded-[5px] bg-white text-neutral-900 hover:bg-neutral-100 active:bg-neutral-200 disabled:bg-white/30"
+          >
+            다음
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            onClick={submit}
+            loading={mutation.isPending}
+            disabled={!canSubmit}
+            className="rounded-[5px] bg-white text-neutral-900 hover:bg-neutral-100 active:bg-neutral-200 disabled:bg-white/30"
+          >
+            합주 만들기
+          </Button>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/src/app/(main)/jams/create/page.tsx
+++ b/src/app/(main)/jams/create/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+import { JamCreateWizard } from './JamCreateWizard.client';
+
+export const metadata: Metadata = {
+  title: '합주 생성 | Bandage',
+};
+
+export default function PracticeNewPage() {
+  return <JamCreateWizard />;
+}

--- a/src/app/(main)/setlists/SetlistsMobileShell.client.tsx
+++ b/src/app/(main)/setlists/SetlistsMobileShell.client.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { ListMusic } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { useMySetlists } from '@/domain/setlist/hooks/useMySetlists';
+import type { SetlistResponse } from '@/domain/setlist/types/res';
+import { ROUTES } from '@/global/config/routes';
+import { useIsDesktop } from '@/hooks/use-media-query';
+import { listItemClasses } from '@/lib/list-item-styles';
+
+function SetlistRow({ item, active }: { item: SetlistResponse; active: boolean }) {
+  const href = ROUTES.SETLIST_DETAIL(item.setlistId);
+  const dateLabel = item.updatedAt ?? item.createdAt;
+  const label = dateLabel
+    ? new Date(dateLabel).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })
+    : null;
+
+  return (
+    <li>
+      <Link
+        href={href}
+        aria-current={active ? 'page' : undefined}
+        data-slot="setlist-row"
+        className={listItemClasses(
+          active,
+          'accent',
+          'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+        )}
+      >
+        <span className="bg-accent/15 text-accent flex h-9 w-9 shrink-0 items-center justify-center rounded-md">
+          <ListMusic className="h-4 w-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-caption truncate font-semibold">{item.title}</div>
+          {label && <div className="text-foreground-muted text-caption mt-0.5">{label}</div>}
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+export function SetlistsMobileShell() {
+  const pathname = usePathname() ?? '';
+  const isDesktop = useIsDesktop();
+  const { data, isLoading } = useMySetlists();
+  const setlists = data?.content ?? [];
+
+  if (!isDesktop) {
+    return (
+      <p className="text-foreground-muted py-s-10 text-center text-sm">
+        모바일에서는 지원하지 않는 기능입니다. PC에서 이용해 주세요.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="border-border mb-s-3 pb-s-2 pt-s-1 border-b">
+        <h2 className="text-foreground pl-2.5 text-2xl font-bold lg:text-3xl">내 셋리스트</h2>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-s-2">
+          <Skeleton className="h-14 w-full" rounded="md" />
+          <Skeleton className="h-14 w-full" rounded="md" />
+          <Skeleton className="h-14 w-full" rounded="md" />
+        </div>
+      ) : setlists.length === 0 ? (
+        <p className="text-foreground-muted py-s-6 text-center text-sm">
+          생성된 셋리스트가 없습니다.
+        </p>
+      ) : (
+        <ul className="gap-s-1 flex flex-col">
+          {setlists.map((item) => {
+            const href = ROUTES.SETLIST_DETAIL(item.setlistId);
+            const active = pathname === href || pathname.startsWith(`${href}/`);
+            return <SetlistRow key={item.setlistId} item={item} active={active} />;
+          })}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/app/(main)/setlists/[setlistId]/SetlistDetail.client.tsx
+++ b/src/app/(main)/setlists/[setlistId]/SetlistDetail.client.tsx
@@ -1,0 +1,540 @@
+'use client';
+
+import { ArrowLeft, Clock, Edit2, Music, Pencil, Trash2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { EmptyState } from '@/components/feedback/empty-state';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useCreateJamsFromSetlist } from '@/domain/setlist/hooks/useCreateJamsFromSetlist';
+import { useDeleteSetlistTrack } from '@/domain/setlist/hooks/useDeleteSetlistTrack';
+import { useSetlist } from '@/domain/setlist/hooks/useSetlist';
+import { useSetlistTracks } from '@/domain/setlist/hooks/useSetlistTracks';
+import { useUpdateSetlist } from '@/domain/setlist/hooks/useUpdateSetlist';
+import { useUpdateSetlistTrack } from '@/domain/setlist/hooks/useUpdateSetlistTrack';
+import type { SetlistTrackResponse } from '@/domain/setlist/types/res';
+import { formatKst } from '@/lib/date';
+import { useToast } from '@/hooks/useToast';
+
+import { SetlistScheduleBoard } from './SetlistScheduleBoard.client';
+
+function TrackRow({
+  track,
+  onEdit,
+  onDelete,
+}: {
+  track: SetlistTrackResponse;
+  onEdit: (track: SetlistTrackResponse) => void;
+  onDelete: (track: SetlistTrackResponse) => void;
+}) {
+  return (
+    <div className="border-border hover:bg-card flex items-center gap-4 border-b px-5 py-3 transition-colors">
+      <div className="text-foreground-muted w-8 shrink-0 text-center text-sm">
+        {track.sessions?.length > 0 ? '' : ''}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate font-medium">{track.title}</p>
+        <p className="text-foreground-muted truncate text-sm">{track.artist}</p>
+        {track.album && <p className="text-foreground-sub truncate text-xs">{track.album}</p>}
+      </div>
+      <div className="flex shrink-0 items-center gap-3">
+        {track.duration !== undefined && (
+          <span className="text-foreground-muted flex items-center gap-1 text-xs">
+            <Clock className="h-3 w-3" />
+            {Math.floor(track.duration / 60)}:{String(track.duration % 60).padStart(2, '0')}
+          </span>
+        )}
+        {track.sessions && track.sessions.length > 0 && (
+          <div className="flex gap-1">
+            {track.sessions.map((s) => (
+              <span
+                key={s.sessionId}
+                className="bg-card border-border rounded px-1.5 py-0.5 text-xs"
+              >
+                {s.short}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          onClick={() => onEdit(track)}
+          aria-label={`${track.title} 수정`}
+          className="text-foreground-muted hover:text-foreground rounded p-1 transition-colors"
+        >
+          <Edit2 className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(track)}
+          aria-label={`${track.title} 삭제`}
+          className="text-foreground-muted hover:text-danger rounded p-1 transition-colors"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function TrackEditForm({
+  track,
+  onSave,
+  onCancel,
+  isPending,
+}: {
+  track: SetlistTrackResponse;
+  onSave: (values: {
+    title?: string;
+    artist?: string;
+    album?: string;
+    duration?: number;
+    note?: string;
+  }) => void;
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  const [title, setTitle] = useState(track.title);
+  const [artist, setArtist] = useState(track.artist);
+  const [album, setAlbum] = useState(track.album ?? '');
+  const [durationStr, setDurationStr] = useState(
+    track.duration !== undefined
+      ? `${Math.floor(track.duration / 60)}:${String(track.duration % 60).padStart(2, '0')}`
+      : '',
+  );
+  const [note, setNote] = useState(track.note ?? '');
+
+  const parseDuration = (str: string): number | undefined => {
+    const m = str.trim().match(/^(\d{1,2}):(\d{2})$/);
+    if (!m) return undefined;
+    return parseInt(m[1]!, 10) * 60 + parseInt(m[2]!, 10);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave({
+      title: title.trim() || undefined,
+      artist: artist.trim() || undefined,
+      album: album.trim() || undefined,
+      duration: parseDuration(durationStr),
+      note: note.trim() || undefined,
+    });
+  };
+
+  const inputClass =
+    'bg-card border-border text-body placeholder:text-foreground-muted w-full rounded-md border px-3 py-1.5 text-sm outline-none focus:ring-1 focus:ring-current';
+
+  return (
+    <form onSubmit={handleSubmit} className="border-border bg-card space-y-3 border-b px-5 py-4">
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="text-xs font-semibold" htmlFor={`title-${track.setlistTrackId}`}>
+            곡명
+          </label>
+          <input
+            id={`title-${track.setlistTrackId}`}
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className={`mt-1 ${inputClass}`}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-semibold" htmlFor={`artist-${track.setlistTrackId}`}>
+            아티스트
+          </label>
+          <input
+            id={`artist-${track.setlistTrackId}`}
+            type="text"
+            value={artist}
+            onChange={(e) => setArtist(e.target.value)}
+            className={`mt-1 ${inputClass}`}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-semibold" htmlFor={`album-${track.setlistTrackId}`}>
+            앨범
+          </label>
+          <input
+            id={`album-${track.setlistTrackId}`}
+            type="text"
+            value={album}
+            onChange={(e) => setAlbum(e.target.value)}
+            placeholder="선택"
+            className={`mt-1 ${inputClass}`}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-semibold" htmlFor={`duration-${track.setlistTrackId}`}>
+            재생시간 (mm:ss)
+          </label>
+          <input
+            id={`duration-${track.setlistTrackId}`}
+            type="text"
+            value={durationStr}
+            onChange={(e) => setDurationStr(e.target.value)}
+            placeholder="예: 3:45"
+            className={`mt-1 ${inputClass}`}
+          />
+        </div>
+      </div>
+      <div>
+        <label className="text-xs font-semibold" htmlFor={`note-${track.setlistTrackId}`}>
+          노트
+        </label>
+        <input
+          id={`note-${track.setlistTrackId}`}
+          type="text"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="선택"
+          className={`mt-1 ${inputClass}`}
+        />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button type="button" size="sm" variant="secondary" onClick={onCancel} disabled={isPending}>
+          취소
+        </Button>
+        <Button type="submit" size="sm" variant="primary" disabled={isPending}>
+          {isPending ? '저장 중…' : '저장'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function JamCreateForm({
+  onSubmit,
+  onCancel,
+  isPending,
+}: {
+  onSubmit: (values: { startAt: string; durationMinutes: number; venue?: string }) => void;
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  const [startAt, setStartAt] = useState('');
+  const [durationMinutes, setDurationMinutes] = useState(120);
+  const [venue, setVenue] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!startAt) return;
+    // datetime-local → "yyyy-MM-dd HH:mm" (KST 그대로 사용, UTC 변환 금지)
+    const formattedStart = startAt.replace('T', ' ');
+    onSubmit({
+      startAt: formattedStart,
+      durationMinutes,
+      venue: venue.trim() || undefined,
+    });
+  };
+
+  const inputClass =
+    'bg-card border-border text-body placeholder:text-foreground-muted w-full rounded-md border px-3 py-1.5 text-sm outline-none focus:ring-1 focus:ring-current';
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="border-border bg-surface mt-4 space-y-3 rounded-xl border p-5"
+    >
+      <h3 className="text-sm font-bold">합주 일괄 생성</h3>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="col-span-2">
+          <label className="text-xs font-semibold" htmlFor="jam-start">
+            시작 일시
+          </label>
+          <input
+            id="jam-start"
+            type="datetime-local"
+            value={startAt}
+            onChange={(e) => setStartAt(e.target.value)}
+            required
+            className={`mt-1 ${inputClass}`}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-semibold" htmlFor="jam-duration">
+            진행 시간 (분)
+          </label>
+          <input
+            id="jam-duration"
+            type="number"
+            min={1}
+            value={durationMinutes}
+            onChange={(e) => setDurationMinutes(Number(e.target.value))}
+            className={`mt-1 ${inputClass}`}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-semibold" htmlFor="jam-venue">
+            장소
+          </label>
+          <input
+            id="jam-venue"
+            type="text"
+            value={venue}
+            onChange={(e) => setVenue(e.target.value)}
+            placeholder="선택"
+            className={`mt-1 ${inputClass}`}
+          />
+        </div>
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button type="button" size="sm" variant="secondary" onClick={onCancel} disabled={isPending}>
+          취소
+        </Button>
+        <Button type="submit" size="sm" variant="primary" disabled={isPending || !startAt}>
+          {isPending ? '생성 중…' : '합주 생성'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export function SetlistDetail({ setlistId }: { setlistId: string }) {
+  const router = useRouter();
+  const toast = useToast();
+
+  const { data: setlist, isPending: setlistPending, error: setlistError } = useSetlist(setlistId);
+  const { data: tracks, isPending: tracksPending } = useSetlistTracks(setlistId);
+
+  const updateSetlist = useUpdateSetlist(setlistId);
+  const updateTrack = useUpdateSetlistTrack(setlistId);
+  const deleteTrack = useDeleteSetlistTrack(setlistId);
+  const createJams = useCreateJamsFromSetlist(setlistId);
+
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleInput, setTitleInput] = useState('');
+  const [editingTrack, setEditingTrack] = useState<SetlistTrackResponse | null>(null);
+  const [pendingDeleteTrack, setPendingDeleteTrack] = useState<SetlistTrackResponse | null>(null);
+  const [showJamForm, setShowJamForm] = useState(false);
+
+  const handleTitleEdit = () => {
+    setTitleInput(setlist?.title ?? '');
+    setEditingTitle(true);
+  };
+
+  const handleTitleSave = () => {
+    const trimmed = titleInput.trim();
+    if (!trimmed || trimmed === setlist?.title) {
+      setEditingTitle(false);
+      return;
+    }
+    updateSetlist.mutate(trimmed, {
+      onSuccess: () => {
+        toast.success('셋리스트 제목이 수정되었습니다.');
+        setEditingTitle(false);
+      },
+      onError: () => toast.error('제목 수정에 실패했습니다.'),
+    });
+  };
+
+  const handleTrackSave = (values: {
+    title?: string;
+    artist?: string;
+    album?: string;
+    duration?: number;
+    note?: string;
+  }) => {
+    if (!editingTrack) return;
+    updateTrack.mutate(
+      { trackId: editingTrack.setlistTrackId, body: values },
+      {
+        onSuccess: () => {
+          toast.success('트랙이 수정되었습니다.');
+          setEditingTrack(null);
+        },
+        onError: () => toast.error('트랙 수정에 실패했습니다.'),
+      },
+    );
+  };
+
+  const handleTrackDelete = () => {
+    if (!pendingDeleteTrack) return;
+    deleteTrack.mutate(pendingDeleteTrack.setlistTrackId, {
+      onSuccess: () => {
+        toast.success('트랙이 삭제되었습니다.');
+        setPendingDeleteTrack(null);
+      },
+      onError: () => toast.error('트랙 삭제에 실패했습니다.'),
+    });
+  };
+
+  const handleJamCreate = (values: {
+    startAt: string;
+    durationMinutes: number;
+    venue?: string;
+  }) => {
+    createJams.mutate(values, {
+      onSuccess: () => {
+        toast.success('합주가 일괄 생성되었습니다.');
+        setShowJamForm(false);
+      },
+      onError: () => toast.error('합주 생성에 실패했습니다.'),
+    });
+  };
+
+  if (setlistPending) {
+    return (
+      <div className="space-y-3 px-5 py-6">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-4 w-40" />
+        <div className="mt-6 space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (setlistError || !setlist) {
+    return (
+      <div className="px-5 py-6">
+        <p className="text-foreground-muted text-sm">
+          {setlistError?.message ?? '셋리스트를 찾을 수 없습니다.'}
+        </p>
+      </div>
+    );
+  }
+
+  const trackList = tracks?.content ?? [];
+  const hasTrack = trackList.length > 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+      <div className="border-border flex min-h-0 flex-1 flex-col lg:border-r">
+        {/* 헤더 */}
+        <header className="border-border border-b px-5 py-4">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            aria-label="뒤로 가기"
+            className="text-foreground-muted hover:text-foreground mb-3 flex items-center gap-1 text-sm transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            뒤로
+          </button>
+
+          {editingTitle ? (
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={titleInput}
+                onChange={(e) => setTitleInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleTitleSave();
+                  if (e.key === 'Escape') setEditingTitle(false);
+                }}
+                onBlur={handleTitleSave}
+                autoFocus
+                className="bg-card border-border text-title flex-1 rounded-md border px-3 py-1.5 font-bold outline-none focus:ring-1 focus:ring-current"
+              />
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <h1 className="text-title font-bold">{setlist.title}</h1>
+              <button
+                type="button"
+                onClick={handleTitleEdit}
+                aria-label="셋리스트 제목 수정"
+                className="text-foreground-muted hover:text-foreground rounded p-1 transition-colors"
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+            </div>
+          )}
+
+          {setlist.createdAt && (
+            <p className="text-foreground-muted mt-1 text-xs">
+              생성일: {formatKst(new Date(setlist.createdAt))}
+            </p>
+          )}
+        </header>
+
+        {/* 트랙 목록 */}
+        <div className="flex-1 overflow-y-auto">
+          {tracksPending ? (
+            <div className="space-y-2 px-5 py-4">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-14 w-full" />
+              ))}
+            </div>
+          ) : !hasTrack ? (
+            <EmptyState icon={Music} title="아직 트랙이 없습니다" className="py-16" />
+          ) : (
+            <div>
+              {trackList.map((track) =>
+                editingTrack?.setlistTrackId === track.setlistTrackId ? (
+                  <TrackEditForm
+                    key={track.setlistTrackId}
+                    track={track}
+                    onSave={handleTrackSave}
+                    onCancel={() => setEditingTrack(null)}
+                    isPending={updateTrack.isPending}
+                  />
+                ) : (
+                  <TrackRow
+                    key={track.setlistTrackId}
+                    track={track}
+                    onEdit={setEditingTrack}
+                    onDelete={setPendingDeleteTrack}
+                  />
+                ),
+              )}
+            </div>
+          )}
+
+          {/* 합주 일괄 생성 */}
+          <div className="px-5 py-4">
+            {showJamForm ? (
+              <JamCreateForm
+                onSubmit={handleJamCreate}
+                onCancel={() => setShowJamForm(false)}
+                isPending={createJams.isPending}
+              />
+            ) : (
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={!hasTrack}
+                onClick={() => setShowJamForm(true)}
+              >
+                합주 일괄 생성
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 합주 시간표 (미리보기 — 실제 자동배치 API 연동 전) */}
+      <div className="border-border min-h-[360px] border-t lg:min-h-0 lg:w-[480px] lg:shrink-0 lg:border-t-0">
+        <SetlistScheduleBoard tracks={trackList} />
+      </div>
+
+      {/* 트랙 삭제 확인 다이얼로그 */}
+      <ConfirmDialog
+        open={pendingDeleteTrack !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingDeleteTrack(null);
+        }}
+        title="트랙 삭제"
+        description={
+          pendingDeleteTrack ? (
+            <>
+              <strong className="text-foreground">{pendingDeleteTrack.title}</strong> 트랙을 정말
+              삭제하시겠습니까?
+            </>
+          ) : null
+        }
+        confirmLabel="삭제"
+        tone="danger"
+        onConfirm={handleTrackDelete}
+      />
+    </div>
+  );
+}

--- a/src/app/(main)/setlists/[setlistId]/SetlistScheduleBoard.client.tsx
+++ b/src/app/(main)/setlists/[setlistId]/SetlistScheduleBoard.client.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { songTone } from '@/domain/schedule-coordination/components/palette';
+import { WeeklyScheduleGrid } from '@/domain/schedule-coordination/components/WeeklyScheduleGrid.client';
+import { enumerateDays, slotToTime, toLocalISODate } from '@/domain/schedule-coordination/utils';
+import type { SetlistTrackResponse } from '@/domain/setlist/types/res';
+import { cn } from '@/lib/cn';
+
+/** 근무시간 10:00~22:00 (slot 0=00:00, 30분 단위). */
+const SLOT_START = 20;
+const SLOT_END = 44;
+const DEFAULT_DURATION_SLOTS = 4;
+
+interface PlacedTrack {
+  track: SetlistTrackResponse;
+  date: string;
+  startSlot: number;
+  durationSlots: number;
+}
+
+function mondayOf(base: Date): Date {
+  const d = new Date(base);
+  const day = d.getDay();
+  d.setDate(d.getDate() + (day === 0 ? -6 : 1 - day));
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/**
+ * 셋리스트 트랙을 평일 근무시간 안에 순차 배치한 미리보기.
+ * 실제 자동배치는 공연 단위 시간표 API(schedule-boards) 연동 후 대체 예정 — 지금은 시각화 목적의 로컬 배치.
+ */
+function placeTracks(tracks: SetlistTrackResponse[], days: string[]): PlacedTrack[] {
+  const placed: PlacedTrack[] = [];
+  let dayIdx = 0;
+  let cursor = SLOT_START;
+
+  for (const track of tracks) {
+    const durationSlots = track.duration
+      ? Math.max(2, Math.ceil(track.duration / 60 / 30))
+      : DEFAULT_DURATION_SLOTS;
+
+    if (cursor + durationSlots > SLOT_END) {
+      dayIdx += 1;
+      cursor = SLOT_START;
+    }
+    if (dayIdx >= days.length) break;
+
+    placed.push({ track, date: days[dayIdx]!, startSlot: cursor, durationSlots });
+    cursor += durationSlots;
+  }
+
+  return placed;
+}
+
+export function SetlistScheduleBoard({ tracks }: { tracks: SetlistTrackResponse[] }) {
+  const [weekOffset, setWeekOffset] = useState(0);
+
+  const days = useMemo(() => {
+    const monday = mondayOf(new Date());
+    monday.setDate(monday.getDate() + weekOffset * 7);
+    const friday = new Date(monday);
+    friday.setDate(friday.getDate() + 4);
+    return enumerateDays(toLocalISODate(monday), toLocalISODate(friday));
+  }, [weekOffset]);
+
+  const placedTracks = useMemo(() => placeTracks(tracks, days), [tracks, days]);
+
+  const rangeLabel =
+    days.length > 0 ? `${days[0]!.slice(5)} ~ ${days[days.length - 1]!.slice(5)}` : '';
+
+  return (
+    <div className="flex h-full min-w-0 flex-col">
+      <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
+        <p className="text-foreground text-sm font-semibold">합주 시간표</p>
+        <div className="gap-s-1 flex items-center">
+          <button
+            type="button"
+            onClick={() => setWeekOffset((w) => w - 1)}
+            aria-label="이전 주"
+            className="text-foreground-muted hover:text-foreground rounded p-1 transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <span className="text-foreground-muted text-caption min-w-[84px] text-center font-mono">
+            {rangeLabel}
+          </span>
+          <button
+            type="button"
+            onClick={() => setWeekOffset((w) => w + 1)}
+            aria-label="다음 주"
+            className="text-foreground-muted hover:text-foreground rounded p-1 transition-colors"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 px-4 py-3">
+        <WeeklyScheduleGrid
+          days={days}
+          slotStart={SLOT_START}
+          slotEnd={SLOT_END}
+          className="h-full"
+          overlay={placedTracks.map(({ track, date, startSlot, durationSlots }) => {
+            const dIdx = days.indexOf(date);
+            if (dIdx === -1) return null;
+            const tone = songTone(track.setlistTrackId, 0);
+            return (
+              <div
+                key={track.setlistTrackId}
+                className={cn(
+                  'm-px overflow-hidden rounded-sm border px-1.5 py-1 text-left',
+                  tone.softBg,
+                  tone.softBorder,
+                )}
+                style={{
+                  gridRow: `${startSlot - SLOT_START + 2} / span ${durationSlots}`,
+                  gridColumn: dIdx + 2,
+                }}
+              >
+                <p className={cn('truncate text-[11px] font-semibold', tone.text)}>{track.title}</p>
+                <p className="text-foreground-muted truncate text-[10px]">
+                  {slotToTime(startSlot)}
+                </p>
+              </div>
+            );
+          })}
+        />
+      </div>
+
+      {tracks.length > placedTracks.length && (
+        <p className="text-foreground-muted shrink-0 px-4 pb-3 text-xs">
+          이번 주 근무시간에 다 배치하지 못한 트랙이 있습니다. 다음 주로 이동해 확인하세요.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/setlists/[setlistId]/page.tsx
+++ b/src/app/(main)/setlists/[setlistId]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+import { SetlistDetail } from './SetlistDetail.client';
+
+export const metadata: Metadata = {
+  title: '셋리스트 | Bandage',
+};
+
+export default async function SetlistDetailPage({
+  params,
+}: {
+  params: Promise<{ setlistId: string }>;
+}) {
+  const { setlistId } = await params;
+  return <SetlistDetail setlistId={setlistId} />;
+}

--- a/src/app/(main)/setlists/page.tsx
+++ b/src/app/(main)/setlists/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+
+import { SetlistsMobileShell } from './SetlistsMobileShell.client';
+
+export const metadata: Metadata = {
+  title: '셋리스트 | Bandage',
+};
+
+export default function SetlistsPage() {
+  return (
+    <div className="p-s-4 lg:pt-10">
+      <SetlistsMobileShell />
+    </div>
+  );
+}

--- a/src/app/(main)/track-selections/TrackSelectionsMobileShell.client.tsx
+++ b/src/app/(main)/track-selections/TrackSelectionsMobileShell.client.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Lock, Plus } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { Button } from '@/components/ui/button';
+import { IconTile } from '@/components/ui/icon-tile';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useMyTrackSelections } from '@/domain/track-selection/hooks/useMyTrackSelections';
+import type { TrackSelectionResponse } from '@/domain/track-selection/types/res';
+import { ROUTES } from '@/global/config/routes';
+import { useIsDesktop } from '@/hooks/use-media-query';
+import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES } from '@/lib/domain-icons';
+import { listItemClasses } from '@/lib/list-item-styles';
+
+const TrackSelectionIcon = DOMAIN_ICONS['track-selection'];
+
+function MeetingRow({ item, active }: { item: TrackSelectionResponse; active: boolean }) {
+  const locked = Boolean(item.lockedAt);
+  const updatedLabel = item.updatedAt
+    ? new Date(item.updatedAt).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })
+    : null;
+
+  return (
+    <li>
+      <Link
+        href={ROUTES.TRACK_SELECTION_DETAIL(item.selectionId)}
+        aria-current={active ? 'page' : undefined}
+        data-slot="track-selection-row"
+        className={listItemClasses(
+          active,
+          DOMAIN_LIST_SELECTED_TONES['track-selection'],
+          'focus-visible:ring-offset-bg text-white focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:outline-none',
+        )}
+      >
+        <IconTile icon={<TrackSelectionIcon />} size="sm" className="bg-white/15 text-white" />
+        <div className="min-w-0 flex-1">
+          <div className="gap-s-1 flex items-center">
+            <span className="text-caption truncate font-semibold">{item.title}</span>
+            {locked && <Lock className="text-foreground-muted h-3 w-3 shrink-0" />}
+          </div>
+          {updatedLabel && (
+            <div className="text-foreground-muted text-caption mt-0.5">{updatedLabel}</div>
+          )}
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+export function TrackSelectionsMobileShell() {
+  const pathname = usePathname() ?? '';
+  const isDesktop = useIsDesktop();
+
+  const { data, isLoading } = useMyTrackSelections(50);
+  const meetings = data?.pages.flatMap((p) => p.content) ?? [];
+
+  if (!isDesktop) {
+    return (
+      <p className="text-foreground-muted py-s-10 text-center text-sm">
+        모바일에서는 지원하지 않는 기능입니다. PC에서 이용해 주세요.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="border-border mb-s-3 pb-s-2 pt-s-1 flex items-center justify-between border-b">
+        <h2 className="text-foreground pl-2.5 text-2xl font-bold lg:text-3xl">내 선곡</h2>
+        <Button
+          asChild
+          size="sm"
+          variant="accent-outline"
+          aria-label="선곡 생성"
+          className="rounded-[5px] border-white text-white hover:border-transparent hover:bg-white hover:text-neutral-900 active:border-transparent active:bg-neutral-200 active:text-neutral-900"
+        >
+          <Link href={ROUTES.TRACK_SELECTION_CREATE}>
+            <Plus className="h-4 w-4" /> 선곡 생성
+          </Link>
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-s-2">
+          <Skeleton className="h-14 w-full" rounded="md" />
+          <Skeleton className="h-14 w-full" rounded="md" />
+          <Skeleton className="h-14 w-full" rounded="md" />
+        </div>
+      ) : meetings.length === 0 ? (
+        <p className="text-foreground-muted py-s-6 text-center text-sm">
+          참여 중인 선곡회의가 없습니다.
+        </p>
+      ) : (
+        <ul className="gap-s-1 flex flex-col">
+          {meetings.map((item) => {
+            const href = ROUTES.TRACK_SELECTION_DETAIL(item.selectionId);
+            const active = pathname === href || pathname.startsWith(`${href}/`);
+            return <MeetingRow key={item.selectionId} item={item} active={active} />;
+          })}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/app/(main)/track-selections/[selectionId]/MeetingDetail.client.tsx
+++ b/src/app/(main)/track-selections/[selectionId]/MeetingDetail.client.tsx
@@ -1,0 +1,704 @@
+'use client';
+
+import {
+  CheckCircle2,
+  ListMusic,
+  Lock,
+  PanelRightOpen,
+  Plus,
+  RotateCcw,
+  Search,
+  Users,
+} from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { ROUTES } from '@/global/config/routes';
+
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AddSongModal } from '@/domain/setlist-meeting/components/AddSongModal.client';
+import { MeetingChatBox } from '@/domain/setlist-meeting/components/MeetingChatBox.client';
+import { SessionPanel } from '@/domain/setlist-meeting/components/SessionPanel.client';
+import {
+  SongTable,
+  type SongSortDir,
+  type SongSortKey,
+} from '@/domain/setlist-meeting/components/SongTable.client';
+import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
+import { useMe } from '@/domain/member/hooks/useMe';
+import { useTrackSelection } from '@/domain/track-selection/hooks/useTrackSelection';
+import { useTrackSelectionItems } from '@/domain/track-selection/hooks/useTrackSelectionItems';
+import { useDeleteTrackSelectionItem } from '@/domain/track-selection/hooks/useDeleteTrackSelectionItem';
+import { toSong } from '@/domain/track-selection/utils/toSong';
+import { resolveMemberId } from '@/domain/track-selection/utils/resolveMemberId';
+import { lockSelection, unlockSelection } from '@/domain/track-selection/api/lockSelection';
+import { useUpdateItemSelection } from '@/domain/track-selection/hooks/useUpdateItemSelection';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/global/config/queryKeys';
+import type { Member } from '@/domain/setlist-meeting/types';
+import { ParticipantsModal } from '@/domain/setlist-meeting/components/ParticipantsModal.client';
+import { useCreateSetlist } from '@/domain/setlist/hooks/useCreateSetlist';
+import { useToast } from '@/hooks/useToast';
+import type { Song } from '@/domain/setlist-meeting/types';
+import { confirmedCount, isReady, totalNeed } from '@/domain/setlist-meeting/utils';
+import { cn } from '@/lib/cn';
+
+type Filter = 'all' | 'ready' | 'pending' | 'mine';
+
+function applyFilter(songs: Song[], filter: Filter, currentUserId: string): Song[] {
+  switch (filter) {
+    case 'ready':
+      return songs.filter(isReady);
+    case 'pending':
+      return songs.filter((s) => !isReady(s));
+    case 'mine':
+      return songs.filter((s) =>
+        Object.values(s.applicants).some((list) => list.includes(currentUserId)),
+      );
+    case 'all':
+    default:
+      return songs;
+  }
+}
+
+function applySearch(songs: Song[], q: string): Song[] {
+  const t = q.trim().toLowerCase();
+  if (!t) return songs;
+  return songs.filter(
+    (s) =>
+      s.title.toLowerCase().includes(t) ||
+      s.artist.toLowerCase().includes(t) ||
+      (s.album ?? '').toLowerCase().includes(t),
+  );
+}
+
+export function MeetingDetail({ meetingId }: { meetingId: string }) {
+  // 실API: 선곡 상세 조회
+  const {
+    data: selection,
+    isPending: selectionPending,
+    error: selectionError,
+  } = useTrackSelection(meetingId);
+  const { data: me } = useMe();
+
+  // 실API: 선곡 항목 목록 조회 → mock store에 동기화
+  const { data: itemsData } = useTrackSelectionItems(meetingId, 50);
+  const deleteItem = useDeleteTrackSelectionItem(meetingId);
+  const toggleSelection = useUpdateItemSelection(meetingId);
+  const qc = useQueryClient();
+
+  const members: Member[] = useMemo(
+    () =>
+      (selection?.participants ?? []).map((p) => {
+        const memberId = resolveMemberId(p);
+        return {
+          id: String(memberId),
+          name: p.member?.name ?? `멤버 #${memberId}`,
+          role: '',
+          avatar: 'var(--color-accent)',
+          profileImg: p.member?.profileImg,
+        };
+      }),
+    [selection?.participants],
+  );
+
+  const songs = useSetlistStore((s) => s.songs);
+  const allSongs = useMemo(
+    () => songs.filter((song) => song.meetingId === meetingId),
+    [songs, meetingId],
+  );
+  const currentUserId = useSetlistStore((s) => s.currentUserId);
+  const setCurrentUser = useSetlistStore((s) => s.setCurrentUser);
+  const setSongs = useSetlistStore((s) => s.setSongs);
+  const selectedSongId = useSetlistStore((s) => s.selectedSongId);
+  const setSelectedMeeting = useSetlistStore((s) => s.setSelectedMeeting);
+  const setSelectedSong = useSetlistStore((s) => s.setSelectedSong);
+  const setFocusedSession = useSetlistStore((s) => s.setFocusedSession);
+  const deleteSong = useSetlistStore((s) => s.deleteSong);
+  const lockMeeting = useSetlistStore((s) => s.lockMeeting);
+  const unlockMeeting = useSetlistStore((s) => s.unlockMeeting);
+
+  const isManager = selection ? selection.managerId === me?.id : false;
+  const isLocked = Boolean(selection?.lockedAt);
+  const [pendingLockAction, setPendingLockAction] = useState<'lock' | 'unlock' | null>(null);
+  const [showParticipantsModal, setShowParticipantsModal] = useState(false);
+  const [showCreateSetlist, setShowCreateSetlist] = useState(false);
+  const [setlistTitle, setSetlistTitle] = useState('');
+  const setlistTitleRef = useRef<HTMLInputElement>(null);
+  const createSetlist = useCreateSetlist();
+  const router = useRouter();
+  const toast = useToast();
+
+  const hasSelectedSongs = allSongs.some((s) => s.isSelected);
+
+  const [filter, setFilter] = useState<Filter>('all');
+  const [query, setQuery] = useState('');
+  const [memberQuery, setMemberQuery] = useState('');
+  // 우측 세션 패널 토글. 곡을 새로 선택하면 자동 열림.
+  const [sessionPanelOpen, setSessionPanelOpen] = useState(false);
+  // 컬럼 정렬 — 재생시간 / 세션 모집 현황. 동일 컬럼 재클릭 시 asc↔desc 토글.
+  const [sortKey, setSortKey] = useState<SongSortKey | null>(null);
+  const [sortDir, setSortDir] = useState<SongSortDir>('asc');
+  // 곡 수정 / 삭제 다이얼로그 상태.
+  const [editingSong, setEditingSong] = useState<Song | null>(null);
+  const [pendingDeleteSong, setPendingDeleteSong] = useState<Song | null>(null);
+  // 우측 패널 / 하단 채팅 순차 애니메이션:
+  //  - 오픈 시: 채팅이 먼저 슬라이드 업(0~200ms) → 끝나면 우측 패널 슬라이드 인(200~400ms)
+  //  - 닫기 시: 우측 패널이 먼저 슬라이드 아웃(0~200ms) → 끝나면 채팅 슬라이드 다운(200~400ms) → 480ms 후 unmount
+  // 결과: 우측 패널은 항상 채팅이 자리잡은 후에만 보이고, 채팅은 우측 패널이 사라진 후에야 사라짐.
+  const [chatMounted, setChatMounted] = useState(false);
+  const [chatSlideIn, setChatSlideIn] = useState(false);
+  const [panelSlideIn, setPanelSlideIn] = useState(false);
+
+  useEffect(() => {
+    setSelectedMeeting(meetingId);
+  }, [meetingId, setSelectedMeeting]);
+
+  // 실 유저 ID → mock store 동기화 (SessionPanel, SongTable, AddSongModal 공통 기준점)
+  useEffect(() => {
+    if (me?.id !== undefined) setCurrentUser(String(me.id));
+  }, [me?.id, setCurrentUser]);
+
+  // 실 API items → mock store 동기화 (다른 멤버가 추가한 곡도 표시)
+  useEffect(() => {
+    if (!itemsData) return;
+    const realSongs = itemsData.pages.flatMap((p) => p.content).map(toSong);
+    setSongs(meetingId, realSongs);
+  }, [itemsData, meetingId, setSongs]);
+
+  useEffect(() => {
+    if (sessionPanelOpen && selectedSongId) {
+      // 오픈 시퀀스: 채팅 먼저 → 200ms 후 우측 패널.
+      setChatMounted(true);
+      // 다음 프레임에 translate 클래스 변경(이전 mount 직후 transition 발동).
+      const enter = requestAnimationFrame(() => setChatSlideIn(true));
+      const panelTimer = setTimeout(() => setPanelSlideIn(true), 200);
+      return () => {
+        cancelAnimationFrame(enter);
+        clearTimeout(panelTimer);
+      };
+    }
+    // 클로즈 시퀀스: 우측 패널 먼저 → 200ms 후 채팅 슬라이드 다운 → 480ms 후 unmount.
+    setPanelSlideIn(false);
+    const chatOut = setTimeout(() => setChatSlideIn(false), 200);
+    const unmount = setTimeout(() => setChatMounted(false), 480);
+    return () => {
+      clearTimeout(chatOut);
+      clearTimeout(unmount);
+    };
+  }, [sessionPanelOpen, selectedSongId]);
+
+  const stats = useMemo(() => {
+    const total = allSongs.length;
+    const readyCount = allSongs.filter(isReady).length;
+    return { total, ready: readyCount, pending: total - readyCount };
+  }, [allSongs]);
+
+  // 멤버 이름 부분 매칭 → userId 집합. 빈 검색이면 빈 Set.
+  const matchedUserIds = useMemo(() => {
+    const t = memberQuery.trim().toLowerCase();
+    if (!t) return new Set<string>();
+    return new Set(members.filter((m) => m.name.toLowerCase().includes(t)).map((m) => m.id));
+  }, [members, memberQuery]);
+
+  const filtered = useMemo(() => {
+    let result = applySearch(applyFilter(allSongs, filter, currentUserId), query);
+    if (matchedUserIds.size > 0) {
+      // 곡 필터 + 멤버 필터 AND: 매칭 유저가 어떤 세션이든 들어있는 곡만.
+      result = result.filter(
+        (s) =>
+          Object.values(s.applicants).some((list) => list.some((u) => matchedUserIds.has(u))) ||
+          Object.values(s.confirmed).some((list) => list.some((u) => matchedUserIds.has(u))),
+      );
+    }
+    return result;
+  }, [allSongs, filter, currentUserId, query, matchedUserIds]);
+
+  // 컬럼 정렬 적용. progress = confirmed/totalNeed 비율, duration = mm*60+ss 초.
+  const visible = useMemo(() => {
+    if (!sortKey) return filtered;
+    const score = (s: Song): number => {
+      if (sortKey === 'duration') {
+        if (!s.duration) return Number.NEGATIVE_INFINITY;
+        const m = s.duration.match(/^(\d{1,2}):(\d{2})$/);
+        if (!m) return Number.NEGATIVE_INFINITY;
+        return parseInt(m[1]!, 10) * 60 + parseInt(m[2]!, 10);
+      }
+      const total = totalNeed(s);
+      return total === 0 ? 0 : confirmedCount(s) / total;
+    };
+    return [...filtered].sort((a, b) => {
+      const av = score(a);
+      const bv = score(b);
+      return sortDir === 'asc' ? av - bv : bv - av;
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  const handleToggleSort = (key: SongSortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
+
+  // ↑/↓ 키보드 네비게이션 — 입력 필드 포커스 시에는 무시. 이동 시 focusedSession 정리(overview 모드).
+  useEffect(() => {
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+      const tag = (e.target as HTMLElement | null)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (visible.length === 0) return;
+      e.preventDefault();
+      const idx = selectedSongId ? visible.findIndex((s) => s.id === selectedSongId) : -1;
+      let nextIdx: number;
+      if (idx < 0) {
+        nextIdx = e.key === 'ArrowDown' ? 0 : visible.length - 1;
+      } else {
+        nextIdx =
+          e.key === 'ArrowUp' ? Math.max(0, idx - 1) : Math.min(visible.length - 1, idx + 1);
+      }
+      const nextSong = visible[nextIdx];
+      if (!nextSong) return;
+      if (nextSong.id !== selectedSongId) {
+        setSelectedSong(nextSong.id);
+        setFocusedSession(null);
+        setSessionPanelOpen(true);
+        // Task 25 — 포커스된 곡 행이 항상 보이도록 자동 스크롤.
+        // 마이크로태스크 후 호출 — 리스트가 selected 클래스로 재렌더된 다음 스크롤.
+        queueMicrotask(() => {
+          const row = document.querySelector<HTMLElement>(`[data-song-id="${nextSong.id}"]`);
+          row?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        });
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [visible, selectedSongId, setSelectedSong, setFocusedSession]);
+
+  if (selectionPending) {
+    return (
+      <div className="px-s-5 py-s-6 space-y-s-3">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-4 w-48" />
+      </div>
+    );
+  }
+
+  if (selectionError || !selection) {
+    return (
+      <div className="px-s-5 py-s-6">
+        <p className="text-foreground-muted text-caption">
+          {selectionError?.message ?? '회의를 찾을 수 없습니다.'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex h-full">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="border-border px-s-5 py-s-4 border-b">
+          <div className="min-w-0">
+            <h1 className="text-title-lg mt-s-1 font-bold">{selection.title}</h1>
+            <div className="text-foreground-muted text-caption gap-s-3 mt-s-2 flex flex-wrap items-center">
+              <span>
+                전체 <strong className="text-foreground">{stats.total}</strong>곡
+              </span>
+              <span className="text-success">
+                합주 가능 <strong>{stats.ready}</strong>
+              </span>
+              <span className="text-warn">
+                모집 중 <strong>{stats.pending}</strong>
+              </span>
+            </div>
+          </div>
+
+          {/* 필터 탭 + 검색 + '곡 추가'(매니저) 를 같은 라인에 — 사용자가 표 바로 위에서 즉시 곡을 추가할 수 있도록. */}
+          <div className="gap-s-3 mt-s-4 flex flex-col items-stretch md:flex-row md:flex-wrap md:items-center">
+            <Tabs value={filter} onValueChange={(v) => setFilter(v as Filter)}>
+              <TabsList>
+                <TabsTrigger value="all">전체</TabsTrigger>
+                <TabsTrigger value="ready">합주 가능</TabsTrigger>
+                <TabsTrigger value="pending">모집 중</TabsTrigger>
+                <TabsTrigger value="mine">내 지원</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 flex items-center rounded-md border md:w-60">
+              <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="곡명 · 아티스트 · 앨범"
+                aria-label="곡 검색"
+                className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+              />
+            </div>
+            <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 flex items-center rounded-md border md:w-52">
+              <Search className="text-foreground-muted h-4 w-4 shrink-0" aria-hidden="true" />
+              <input
+                type="search"
+                value={memberQuery}
+                onChange={(e) => setMemberQuery(e.target.value)}
+                placeholder="멤버 이름"
+                aria-label="멤버 검색"
+                className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+              />
+            </div>
+            <div className="gap-s-2 flex items-center md:ml-auto">
+              {isManager && !isLocked && (
+                <AddSongModal
+                  meetingId={meetingId}
+                  trigger={
+                    <Button size="sm" variant="primary" aria-label="새 곡 추가">
+                      <Plus className="h-4 w-4" /> 곡 추가
+                    </Button>
+                  }
+                />
+              )}
+              {isManager && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => setShowParticipantsModal(true)}
+                  aria-label="참여자 관리"
+                >
+                  <Users className="h-4 w-4" /> 참여자
+                </Button>
+              )}
+              {isManager && !isLocked && (
+                <Button
+                  size="sm"
+                  variant="primary"
+                  onClick={() => setPendingLockAction('lock')}
+                  aria-label="선곡 확정"
+                  className="bg-success hover:bg-success/90 text-white"
+                >
+                  <CheckCircle2 className="h-4 w-4" /> 선곡 확정
+                </Button>
+              )}
+              {isManager && isLocked && (
+                <Button
+                  size="sm"
+                  variant="primary"
+                  onClick={() => {
+                    setSetlistTitle(selection?.title ?? '');
+                    setShowCreateSetlist(true);
+                  }}
+                  disabled={!hasSelectedSongs}
+                  aria-label="셋리스트 생성"
+                  aria-disabled={!hasSelectedSongs}
+                >
+                  <ListMusic className="h-4 w-4" /> 셋리스트 생성
+                </Button>
+              )}
+              {isManager && isLocked && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => setPendingLockAction('unlock')}
+                  aria-label="회의 재개"
+                >
+                  <RotateCcw className="h-4 w-4" /> 회의 재개
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {/* 잠금 안내 배너 — 모든 멤버에게 노출. */}
+          {isLocked && (
+            <div className="bg-success-dim border-success/30 mt-s-3 px-s-3 py-s-2 gap-s-2 text-caption text-success flex items-center rounded-md border">
+              <Lock className="h-4 w-4 shrink-0" />
+              <span className="font-semibold">선곡이 확정된 회의입니다.</span>
+              <span className="text-foreground-sub">
+                곡 추가/수정/삭제는 잠겨 있습니다.
+                {isManager && hasSelectedSongs && (
+                  <>
+                    {' '}
+                    ★ 표시된 {allSongs.filter((s) => s.isSelected).length}곡으로 셋리스트를 생성할
+                    수 있습니다.
+                  </>
+                )}
+                {isManager && !hasSelectedSongs && (
+                  <> 회의를 재개한 뒤 ★ 아이콘으로 곡을 선택하고 다시 확정하세요.</>
+                )}
+              </span>
+            </div>
+          )}
+        </header>
+
+        <div className="flex-1 overflow-y-auto">
+          <SongTable
+            songs={visible}
+            members={members}
+            selectedSongId={selectedSongId}
+            currentUserId={currentUserId}
+            isManager={isManager}
+            isLocked={isLocked}
+            matchedUserIds={matchedUserIds}
+            sortKey={sortKey}
+            sortDir={sortDir}
+            onToggleSort={handleToggleSort}
+            onSelectSong={(id) => {
+              // 메인 행 클릭은 항상 overview 모드로 진입. 세션 focus 는 우측 패널에서만.
+              if (id === selectedSongId) {
+                setSessionPanelOpen((v) => !v);
+                return;
+              }
+              setSelectedSong(id);
+              setFocusedSession(null);
+              setSessionPanelOpen(true);
+            }}
+            onEditSong={(id) => {
+              const s = visible.find((x) => x.id === id);
+              if (s) setEditingSong(s);
+            }}
+            onDeleteSong={(id) => {
+              const s = visible.find((x) => x.id === id);
+              if (s) setPendingDeleteSong(s);
+            }}
+            onToggleSelection={(id, selected) => {
+              // 낙관적 업데이트: 클릭 즉시 store 반영
+              setSongs(
+                meetingId,
+                allSongs.map((s) => (s.id === id ? { ...s, isSelected: selected } : s)),
+              );
+              toggleSelection.mutate(
+                { itemId: id, selected },
+                {
+                  onError: () => {
+                    // 실패 시 롤백
+                    setSongs(
+                      meetingId,
+                      allSongs.map((s) => (s.id === id ? { ...s, isSelected: !selected } : s)),
+                    );
+                    toast.error(
+                      selected
+                        ? '곡 선택에 실패했습니다. 모든 세션의 확정 인원이 충족되어야 합니다.'
+                        : '곡 선택 해제에 실패했습니다.',
+                    );
+                  },
+                },
+              );
+            }}
+          />
+        </div>
+        {/* 메인 컬럼 하단 채팅 — 시퀀싱: 오픈 시 먼저 들어오고, 닫을 때는 우측 패널 후에 나감. */}
+        {chatMounted && selectedSongId && (
+          <div
+            className={cn(
+              'relative z-30 transition-transform duration-200 ease-out',
+              chatSlideIn ? 'translate-y-0' : 'pointer-events-none translate-y-full',
+            )}
+          >
+            <MeetingChatBox selectionId={meetingId} songId={selectedSongId} />
+          </div>
+        )}
+      </div>
+
+      {/* 우측 오버레이 SessionPanel — panelSlideIn 상태로 슬라이드. 채팅이 자리잡은 후에만 보이고 채팅이 사라지기 전에 먼저 빠짐. */}
+      {selectedSongId && (
+        <aside
+          aria-hidden={!panelSlideIn}
+          className={cn(
+            'absolute top-0 right-0 bottom-[280px] z-20 hidden shadow-lg transition-transform duration-200 ease-out lg:flex',
+            panelSlideIn ? 'translate-x-0' : 'pointer-events-none translate-x-full',
+          )}
+          style={{ width: 380 }}
+        >
+          <SessionPanel
+            songId={selectedSongId}
+            selectionId={meetingId}
+            members={members}
+            isManager={isManager}
+            onClose={() => setSessionPanelOpen(false)}
+          />
+        </aside>
+      )}
+
+      {/* 닫혔을 때 다시 열기 핸들. */}
+      {selectedSongId && !sessionPanelOpen && (
+        <button
+          type="button"
+          onClick={() => setSessionPanelOpen(true)}
+          aria-label="세션 패널 열기"
+          className="bg-surface border-border text-foreground-sub hover:bg-card hover:text-foreground top-s-3 right-s-3 absolute z-30 hidden h-8 w-8 items-center justify-center rounded-md border shadow-sm transition-colors lg:inline-flex"
+        >
+          <PanelRightOpen className="h-4 w-4" />
+        </button>
+      )}
+
+      {/* 곡 수정 모달 — 외부에서 open 제어. song 이 있으면 수정 모드로 동작. */}
+      {editingSong && (
+        <AddSongModal
+          meetingId={meetingId}
+          song={editingSong}
+          open={true}
+          onOpenChange={(o) => {
+            if (!o) setEditingSong(null);
+          }}
+        />
+      )}
+
+      {/* 삭제 확인 다이얼로그 — 브라우저 기본 confirm 대신 디자인 토큰 적용. */}
+      <ConfirmDialog
+        open={pendingDeleteSong !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingDeleteSong(null);
+        }}
+        title="곡 삭제"
+        description={
+          pendingDeleteSong ? (
+            <>
+              <strong className="text-foreground">{pendingDeleteSong.title}</strong> 곡을 정말
+              삭제하시겠습니까? 지원/확정 정보도 함께 사라집니다.
+            </>
+          ) : null
+        }
+        confirmLabel="삭제"
+        tone="danger"
+        onConfirm={() => {
+          if (!pendingDeleteSong) return;
+          deleteItem.mutate(pendingDeleteSong.id, {
+            onSuccess: () => {
+              deleteSong(pendingDeleteSong.id);
+              toast.success('곡이 삭제되었습니다.');
+            },
+            onError: () => {
+              toast.error('곡 삭제에 실패했습니다.');
+            },
+          });
+        }}
+      />
+
+      {/* 참여자 관리 모달 — 매니저 전용. */}
+      {showParticipantsModal && selection && (
+        <ParticipantsModal
+          selectionId={meetingId}
+          bandIds={selection.bandIds}
+          participants={selection.participants}
+          members={members}
+          currentUserId={currentUserId}
+          onClose={() => setShowParticipantsModal(false)}
+        />
+      )}
+
+      {/* 셋리스트 생성 다이얼로그 */}
+      {showCreateSetlist && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="bg-surface border-border w-full max-w-sm rounded-xl border shadow-xl">
+            <header className="border-border px-s-5 py-s-4 border-b">
+              <h2 className="text-title gap-s-2 flex items-center font-bold">
+                <ListMusic className="h-4 w-4" /> 셋리스트 생성
+              </h2>
+              <p className="text-foreground-muted text-caption mt-s-1">
+                선택된 곡({allSongs.filter((s) => s.isSelected).length}곡)으로 셋리스트를 만듭니다.
+              </p>
+            </header>
+            <div className="px-s-5 py-s-4">
+              <label className="text-caption font-semibold" htmlFor="setlist-title">
+                셋리스트 이름 <span className="text-foreground-muted font-normal">(선택)</span>
+              </label>
+              <input
+                ref={setlistTitleRef}
+                id="setlist-title"
+                type="text"
+                value={setlistTitle}
+                onChange={(e) => setSetlistTitle(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !createSetlist.isPending) {
+                    e.preventDefault();
+                    createSetlist.mutate(
+                      { trackSelectionId: meetingId, title: setlistTitle.trim() || undefined },
+                      {
+                        onSuccess: (data) => {
+                          toast.success('셋리스트가 생성되었습니다.');
+                          setShowCreateSetlist(false);
+                          router.push(ROUTES.SETLIST_DETAIL(data.setlistId));
+                        },
+                        onError: () => toast.error('셋리스트 생성에 실패했습니다.'),
+                      },
+                    );
+                  }
+                  if (e.key === 'Escape') setShowCreateSetlist(false);
+                }}
+                placeholder={selection?.title ?? '셋리스트 이름'}
+                autoFocus
+                className="bg-card border-border text-body placeholder:text-foreground-muted mt-s-2 px-s-3 py-s-2 w-full rounded-md border outline-none focus:ring-1 focus:ring-current"
+              />
+            </div>
+            <footer className="border-border px-s-5 py-s-3 gap-s-2 flex justify-end border-t">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setShowCreateSetlist(false)}
+                disabled={createSetlist.isPending}
+              >
+                취소
+              </Button>
+              <Button
+                size="sm"
+                variant="primary"
+                disabled={createSetlist.isPending}
+                onClick={() =>
+                  createSetlist.mutate(
+                    { trackSelectionId: meetingId, title: setlistTitle.trim() || undefined },
+                    {
+                      onSuccess: (data) => {
+                        toast.success('셋리스트가 생성되었습니다.');
+                        setShowCreateSetlist(false);
+                        router.push(ROUTES.SETLIST_DETAIL(data.setlistId));
+                      },
+                      onError: () => toast.error('셋리스트 생성에 실패했습니다.'),
+                    },
+                  )
+                }
+              >
+                {createSetlist.isPending ? '생성 중…' : '생성'}
+              </Button>
+            </footer>
+          </div>
+        </div>
+      )}
+
+      {/* 선곡 확정 / 회의 재개 확인 다이얼로그 — 매니저 전용 액션. */}
+      <ConfirmDialog
+        open={pendingLockAction !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingLockAction(null);
+        }}
+        title={pendingLockAction === 'lock' ? '선곡 확정' : '회의 재개'}
+        description={
+          pendingLockAction === 'lock'
+            ? '선곡을 확정하면 모든 멤버의 곡 추가·수정·삭제가 잠깁니다. 진행하시겠습니까?'
+            : '회의를 재개하면 다시 곡 추가·수정·삭제가 가능해집니다. 진행하시겠습니까?'
+        }
+        confirmLabel={pendingLockAction === 'lock' ? '확정' : '재개'}
+        onConfirm={async () => {
+          try {
+            if (pendingLockAction === 'lock') {
+              await lockSelection(meetingId);
+              lockMeeting(meetingId);
+              toast.success('선곡이 확정되었습니다.');
+            } else if (pendingLockAction === 'unlock') {
+              await unlockSelection(meetingId);
+              unlockMeeting(meetingId);
+              toast.info('회의가 재개되었습니다.');
+            }
+            await qc.invalidateQueries({ queryKey: queryKeys.trackSelection.detail(meetingId) });
+          } catch {
+            toast.error('요청에 실패했습니다.');
+          } finally {
+            setPendingLockAction(null);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(main)/track-selections/[selectionId]/page.tsx
+++ b/src/app/(main)/track-selections/[selectionId]/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { ROUTES } from '@/global/config/routes';
+
+import { MeetingDetail } from './MeetingDetail.client';
+
+export const metadata: Metadata = {
+  title: '선곡 회의 상세 | Bandage',
+};
+
+export default async function TrackSelectionDetailPage({
+  params,
+}: {
+  params: Promise<{ selectionId: string }>;
+}) {
+  const { selectionId } = await params;
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 py-3 pr-5 pl-2 lg:pr-8 lg:pl-4">
+        <Link
+          href={ROUTES.TRACK_SELECTIONS}
+          className="text-foreground-sub hover:text-foreground inline-flex items-center gap-1 text-sm no-underline transition-colors"
+        >
+          ← 선곡 목록
+        </Link>
+      </div>
+      <div className="min-h-0 flex-1">
+        <MeetingDetail meetingId={selectionId} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/track-selections/create/MeetingCreateWizard.client.tsx
+++ b/src/app/(main)/track-selections/create/MeetingCreateWizard.client.tsx
@@ -1,0 +1,796 @@
+'use client';
+
+import { ArrowRight, CalendarDays, Loader2, Search, Users, X } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { Avatar } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { StepIndicator } from '@/components/ui/step-indicator';
+import { getBandMembers } from '@/domain/band/api/getBandMembers';
+import { useBandSearch } from '@/domain/band/hooks/useBandSearch';
+import { useMyBands } from '@/domain/band/hooks/useMyBands';
+import type { BandInfoResponse, MyBandInfoResponse } from '@/domain/band/types';
+import { getMe } from '@/domain/member/api/getMe';
+import { useMe } from '@/domain/member/hooks/useMe';
+import { useMemberSearch } from '@/domain/member/hooks/useMemberSearch';
+import type { MemberSearchItemResponse } from '@/domain/member/types';
+import { createTrackSelection } from '@/domain/track-selection/api/createTrackSelection';
+import { ROUTES } from '@/global/config/routes';
+import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/cn';
+
+const STEPS = ['참여 인원', '회의 정보', '확인'] as const;
+type Step = 0 | 1 | 2;
+type BandTab = 'my-bands' | 'band-search' | 'member';
+
+type Participant = {
+  memberId: number;
+  name: string;
+  profileImg?: string | null;
+};
+
+export function MeetingCreateWizard() {
+  const router = useRouter();
+  const toast = useToast();
+  const { data: me } = useMe();
+  const myMemberId = me?.id;
+
+  const [step, setStep] = useState<Step>(0);
+  const [isPending, setIsPending] = useState(false);
+
+  // Step 0 — 참여 인원
+  const [bandTab, setBandTab] = useState<BandTab>('my-bands');
+  const [selectedBandIds, setSelectedBandIds] = useState<string[]>([]);
+  // 선택된 밴드 이름 조회용 (내 밴드 + 검색 결과 통합)
+  const [selectedBandNames, setSelectedBandNames] = useState<Record<string, string>>({});
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [memberQuery, setMemberQuery] = useState('');
+  const [bandQuery, setBandQuery] = useState('');
+  const [importing, setImporting] = useState(false);
+
+  // Step 1 — 회의 정보
+  const [title, setTitle] = useState('');
+  const [managerId, setManagerId] = useState<number | null>(null);
+  const [practiceFrom, setPracticeFrom] = useState('');
+  const [practiceTo, setPracticeTo] = useState('');
+
+  // Real API data
+  const { data: myBands = [] } = useMyBands(50);
+  const { data: memberSearchResults = [] } = useMemberSearch(memberQuery);
+  const bandSearchResult = useBandSearch(bandQuery, 20);
+  const bandSearchItems = bandSearchResult.data?.pages.flatMap((p) => p.content) ?? [];
+
+  const canNext = (() => {
+    if (step === 0) return selectedBandIds.length > 0 && participants.length > 0;
+    if (step === 1) return title.trim().length > 0 && managerId !== null;
+    return true;
+  })();
+
+  const next = () => {
+    if (!canNext) {
+      if (step === 0) {
+        if (selectedBandIds.length === 0) toast.error('최소 1개 이상의 밴드를 선택하세요.');
+        else toast.error('최소 1명 이상의 참여 멤버를 추가하세요.');
+      } else if (step === 1) {
+        if (!title.trim()) toast.error('회의 제목을 입력하세요.');
+        else toast.error('매니저를 지정하세요.');
+      }
+      return;
+    }
+    if (step < 2) setStep((step + 1) as Step);
+  };
+
+  const back = () => step > 0 && setStep((step - 1) as Step);
+
+  const toggleBand = (band: Pick<BandInfoResponse, 'bandId' | 'bandName'>) => {
+    const { bandId, bandName } = band;
+    setSelectedBandIds((prev) =>
+      prev.includes(bandId) ? prev.filter((id) => id !== bandId) : [...prev, bandId],
+    );
+    setSelectedBandNames((prev) => ({ ...prev, [bandId]: bandName }));
+  };
+
+  const importBandMembers = async () => {
+    if (selectedBandIds.length === 0) return;
+    setImporting(true);
+    try {
+      const results = await Promise.all(
+        selectedBandIds.map((id) => getBandMembers(id, { pageSize: 100 })),
+      );
+      const raw: Participant[] = results.flatMap((r) =>
+        r.content.map((m) => {
+          // 본인 항목은 useMe() 데이터로 name/profileImg 보정 (백엔드 FE-API-012 미지원 대응)
+          const isMe = me && m.memberId === me.id;
+          return {
+            memberId: m.memberId,
+            name: isMe ? me.name : (m.name ?? `멤버 #${m.memberId}`),
+            profileImg: isMe ? (me.profileImg ?? m.profileImg) : m.profileImg,
+          };
+        }),
+      );
+      // 여러 밴드 선택 시 incoming 내 중복 제거
+      const incomingMap = new Map<number, Participant>();
+      for (const m of raw) {
+        if (!incomingMap.has(m.memberId)) incomingMap.set(m.memberId, m);
+      }
+      // 백엔드가 리더/생성자를 members 목록에서 제외하는 경우 자동 추가
+      // me가 null/undefined이면 직접 API 호출로 보장
+      const currentUser = me ?? (await getMe());
+      if (currentUser && !incomingMap.has(currentUser.id)) {
+        incomingMap.set(currentUser.id, {
+          memberId: currentUser.id,
+          name: currentUser.name,
+          profileImg: currentUser.profileImg,
+        });
+      }
+      setParticipants((prev) => {
+        const existing = new Set(prev.map((p) => p.memberId));
+        const toAdd = Array.from(incomingMap.values()).filter((m) => !existing.has(m.memberId));
+        return [...prev, ...toAdd];
+      });
+      toast.success('멤버를 추가했습니다.');
+    } catch {
+      toast.error('멤버 불러오기에 실패했습니다.');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const addParticipant = (m: MemberSearchItemResponse) => {
+    setParticipants((prev) =>
+      prev.some((p) => p.memberId === m.memberId)
+        ? prev
+        : [...prev, { memberId: m.memberId, name: m.name, profileImg: m.profileImg }],
+    );
+  };
+
+  const removeParticipant = (memberId: number) => {
+    setParticipants((prev) => prev.filter((p) => p.memberId !== memberId));
+    if (managerId === memberId) setManagerId(null);
+  };
+
+  const submit = async () => {
+    if (managerId === null || isPending) return;
+    setIsPending(true);
+    try {
+      const pw =
+        practiceFrom && practiceTo && practiceFrom <= practiceTo
+          ? { from: practiceFrom, to: practiceTo }
+          : undefined;
+      const res = await createTrackSelection({
+        title: title.trim(),
+        bandIds: selectedBandIds,
+        managerId,
+        participantUserIds: participants.map((p) => p.memberId),
+        practiceWindow: pw,
+      });
+      toast.success('선곡 회의가 만들어졌습니다.');
+      router.replace(ROUTES.TRACK_SELECTION_DETAIL(res.selectionId));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '선곡 생성에 실패했습니다.';
+      toast.error(message);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <div
+      data-slot="meeting-create-wizard"
+      className="px-s-5 py-s-6 lg:px-s-8 lg:py-s-8 mx-auto max-w-3xl"
+    >
+      <header className="mb-s-6">
+        <button
+          type="button"
+          onClick={() => router.push(ROUTES.TRACK_SELECTIONS)}
+          className="text-foreground-muted hover:text-foreground text-caption mb-s-2"
+        >
+          ← 선곡 회의 목록
+        </button>
+        <h1 className="text-title-lg font-bold">선곡 회의 만들기</h1>
+      </header>
+
+      <StepIndicator steps={STEPS} current={step} className="mb-s-6" />
+
+      {step === 0 && (
+        <StepParticipants
+          myBands={myBands}
+          bandTab={bandTab}
+          setBandTab={setBandTab}
+          selectedBandIds={selectedBandIds}
+          onToggleBand={toggleBand}
+          onImportBandMembers={importBandMembers}
+          importing={importing}
+          selectedBandNames={selectedBandNames}
+          bandQuery={bandQuery}
+          setBandQuery={setBandQuery}
+          bandSearchItems={bandSearchItems}
+          bandSearchLoading={bandSearchResult.isFetching}
+          memberQuery={memberQuery}
+          setMemberQuery={setMemberQuery}
+          memberSearchResults={memberSearchResults}
+          participants={participants}
+          onAddParticipant={addParticipant}
+          onRemoveParticipant={removeParticipant}
+          myMemberId={myMemberId}
+          myName={me?.name}
+          myProfileImg={me?.profileImg}
+        />
+      )}
+      {step === 1 && (
+        <StepInfo
+          title={title}
+          setTitle={setTitle}
+          managerId={managerId}
+          setManagerId={setManagerId}
+          participants={participants}
+          myMemberId={myMemberId}
+          practiceFrom={practiceFrom}
+          setPracticeFrom={setPracticeFrom}
+          practiceTo={practiceTo}
+          setPracticeTo={setPracticeTo}
+        />
+      )}
+      {step === 2 && (
+        <StepReview
+          selectedBandNames={selectedBandNames}
+          selectedBandIds={selectedBandIds}
+          participants={participants}
+          title={title}
+          managerId={managerId}
+          practiceFrom={practiceFrom}
+          practiceTo={practiceTo}
+        />
+      )}
+
+      <footer className="mt-s-8 gap-s-3 flex items-center justify-between">
+        <Button type="button" variant="ghost" onClick={back} disabled={step === 0}>
+          이전
+        </Button>
+        {step < 2 ? (
+          <Button type="button" variant="primary" onClick={next} disabled={!canNext}>
+            다음 <ArrowRight className="h-4 w-4" />
+          </Button>
+        ) : (
+          <Button type="button" variant="primary" onClick={submit} disabled={isPending}>
+            {isPending ? (
+              <span className="flex items-center gap-1.5">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                생성 중…
+              </span>
+            ) : (
+              '회의 만들기'
+            )}
+          </Button>
+        )}
+      </footer>
+    </div>
+  );
+}
+
+// ── Step 0 — 참여 인원 ────────────────────────────────────────────────
+function StepParticipants({
+  myBands,
+  bandTab,
+  setBandTab,
+  selectedBandIds,
+  onToggleBand,
+  onImportBandMembers,
+  importing,
+  selectedBandNames,
+  bandQuery,
+  setBandQuery,
+  bandSearchItems,
+  bandSearchLoading,
+  memberQuery,
+  setMemberQuery,
+  memberSearchResults,
+  participants,
+  onAddParticipant,
+  onRemoveParticipant,
+  myMemberId,
+  myName,
+  myProfileImg,
+}: {
+  myBands: MyBandInfoResponse[];
+  bandTab: BandTab;
+  setBandTab: (t: BandTab) => void;
+  selectedBandIds: string[];
+  selectedBandNames: Record<string, string>;
+  onToggleBand: (band: Pick<BandInfoResponse, 'bandId' | 'bandName'>) => void;
+  onImportBandMembers: () => Promise<void>;
+  importing: boolean;
+  bandQuery: string;
+  setBandQuery: (q: string) => void;
+  bandSearchItems: BandInfoResponse[];
+  bandSearchLoading: boolean;
+  memberQuery: string;
+  setMemberQuery: (q: string) => void;
+  memberSearchResults: MemberSearchItemResponse[];
+  participants: Participant[];
+  onAddParticipant: (m: MemberSearchItemResponse) => void;
+  onRemoveParticipant: (memberId: number) => void;
+  myMemberId?: number;
+  myName?: string;
+  myProfileImg?: string | null;
+}) {
+  const participantSet = new Set(participants.map((p) => p.memberId));
+
+  const BandCheckList = ({
+    bands,
+  }: {
+    bands: Array<Pick<BandInfoResponse, 'bandId' | 'bandName'>>;
+  }) => (
+    <ul className="gap-s-1 flex flex-col">
+      {bands.map((b) => {
+        const active = selectedBandIds.includes(b.bandId);
+        return (
+          <li key={b.bandId}>
+            <label
+              className={cn(
+                'gap-s-3 px-s-3 py-s-2 hover:bg-card flex w-full cursor-pointer items-center rounded-md text-left transition-colors',
+                active && 'bg-accent-dim border-accent/30 border',
+              )}
+            >
+              <input
+                type="checkbox"
+                className="accent-accent h-4 w-4"
+                checked={active}
+                onChange={() => onToggleBand(b)}
+              />
+              <Users className="text-foreground-muted h-4 w-4 shrink-0" />
+              <span className="text-caption font-bold">{b.bandName}</span>
+            </label>
+          </li>
+        );
+      })}
+    </ul>
+  );
+
+  return (
+    <section className="gap-s-3 flex flex-col">
+      <UnderlineTabs
+        value={bandTab}
+        onChange={(v) => setBandTab(v as BandTab)}
+        items={[
+          { id: 'my-bands', label: '내 밴드' },
+          { id: 'band-search', label: '밴드 검색' },
+          { id: 'member', label: '멤버 검색' },
+        ]}
+      />
+
+      {/* ── 내 밴드 ── */}
+      {bandTab === 'my-bands' && (
+        <>
+          <p className="text-foreground-muted text-caption">
+            여러 밴드를 다중 선택 후 &lsquo;선택 밴드 멤버 추가&rsquo;로 일괄 추가하세요.
+          </p>
+          {myBands.length === 0 ? (
+            <p className="text-foreground-muted text-caption py-s-6 text-center">
+              소속된 밴드가 없습니다.
+            </p>
+          ) : (
+            <BandCheckList bands={myBands} />
+          )}
+        </>
+      )}
+
+      {/* ── 밴드 검색 ── */}
+      {bandTab === 'band-search' && (
+        <>
+          <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 flex items-center rounded-md border">
+            <Search className="text-foreground-muted h-4 w-4 shrink-0" />
+            <input
+              type="search"
+              value={bandQuery}
+              onChange={(e) => setBandQuery(e.target.value)}
+              placeholder="밴드명으로 검색"
+              aria-label="밴드 검색"
+              className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+            />
+            {bandSearchLoading && (
+              <Loader2 className="text-foreground-muted h-4 w-4 animate-spin" />
+            )}
+          </div>
+          {!bandQuery.trim() ? (
+            <p className="text-foreground-muted text-caption py-s-4 text-center">
+              밴드명을 입력하면 검색 결과가 나타납니다.
+            </p>
+          ) : bandSearchItems.length === 0 && !bandSearchLoading ? (
+            <p className="text-foreground-muted text-caption py-s-4 text-center">
+              일치하는 밴드가 없습니다.
+            </p>
+          ) : (
+            <BandCheckList bands={bandSearchItems} />
+          )}
+        </>
+      )}
+
+      {/* 밴드 탭 공통 — 선택된 밴드 칩 + 멤버 추가 버튼 */}
+      {(bandTab === 'my-bands' || bandTab === 'band-search') && selectedBandIds.length > 0 && (
+        <div className="border-border px-s-3 py-s-2 gap-s-2 flex flex-wrap items-center rounded-md border border-dashed">
+          <span className="text-foreground-muted text-micro font-bold">선택된 밴드</span>
+          {selectedBandIds.map((id) => (
+            <span
+              key={id}
+              className="bg-accent-dim border-accent/30 text-accent gap-s-1 px-s-2 inline-flex items-center rounded-full border py-0.5 text-xs font-semibold"
+            >
+              {selectedBandNames[id] ?? id}
+              <button
+                type="button"
+                onClick={() => onToggleBand({ bandId: id, bandName: selectedBandNames[id] ?? id })}
+                aria-label={`${selectedBandNames[id] ?? id} 선택 해제`}
+                className="hover:text-danger ml-0.5"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      {(bandTab === 'my-bands' || bandTab === 'band-search') && (
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={onImportBandMembers}
+          disabled={selectedBandIds.length === 0 || importing}
+        >
+          {importing ? (
+            <span className="flex items-center gap-1.5">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              불러오는 중…
+            </span>
+          ) : (
+            `선택 밴드 멤버 추가 (${selectedBandIds.length}개 밴드)`
+          )}
+        </Button>
+      )}
+
+      {/* ── 멤버 검색 ── */}
+      {bandTab === 'member' && (
+        <>
+          {/* 본인은 API에서 제외되므로 별도 버튼으로 추가 */}
+          {myMemberId !== undefined && !participantSet.has(myMemberId) && (
+            <button
+              type="button"
+              onClick={() =>
+                onAddParticipant({
+                  memberId: myMemberId,
+                  name: myName ?? '나',
+                  email: '',
+                  profileImg: myProfileImg ?? null,
+                })
+              }
+              className="bg-accent-dim border-accent/30 hover:bg-accent/20 gap-s-2 px-s-3 py-s-2 flex w-full items-center rounded-md border text-sm transition-colors"
+            >
+              <span className="text-accent font-bold">+ 나 추가</span>
+              <span className="text-foreground-muted text-micro font-normal">
+                {myName ? `(${myName})` : ''} 본인은 검색 결과에 포함되지 않아요
+              </span>
+            </button>
+          )}
+          <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 flex items-center rounded-md border">
+            <Search className="text-foreground-muted h-4 w-4 shrink-0" />
+            <input
+              type="search"
+              value={memberQuery}
+              onChange={(e) => setMemberQuery(e.target.value)}
+              placeholder="이름 · 이메일로 검색"
+              aria-label="멤버 검색"
+              className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+            />
+          </div>
+          <div className="border-border h-50 overflow-y-auto rounded-md border">
+            {!memberQuery.trim() ? (
+              <div className="text-foreground-muted text-caption px-s-4 py-s-8 text-center">
+                이름 또는 이메일로 검색하세요.
+              </div>
+            ) : memberSearchResults.length === 0 ? (
+              <div className="text-foreground-muted text-caption px-s-4 py-s-8 text-center">
+                일치하는 멤버가 없습니다.
+              </div>
+            ) : (
+              <ul>
+                {memberSearchResults.map((m) => {
+                  const added = participantSet.has(m.memberId);
+                  return (
+                    <li key={m.memberId}>
+                      <button
+                        type="button"
+                        onClick={() => onAddParticipant(m)}
+                        disabled={added}
+                        className="hover:bg-card border-border px-s-3 py-s-2 gap-s-3 flex w-full items-center border-b text-left last:border-b-0 disabled:cursor-default"
+                      >
+                        <Avatar src={m.profileImg ?? undefined} fallback={m.name} size="sm" />
+                        <div className="min-w-0 flex-1">
+                          <div className="text-caption truncate font-semibold">{m.name}</div>
+                          <div className="text-foreground-muted text-micro truncate">{m.email}</div>
+                        </div>
+                        <span
+                          className={cn(
+                            'text-micro px-s-2 shrink-0 rounded-full py-0.5 font-bold',
+                            added ? 'bg-success-dim text-success' : 'bg-accent-dim text-accent',
+                          )}
+                        >
+                          {added ? '추가됨' : '+ 추가'}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* 참여 확정 풀 */}
+      <div className="border-border mt-s-2 px-s-3 py-s-3 rounded-md border">
+        <div className="text-foreground-muted text-micro mb-s-2 font-bold uppercase">
+          참여 확정 ({participants.length})
+        </div>
+        {participants.length === 0 ? (
+          <p className="text-foreground-muted text-caption">
+            밴드 선택 후 &lsquo;멤버 추가&rsquo; 버튼을 누르거나 멤버 검색으로 직접 추가하세요.
+          </p>
+        ) : (
+          <ul className="gap-s-2 flex flex-wrap">
+            {participants.map((p) => (
+              <li
+                key={p.memberId}
+                className={cn(
+                  'bg-card border-border gap-s-1 px-s-2 inline-flex items-center rounded-full border py-0.5',
+                  p.memberId === myMemberId && 'border-accent/40 bg-accent-dim',
+                )}
+              >
+                <Avatar src={p.profileImg ?? undefined} fallback={p.name} size="sm" />
+                <span className="text-micro font-semibold">{p.name}</span>
+                {p.memberId === myMemberId && (
+                  <span className="text-accent text-micro font-bold">나</span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => onRemoveParticipant(p.memberId)}
+                  aria-label={`${p.name} 제거`}
+                  className="text-foreground-muted hover:text-danger ml-1"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ── Step 1 — 회의 정보 ────────────────────────────────────────────────
+function StepInfo({
+  title,
+  setTitle,
+  managerId,
+  setManagerId,
+  participants,
+  myMemberId,
+  practiceFrom,
+  setPracticeFrom,
+  practiceTo,
+  setPracticeTo,
+}: {
+  title: string;
+  setTitle: (t: string) => void;
+  managerId: number | null;
+  setManagerId: (id: number) => void;
+  participants: Participant[];
+  myMemberId?: number;
+  practiceFrom: string;
+  setPracticeFrom: (v: string) => void;
+  practiceTo: string;
+  setPracticeTo: (v: string) => void;
+}) {
+  const today = new Date().toISOString().slice(0, 10);
+  return (
+    <section className="gap-s-4 flex flex-col">
+      <Input
+        label="회의 제목"
+        required
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="예: 여름 페스티벌 셋리스트 회의"
+      />
+
+      <div>
+        <div className="text-foreground mb-s-2 text-sm font-medium">합주 가능 기간 (선택)</div>
+        <div className="text-foreground-muted text-micro mb-s-2">
+          회의에서 다룰 합주가 가능한 기간을 입력하세요. 멤버 스케줄 조율의 기준이 됩니다.
+        </div>
+        <div className="gap-s-3 flex items-center">
+          <input
+            type="date"
+            value={practiceFrom}
+            min={today}
+            onChange={(e) => setPracticeFrom(e.target.value)}
+            aria-label="합주 시작일"
+            className="bg-surface border-border px-s-3 focus:ring-accent h-10 rounded-md border text-sm outline-none focus:ring-2"
+          />
+          <span className="text-foreground-muted">~</span>
+          <input
+            type="date"
+            value={practiceTo}
+            min={practiceFrom || today}
+            onChange={(e) => setPracticeTo(e.target.value)}
+            aria-label="합주 종료일"
+            className="bg-surface border-border px-s-3 focus:ring-accent h-10 rounded-md border text-sm outline-none focus:ring-2"
+          />
+        </div>
+        {practiceFrom && practiceTo && practiceFrom > practiceTo && (
+          <p className="text-danger text-micro mt-s-2">시작일은 종료일보다 빨라야 합니다.</p>
+        )}
+      </div>
+
+      <div>
+        <div className="text-foreground mb-s-2 text-sm font-medium">
+          매니저 지정 <span className="text-danger">*</span>
+        </div>
+        <div className="text-foreground-muted text-micro mb-s-2">
+          매니저는 선곡 확정·해제 등 회의 권한 액션을 수행합니다.
+        </div>
+        <ul className="border-border gap-s-1 flex max-h-70 flex-col overflow-y-auto rounded-md border p-1">
+          {participants.map((p) => {
+            const active = managerId === p.memberId;
+            return (
+              <li key={p.memberId}>
+                <label
+                  className={cn(
+                    'gap-s-3 px-s-3 py-s-2 flex cursor-pointer items-center rounded-md transition-colors',
+                    active ? 'bg-accent-dim border-accent/30 border' : 'hover:bg-card',
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="manager"
+                    className="accent-accent h-4 w-4"
+                    checked={active}
+                    onChange={() => setManagerId(p.memberId)}
+                  />
+                  <Avatar src={p.profileImg ?? undefined} fallback={p.name} size="sm" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-caption gap-s-2 flex items-center font-semibold">
+                      <span className="truncate">{p.name}</span>
+                      {p.memberId === myMemberId && (
+                        <span className="text-accent text-micro font-bold">나</span>
+                      )}
+                    </div>
+                  </div>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+// ── Step 2 — 확인 ────────────────────────────────────────────────────
+function StepReview({
+  selectedBandNames,
+  selectedBandIds,
+  participants,
+  title,
+  managerId,
+  practiceFrom,
+  practiceTo,
+}: {
+  selectedBandNames: Record<string, string>;
+  selectedBandIds: string[];
+  participants: Participant[];
+  title: string;
+  managerId: number | null;
+  practiceFrom: string;
+  practiceTo: string;
+}) {
+  const manager = participants.find((p) => p.memberId === managerId);
+  const bandNames = selectedBandIds.map((id) => selectedBandNames[id] ?? id);
+
+  return (
+    <section className="gap-s-4 flex flex-col">
+      {bandNames.length > 0 && (
+        <SummaryRow icon={<Users className="h-4 w-4" />} label="선택 밴드">
+          {bandNames.join(' · ')}
+        </SummaryRow>
+      )}
+      <SummaryRow icon={<Users className="h-4 w-4" />} label={`참여 ${participants.length}명`}>
+        <div className="gap-s-2 flex flex-wrap">
+          {participants.map((p) => (
+            <span
+              key={p.memberId}
+              className="bg-card border-border gap-s-1 px-s-2 inline-flex items-center rounded-full border py-0.5"
+            >
+              <Avatar src={p.profileImg ?? undefined} fallback={p.name} size="sm" />
+              <span className="text-micro font-semibold">{p.name}</span>
+            </span>
+          ))}
+        </div>
+      </SummaryRow>
+      <SummaryRow label="제목">
+        <span className="text-caption font-bold">{title || '(미입력)'}</span>
+      </SummaryRow>
+      {practiceFrom && practiceTo && (
+        <SummaryRow icon={<CalendarDays className="h-4 w-4" />} label="합주 가능 기간">
+          <span className="text-caption font-mono">
+            {practiceFrom} ~ {practiceTo}
+          </span>
+        </SummaryRow>
+      )}
+      <SummaryRow label="매니저">
+        {manager ? (
+          <span className="gap-s-2 inline-flex items-center">
+            <Avatar src={manager.profileImg ?? undefined} fallback={manager.name} size="sm" />
+            <span className="text-caption font-semibold">{manager.name}</span>
+          </span>
+        ) : (
+          <span className="text-foreground-muted">미지정</span>
+        )}
+      </SummaryRow>
+    </section>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+function UnderlineTabs<T extends string>({
+  value,
+  onChange,
+  items,
+}: {
+  value: T;
+  onChange: (v: T) => void;
+  items: ReadonlyArray<{ id: T; label: string }>;
+}) {
+  return (
+    <div className="border-border gap-s-6 flex border-b">
+      {items.map((it) => {
+        const active = value === it.id;
+        return (
+          <button
+            key={it.id}
+            type="button"
+            onClick={() => onChange(it.id)}
+            className={cn(
+              'px-s-1 -mb-px h-10 border-b-2 text-sm font-semibold transition-colors',
+              active
+                ? 'border-accent text-accent'
+                : 'text-foreground-sub hover:text-foreground border-transparent',
+            )}
+          >
+            {it.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SummaryRow({
+  icon,
+  label,
+  children,
+}: {
+  icon?: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-card border-border px-s-4 py-s-3 gap-s-3 flex items-start rounded-lg border">
+      {icon && <div className="text-foreground-muted mt-0.5">{icon}</div>}
+      <div className="min-w-0 flex-1">
+        <div className="text-foreground-muted text-micro mb-s-1 font-bold uppercase">{label}</div>
+        <div className="text-foreground">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/track-selections/create/page.tsx
+++ b/src/app/(main)/track-selections/create/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+import { MeetingCreateWizard } from './MeetingCreateWizard.client';
+
+export const metadata: Metadata = {
+  title: '선곡 회의 만들기 | Bandage',
+};
+
+export default function TrackSelectionCreatePage() {
+  return <MeetingCreateWizard />;
+}

--- a/src/app/(main)/track-selections/layout.tsx
+++ b/src/app/(main)/track-selections/layout.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { type ReactNode } from 'react';
+
+import { ROUTES } from '@/global/config/routes';
+
+import { SchedulingShell } from './scheduling/SchedulingShell.client';
+
+/**
+ * /track-selections 라우트 레이아웃.
+ * - 기본: 목록/디테일 모두 일반 페이지로 렌더 (합주 목록과 동일한 패턴).
+ * - /scheduling/*: SchedulingShell — scheduling 전용 마스터-디테일.
+ * - /create (선곡 만들기 마법사): 풀페이지.
+ */
+export default function TrackSelectionsLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname() ?? '';
+  const scheduling =
+    pathname === ROUTES.TRACK_SELECTION_SCHEDULING ||
+    pathname.startsWith(`${ROUTES.TRACK_SELECTION_SCHEDULING}/`);
+
+  if (scheduling) {
+    return <SchedulingShell>{children}</SchedulingShell>;
+  }
+  return <div className="h-full overflow-y-auto">{children}</div>;
+}

--- a/src/app/(main)/track-selections/page.tsx
+++ b/src/app/(main)/track-selections/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+
+import { TrackSelectionsMobileShell } from './TrackSelectionsMobileShell.client';
+
+export const metadata: Metadata = {
+  title: '선곡 회의 | Bandage',
+};
+
+export default function TrackSelectionsPage() {
+  return (
+    <div className="p-s-4 lg:pt-10">
+      <TrackSelectionsMobileShell />
+    </div>
+  );
+}

--- a/src/app/(main)/track-selections/scheduling/SchedulingListPane.client.tsx
+++ b/src/app/(main)/track-selections/scheduling/SchedulingListPane.client.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { X } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useMemo } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { IconTile } from '@/components/ui/icon-tile';
+import {
+  selectSchedulingProgress,
+  useScheduleStore,
+} from '@/domain/schedule-coordination/store/scheduleStore';
+import { useTimetableStore } from '@/domain/schedule-coordination/store/timetableStore';
+import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
+import type { Meeting } from '@/domain/setlist-meeting/types';
+import { ROUTES } from '@/global/config/routes';
+import { DOMAIN_ICONS, DOMAIN_LIST_SELECTED_TONES, DOMAIN_TONES } from '@/lib/domain-icons';
+import { listItemClasses } from '@/lib/list-item-styles';
+
+const TrackSelectionIcon = DOMAIN_ICONS['track-selection'];
+
+interface SchedulingSummary {
+  meeting: Meeting;
+  total: number;
+  completed: number;
+  pct: number;
+  confirmed: boolean;
+}
+
+function SchedulingRow({ summary, active }: { summary: SchedulingSummary; active: boolean }) {
+  const { meeting, total, completed, pct, confirmed } = summary;
+  const barTone = confirmed ? 'bg-success' : 'bg-accent';
+  const labelTone = confirmed ? 'text-success' : 'text-accent';
+  return (
+    <li>
+      <Link
+        href={ROUTES.TRACK_SELECTION_SCHEDULING_DETAIL(meeting.id)}
+        aria-current={active ? 'page' : undefined}
+        data-slot="scheduling-meeting-row"
+        className={listItemClasses(
+          active,
+          DOMAIN_LIST_SELECTED_TONES['track-selection'],
+          'focus-visible:ring-accent focus-visible:ring-offset-bg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+        )}
+      >
+        <IconTile icon={<TrackSelectionIcon />} size="sm" tone={DOMAIN_TONES['track-selection']} />
+        <div className="min-w-0 flex-1">
+          <div className={cn('text-micro truncate font-semibold', labelTone)}>
+            {meeting.bandName}
+          </div>
+          <div className="text-caption mt-0.5 truncate font-bold">{meeting.title}</div>
+          <div className="mt-s-2 gap-s-2 flex items-center">
+            <div
+              className="bg-card border-border h-1.5 flex-1 overflow-hidden rounded-full border"
+              role="progressbar"
+              aria-valuenow={pct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${meeting.title} 일정 입력 ${pct}%`}
+            >
+              <div className={cn('h-full', barTone)} style={{ width: `${pct}%` }} />
+            </div>
+            <span className="text-foreground-muted text-micro shrink-0 tabular-nums">
+              {completed}/{total}
+            </span>
+          </div>
+          <div className="text-foreground-muted text-micro mt-0.5">
+            {confirmed ? '시간표 확정' : `입력 ${pct}%`}
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+export interface SchedulingListPaneProps {
+  mode?: 'overlay' | 'fixed';
+  open?: boolean;
+  onClose?: () => void;
+}
+
+export function SchedulingListPane({
+  mode = 'fixed',
+  open = false,
+  onClose,
+}: SchedulingListPaneProps = {}) {
+  const pathname = usePathname() ?? '';
+  const meetings = useSetlistStore((s) => s.meetings);
+  const schedules = useScheduleStore((s) => s.schedules);
+  const confirmedMap = useTimetableStore((s) => s.confirmedByMeetingId);
+
+  const summaries = useMemo<SchedulingSummary[]>(() => {
+    return meetings.map((meeting) => {
+      const participantUserIds = meeting.participantUserIds ?? [];
+      const { total, completed, pct } = selectSchedulingProgress(
+        schedules,
+        meeting.id,
+        participantUserIds,
+      );
+      return {
+        meeting,
+        total,
+        completed,
+        pct,
+        confirmed: Boolean(confirmedMap[meeting.id]),
+      };
+    });
+  }, [meetings, schedules, confirmedMap]);
+
+  const overlay = mode === 'overlay';
+
+  return (
+    <aside
+      className={cn(
+        'bg-surface border-border shrink-0 flex-col border-r shadow-lg',
+        overlay
+          ? cn(
+              'absolute top-0 left-0 z-30 h-full transition-transform duration-200 ease-out',
+              open ? 'flex translate-x-0' : 'pointer-events-none flex -translate-x-full',
+            )
+          : 'hidden lg:flex',
+      )}
+      style={{ width: 'var(--list-pane-w)' }}
+      data-slot="scheduling-list-pane"
+      aria-label="합주 일정 조율 회의 목록"
+      aria-hidden={overlay && !open ? true : undefined}
+    >
+      <div className="border-border px-s-3 py-s-3 gap-s-2 flex items-center justify-between border-b">
+        <div className="min-w-0">
+          <h2 className="text-body font-bold">합주 일정 조율</h2>
+          <p className="text-foreground-muted text-micro mt-0.5">{meetings.length}건 조율 중</p>
+        </div>
+        {overlay && onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-foreground-muted hover:text-foreground rounded-md p-1"
+            aria-label="목록 닫기"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      <div className="px-s-2 py-s-2 flex-1 overflow-y-auto">
+        {summaries.length === 0 ? (
+          <p className="text-foreground-muted p-s-3 text-caption">조율 중인 회의가 없습니다.</p>
+        ) : (
+          <ul className="gap-s-1 flex flex-col">
+            {summaries.map((s) => {
+              const href = ROUTES.TRACK_SELECTION_SCHEDULING_DETAIL(s.meeting.id);
+              const active = pathname === href || pathname.startsWith(`${href}/`);
+              return <SchedulingRow key={s.meeting.id} summary={s} active={active} />;
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/app/(main)/track-selections/scheduling/SchedulingShell.client.tsx
+++ b/src/app/(main)/track-selections/scheduling/SchedulingShell.client.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { PanelLeftOpen } from 'lucide-react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useRef, useState, type ReactNode } from 'react';
+
+import { SchedulingListPane } from './SchedulingListPane.client';
+
+/**
+ * 합주 일정 조율 영역 셸 — 마스터(좌측 회의 목록 오버레이) + 디테일(우측 본문).
+ * TrackSelectionsShell 과 동일한 패턴이지만 scheduling 전용 ListPane 을 사용.
+ */
+export function SchedulingShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname() ?? '';
+  const searchParams = useSearchParams();
+  const initialListOpen = searchParams?.get('listOpen') === '1';
+  const [listOpen, setListOpen] = useState(initialListOpen);
+
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    setListOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!listOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setListOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [listOpen]);
+
+  return (
+    <div className="relative flex h-full">
+      <button
+        type="button"
+        onClick={() => setListOpen((v) => !v)}
+        aria-expanded={listOpen}
+        aria-label="조율 회의 목록 열기/닫기"
+        className="bg-surface border-border text-foreground-sub hover:bg-card hover:text-foreground top-s-3 left-s-3 absolute z-30 hidden h-8 w-8 items-center justify-center rounded-md border shadow-sm transition-colors lg:inline-flex"
+      >
+        <PanelLeftOpen className="h-4 w-4" />
+      </button>
+
+      {listOpen && (
+        <div
+          aria-hidden="true"
+          onClick={() => setListOpen(false)}
+          className="bg-bg/40 absolute inset-0 z-20 backdrop-blur-sm lg:block"
+        />
+      )}
+
+      <Suspense fallback={null}>
+        <SchedulingListPane open={listOpen} onClose={() => setListOpen(false)} mode="overlay" />
+      </Suspense>
+
+      <div className="min-w-0 flex-1 overflow-y-auto">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(main)/track-selections/scheduling/[selectionId]/ScheduleInputModal.client.tsx
+++ b/src/app/(main)/track-selections/scheduling/[selectionId]/ScheduleInputModal.client.tsx
@@ -1,0 +1,618 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  ResponsiveSheet,
+  ResponsiveSheetBody,
+  ResponsiveSheetContent,
+  ResponsiveSheetFooter,
+  ResponsiveSheetHeader,
+  ResponsiveSheetTitle,
+} from '@/components/ui/responsive-sheet';
+import { Textarea } from '@/components/ui/textarea';
+import { WeeklyScheduleGrid } from '@/domain/schedule-coordination/components/WeeklyScheduleGrid.client';
+import {
+  DEFAULT_DAY_MASK,
+  useScheduleStore,
+} from '@/domain/schedule-coordination/store/scheduleStore';
+import type { SlotMask } from '@/domain/schedule-coordination/types';
+import {
+  addDays,
+  dayOfWeek,
+  isHoliday,
+  isWeekend,
+  startOfWeek,
+} from '@/domain/schedule-coordination/utils';
+import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/cn';
+
+const STEPS = ['가능 일자', '시간 블록', '특이사항', '확인'] as const;
+type Step = 0 | 1 | 2 | 3;
+
+export function ScheduleInputModal({
+  meetingId,
+  userId,
+  allDays,
+  open,
+  onOpenChange,
+}: {
+  meetingId: string;
+  userId: string;
+  allDays: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const existing = useScheduleStore((s) => s.schedules[`${meetingId}__${userId}`]);
+  const upsert = useScheduleStore((s) => s.upsertSchedule);
+  const setCompleted = useScheduleStore((s) => s.setCompleted);
+  const toast = useToast();
+
+  const [step, setStep] = useState<Step>(0);
+  const [availableDates, setAvailableDates] = useState<string[]>(existing?.availableDates ?? []);
+  const [blocks, setBlocks] = useState<Record<string, SlotMask>>(existing?.blocks ?? {});
+  const [note, setNote] = useState(existing?.note ?? '');
+
+  // 모달이 닫힌→열린 전환 시점에만 store 값으로 hydrate. 그 후 store 갱신은 effect 내부에서
+  // 일어나므로 existing 변화로는 재 hydrate 하지 않음(무한 루프 방지).
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      wasOpenRef.current = true;
+      setStep(0);
+      setAvailableDates(existing?.availableDates ?? []);
+      setBlocks(existing?.blocks ?? {});
+      setNote(existing?.note ?? '');
+    } else if (!open && wasOpenRef.current) {
+      wasOpenRef.current = false;
+    }
+    // existing 은 의도적으로 deps 에서 제외 — 첫 오픈 시에만 사용.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // 입력 변동 시 즉시 store 에 저장 → localStorage 영속화 (실수 종료해도 유지).
+  // 기존 completed 는 store 에서 직접 읽지 않고 첫 hydrate 이후엔 별도 setCompleted 로만 변경.
+  const completedRef = useRef(existing?.completed ?? false);
+  useEffect(() => {
+    completedRef.current = existing?.completed ?? false;
+  }, [existing?.completed]);
+
+  useEffect(() => {
+    if (!open) return;
+    upsert({
+      meetingId,
+      userId,
+      availableDates,
+      unavailableDates: [],
+      blocks,
+      note,
+      completed: completedRef.current,
+      updatedAt: new Date().toISOString(),
+    });
+  }, [open, meetingId, userId, availableDates, blocks, note, upsert]);
+
+  const next = () => setStep((s) => (s < 3 ? ((s + 1) as Step) : s));
+  const back = () => setStep((s) => (s > 0 ? ((s - 1) as Step) : s));
+
+  const submit = () => {
+    setCompleted(meetingId, userId, true);
+    toast.success('나의 스케줄이 저장되었습니다.');
+    onOpenChange(false);
+  };
+
+  return (
+    <ResponsiveSheet open={open} onOpenChange={onOpenChange}>
+      <ResponsiveSheetContent className="sm:max-w-2xl">
+        <ResponsiveSheetHeader>
+          <ResponsiveSheetTitle>나의 스케줄 입력</ResponsiveSheetTitle>
+        </ResponsiveSheetHeader>
+        <ResponsiveSheetBody>
+          <ProgressBar step={step} />
+          <div className="mt-s-4">
+            {step === 0 && (
+              <Step1Dates
+                allDays={allDays}
+                availableDates={availableDates}
+                setAvailableDates={setAvailableDates}
+              />
+            )}
+            {step === 1 && (
+              <Step2Blocks
+                allDays={allDays}
+                availableDates={availableDates}
+                blocks={blocks}
+                setBlocks={setBlocks}
+              />
+            )}
+            {step === 2 && <Step3Note note={note} setNote={setNote} />}
+            {step === 3 && (
+              <Step4Review availableDates={availableDates} blocks={blocks} note={note} />
+            )}
+          </div>
+        </ResponsiveSheetBody>
+        <ResponsiveSheetFooter>
+          <Button type="button" variant="ghost" onClick={back} disabled={step === 0}>
+            이전
+          </Button>
+          {step < 3 ? (
+            <Button type="button" variant="primary" onClick={next}>
+              다음
+            </Button>
+          ) : (
+            <Button type="button" variant="primary" onClick={submit}>
+              저장
+            </Button>
+          )}
+        </ResponsiveSheetFooter>
+      </ResponsiveSheetContent>
+    </ResponsiveSheet>
+  );
+}
+
+function ProgressBar({ step }: { step: Step }) {
+  return (
+    <div className="border-border gap-s-1 pb-s-3 flex items-center border-b">
+      {STEPS.map((label, i) => (
+        <div key={label} className="flex-1 text-center">
+          <div
+            className={cn(
+              'text-micro mb-1 font-bold',
+              i === step ? 'text-accent' : i < step ? 'text-success' : 'text-foreground-muted',
+            )}
+          >
+            {i + 1}. {label}
+          </div>
+          <div
+            className={cn(
+              'h-1 rounded-full',
+              i === step ? 'bg-accent' : i < step ? 'bg-success' : 'bg-card',
+            )}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Step 0 input-mode 탭 제거 (Task 9 v2). AI 입력은 PRD §5-B 비범위.
+
+// Step 1: 가능 일자
+function Step1Dates({
+  allDays,
+  availableDates,
+  setAvailableDates,
+}: {
+  allDays: string[];
+  availableDates: string[];
+  setAvailableDates: (next: string[]) => void;
+}) {
+  // 다중 필터 — 평일 / 주말 (포함 조건) + 공휴일 제외 (배제 조건). 모두 독립 토글.
+  const [includeWeekday, setIncludeWeekday] = useState(true);
+  const [includeWeekend, setIncludeWeekend] = useState(true);
+  const [excludeHolidays, setExcludeHolidays] = useState(false);
+
+  const passesFilter = (d: string) => {
+    const wk = isWeekend(d);
+    if (wk && !includeWeekend) return false;
+    if (!wk && !includeWeekday) return false;
+    if (excludeHolidays && isHoliday(d)) return false;
+    return true;
+  };
+
+  const toggle = (d: string) => {
+    if (availableDates.includes(d)) {
+      setAvailableDates(availableDates.filter((x) => x !== d));
+    } else {
+      setAvailableDates([...availableDates, d]);
+    }
+  };
+
+  const applyFilter = () => {
+    setAvailableDates(allDays.filter(passesFilter));
+  };
+
+  const Chip = ({
+    label,
+    active,
+    onClick,
+  }: {
+    label: string;
+    active: boolean;
+    onClick: () => void;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        'px-s-3 py-s-1 text-micro rounded-full border font-semibold transition-colors',
+        active
+          ? 'bg-accent-dim border-accent/40 text-accent'
+          : 'bg-card border-border text-foreground-muted hover:border-border-hi',
+      )}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <section className="gap-s-3 flex flex-col">
+      <p className="text-foreground-muted text-caption">
+        합주 가능한 일자를 선택하세요. 필터는 중복 적용되며 ‘필터로 일괄 선택’ 으로 한번에
+        반영합니다.
+      </p>
+      <div className="gap-s-2 flex flex-wrap items-center">
+        <Chip label="평일" active={includeWeekday} onClick={() => setIncludeWeekday((v) => !v)} />
+        <Chip label="주말" active={includeWeekend} onClick={() => setIncludeWeekend((v) => !v)} />
+        <Chip
+          label="공휴일 제외"
+          active={excludeHolidays}
+          onClick={() => setExcludeHolidays((v) => !v)}
+        />
+        <button
+          type="button"
+          onClick={applyFilter}
+          className="text-accent text-micro ml-auto font-semibold hover:underline"
+        >
+          필터로 일괄 선택
+        </button>
+      </div>
+      <div className="grid grid-cols-7 gap-1">
+        {['일', '월', '화', '수', '목', '금', '토'].map((d) => (
+          <div key={d} className="text-foreground-muted text-micro text-center font-bold">
+            {d}
+          </div>
+        ))}
+        {allDays.length > 0 &&
+          // 첫 일자의 요일만큼 빈 칸 채워 정렬.
+          Array.from({ length: dayOfWeek(allDays[0]!) }).map((_, i) => <div key={`pad-${i}`} />)}
+        {allDays.map((d) => {
+          const selected = availableDates.includes(d);
+          const dim = !passesFilter(d);
+          const holiday = isHoliday(d);
+          return (
+            <button
+              key={d}
+              type="button"
+              onClick={() => toggle(d)}
+              className={cn(
+                'text-caption rounded-md px-1 py-2 text-center font-mono font-bold',
+                selected
+                  ? 'bg-accent text-foreground'
+                  : 'bg-card text-foreground-muted hover:bg-card-hover',
+                holiday && !selected && 'text-danger',
+                dim && !selected && 'opacity-40',
+              )}
+            >
+              {d.slice(8)}
+            </button>
+          );
+        })}
+      </div>
+      <div className="text-foreground-sub text-caption">
+        선택 <strong className="text-foreground">{availableDates.length}</strong>일
+      </div>
+    </section>
+  );
+}
+
+// Step 2: 시간 블록 — 합주 시간표 생성 탭과 동일한 WeeklyScheduleGrid 사용.
+function Step2Blocks({
+  availableDates,
+  blocks,
+  setBlocks,
+}: {
+  allDays: string[];
+  availableDates: string[];
+  blocks: Record<string, SlotMask>;
+  setBlocks: (next: Record<string, SlotMask>) => void;
+}) {
+  const toast = useToast();
+  const sortedAvail = useMemo(() => [...availableDates].sort(), [availableDates]);
+  /** compact: 가용 일자가 모두 같은 ISO 주(월~일) 내에 있으면 페이지네이션 숨김. */
+  const compact = useMemo(() => {
+    if (sortedAvail.length === 0) return true;
+    const w0 = startOfWeek(sortedAvail[0]!);
+    return sortedAvail.every((d) => startOfWeek(d) === w0);
+  }, [sortedAvail]);
+  const firstWeekStart = useMemo(
+    () => (sortedAvail[0] ? startOfWeek(sortedAvail[0]) : ''),
+    [sortedAvail],
+  );
+  const [weekStart, setWeekStart] = useState(firstWeekStart);
+  const [range, setRange] = useState<'9-22' | '24h'>('9-22');
+  const slotStart = range === '24h' ? 0 : 18;
+  const slotEnd = range === '24h' ? 48 : 44;
+
+  /** 항상 월~일 7컬럼 고정. 가용 외 일자는 isInWindow=false. */
+  const visibleDays = useMemo<string[]>(() => {
+    if (sortedAvail.length === 0) return [];
+    return Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+  }, [sortedAvail, weekStart]);
+
+  const availSet = useMemo(() => new Set(sortedAvail), [sortedAvail]);
+  const isInWindow = (d: string) => availSet.has(d);
+
+  const ensureMask = (date: string): SlotMask => blocks[date] ?? [...DEFAULT_DAY_MASK];
+
+  // 드래그 페인트 — pointerdown 한 셀의 반대값을 의도(intent)로 결정,
+  // 같은 의도를 enter 한 셀들에 일괄 적용. (Sling/when2meet 패턴)
+  const paintIntentRef = useRef<boolean | null>(null);
+
+  // 빠른 연속 페인트 시 stale state 방지를 위해 ref 로 최신 blocks 추적.
+  const blocksRef = useRef(blocks);
+  useEffect(() => {
+    blocksRef.current = blocks;
+  }, [blocks]);
+
+  const setSlotValue = useCallback(
+    (date: string, slot: number, value: boolean) => {
+      const cur = blocksRef.current;
+      const mask = (cur[date] ?? [...DEFAULT_DAY_MASK]).slice();
+      if (mask[slot] === value) return;
+      mask[slot] = value;
+      const nextBlocks = { ...cur, [date]: mask };
+      blocksRef.current = nextBlocks;
+      setBlocks(nextBlocks);
+    },
+    [setBlocks],
+  );
+
+  const onPaintStart = (date: string, slot: number) => {
+    const cur = ensureMask(date)[slot] ?? false;
+    const intent = !cur;
+    paintIntentRef.current = intent;
+    setSlotValue(date, slot, intent);
+  };
+
+  const onPaintEnter = (date: string, slot: number) => {
+    if (paintIntentRef.current === null) return;
+    setSlotValue(date, slot, paintIntentRef.current);
+  };
+
+  // pointerup 후 intent 초기화 — 글로벌 핸들러.
+  useEffect(() => {
+    const reset = () => {
+      paintIntentRef.current = null;
+    };
+    window.addEventListener('pointerup', reset);
+    window.addEventListener('pointercancel', reset);
+    return () => {
+      window.removeEventListener('pointerup', reset);
+      window.removeEventListener('pointercancel', reset);
+    };
+  }, []);
+
+  // 9-B 프리셋 칩 — 현재 보이는 가능 일자에 일괄 적용. shift=추가, alt=제거.
+  const PRESETS: Array<{ id: string; label: string; range: [number, number] }> = [
+    { id: 'morning', label: '오전 09-12', range: [18, 24] },
+    { id: 'lunch', label: '점심 12-14', range: [24, 28] },
+    { id: 'afternoon', label: '오후 14-18', range: [28, 36] },
+    { id: 'evening', label: '저녁 18-22', range: [36, 44] },
+    { id: 'night', label: '심야 22-02', range: [44, 52] },
+  ];
+
+  const applyPreset = (preset: (typeof PRESETS)[number], mode: 'set' | 'add' | 'remove') => {
+    const [from, to] = preset.range;
+    const upd: Record<string, SlotMask> = { ...blocks };
+    const targets = visibleDays.filter(isInWindow);
+    for (const d of targets) {
+      const mask = mode === 'set' ? Array.from({ length: 48 }, () => false) : ensureMask(d).slice();
+      for (let i = from; i < Math.min(48, to); i++) {
+        mask[i] = mode === 'remove' ? false : true;
+      }
+      upd[d] = mask;
+    }
+    setBlocks(upd);
+  };
+
+  // 9-C 전 주 복사 — week 모드 한정.
+  // 가용 외 일자도 포함해서 복사 (전 주 같은 요일에 무엇이든 입력돼 있으면 가져옴 → 사용자에게 즉각 피드백).
+  const copyPrevWeek = () => {
+    if (compact) return;
+    const upd: Record<string, SlotMask> = { ...blocks };
+    let copied = 0;
+    for (let i = 0; i < 7; i++) {
+      const target = addDays(weekStart, i);
+      const source = addDays(target, -7);
+      if (!availSet.has(target)) continue;
+      const srcMask = blocks[source];
+      if (!srcMask) continue;
+      upd[target] = srcMask.slice();
+      copied++;
+    }
+    if (copied > 0) {
+      setBlocks(upd);
+      toast.success(`전 주와 동일하게 ${copied}일 복사`);
+    } else {
+      toast.error('전 주의 같은 요일에 입력된 시간이 없습니다.');
+    }
+  };
+
+  // 9-F Smart Default — 평일 저녁 + 주말 종일.
+  const applySmartDefault = () => {
+    const upd: Record<string, SlotMask> = { ...blocks };
+    for (const d of availableDates) {
+      const day = new Date(`${d}T00:00:00`).getDay();
+      const isWk = day === 0 || day === 6;
+      const mask = Array.from({ length: 48 }, (_, i) =>
+        isWk ? i >= 18 && i < 44 : i >= 36 && i < 44,
+      );
+      upd[d] = mask;
+    }
+    setBlocks(upd);
+  };
+
+  if (sortedAvail.length === 0) {
+    return (
+      <p className="text-foreground-muted text-caption py-s-6 text-center">
+        먼저 이전 단계에서 가능한 일자를 선택하세요.
+      </p>
+    );
+  }
+
+  const firstAvail = sortedAvail[0]!;
+  const lastAvail = sortedAvail[sortedAvail.length - 1]!;
+  const canPrev = !compact && weekStart > startOfWeek(firstAvail);
+  const canNext = !compact && weekStart < startOfWeek(lastAvail);
+
+  return (
+    <section className="gap-s-3 flex flex-col">
+      {/* 주차 라벨 + 네비 (compact 일 때 숨김). */}
+      {!compact && (
+        <div className="gap-s-2 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => canPrev && setWeekStart(addDays(weekStart, -7))}
+            disabled={!canPrev}
+            className="text-foreground-muted hover:text-foreground rounded p-1 disabled:opacity-30"
+            aria-label="이전 주"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <span className="text-caption font-mono font-bold">
+            {weekStart} ~ {addDays(weekStart, 6)}
+          </span>
+          <button
+            type="button"
+            onClick={() => canNext && setWeekStart(addDays(weekStart, 7))}
+            disabled={!canNext}
+            className="text-foreground-muted hover:text-foreground rounded p-1 disabled:opacity-30"
+            aria-label="다음 주"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      <p className="text-foreground-muted text-micro">
+        30분 단위. 셀 클릭으로 가능/불가 토글. 프리셋 칩으로 현재 주 일괄 적용.
+      </p>
+
+      <div className="gap-s-2 flex flex-wrap items-center">
+        {PRESETS.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={(e) => applyPreset(p, e.altKey ? 'remove' : e.shiftKey ? 'add' : 'set')}
+            className="bg-card border-border hover:border-accent text-foreground-sub text-micro px-s-2 rounded-full border py-1 font-bold"
+            title="Shift: 추가 / Alt: 제거"
+          >
+            {p.label}
+          </button>
+        ))}
+        {!compact && (
+          <button
+            type="button"
+            onClick={copyPrevWeek}
+            className="text-accent text-micro ml-auto font-bold hover:underline"
+          >
+            전 주와 동일
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={applySmartDefault}
+          className={cn('text-accent text-micro font-bold hover:underline', compact && 'ml-auto')}
+        >
+          Smart Default
+        </button>
+        <div
+          role="radiogroup"
+          aria-label="시간 범위"
+          className="bg-card border-border ml-s-2 inline-flex rounded-md border p-0.5"
+        >
+          {(['9-22', '24h'] as const).map((r) => {
+            const active = r === range;
+            return (
+              <button
+                key={r}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                onClick={() => setRange(r)}
+                className={cn(
+                  'text-micro px-s-2 rounded py-0.5 font-bold transition-colors',
+                  active
+                    ? 'bg-accent text-bg shadow-sm'
+                    : 'text-foreground-muted hover:text-foreground',
+                )}
+              >
+                {r === '24h' ? '24h' : '09-22'}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="h-[420px]">
+        <WeeklyScheduleGrid
+          days={visibleDays}
+          slotStart={slotStart}
+          slotEnd={slotEnd}
+          isInWindow={isInWindow}
+          onPaintStart={onPaintStart}
+          onPaintEnter={onPaintEnter}
+          cellClassName={(d, s, inWindow) => {
+            if (!inWindow) return undefined;
+            const mask = blocks[d];
+            return mask?.[s] ? 'bg-accent/80' : undefined;
+          }}
+        />
+      </div>
+    </section>
+  );
+}
+
+function Step3Note({ note, setNote }: { note: string; setNote: (n: string) => void }) {
+  return (
+    <section className="gap-s-3 flex flex-col">
+      <Textarea
+        label="특이사항"
+        rows={5}
+        maxLength={200}
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        placeholder="합주 일정 결정 시 참고할 특이사항을 적어주세요. (예: 매주 금요일은 오후 8시 이후만 가능)"
+      />
+      <div className="text-foreground-muted text-micro text-right">{note.length}/200</div>
+    </section>
+  );
+}
+
+function Step4Review({
+  availableDates,
+  blocks,
+  note,
+}: {
+  availableDates: string[];
+  blocks: Record<string, SlotMask>;
+  note: string;
+}) {
+  const totalSlots = Object.values(blocks).reduce(
+    (acc, mask) => acc + mask.filter(Boolean).length,
+    0,
+  );
+  return (
+    <section className="gap-s-3 flex flex-col">
+      <SummaryRow label="가능 일자">{availableDates.length}일</SummaryRow>
+      <SummaryRow label="총 가능 시간">{Math.round((totalSlots * 30) / 60)}시간</SummaryRow>
+      <SummaryRow label="특이사항">
+        {note || <span className="text-foreground-muted">(없음)</span>}
+      </SummaryRow>
+    </section>
+  );
+}
+
+function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-card border-border px-s-4 py-s-3 gap-s-3 flex items-center rounded-lg border">
+      <div className="text-foreground-muted text-micro w-24 shrink-0 font-bold uppercase">
+        {label}
+      </div>
+      <div className="text-foreground text-caption flex-1">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(main)/track-selections/scheduling/[selectionId]/SchedulingMain.client.tsx
+++ b/src/app/(main)/track-selections/scheduling/[selectionId]/SchedulingMain.client.tsx
@@ -1,0 +1,765 @@
+'use client';
+
+import { CalendarDays, Clock3, Crown, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { UnderlineTabs } from '@/components/ui/underline-tabs';
+import { HoveredAvailabilityPanel } from '@/domain/schedule-coordination/components/HoveredAvailabilityPanel.client';
+import { MatrixView } from '@/domain/schedule-coordination/components/MatrixView.client';
+import { ScheduleBoardEditor } from '@/domain/schedule-coordination/components/ScheduleBoardEditor.client';
+import { ScheduleBoardList } from '@/domain/schedule-coordination/components/ScheduleBoardList.client';
+import { DateRangeNav } from '@/domain/schedule-coordination/components/ViewUnitToggle.client';
+import { WeeklyScheduleGrid } from '@/domain/schedule-coordination/components/WeeklyScheduleGrid.client';
+import { useScheduleView } from '@/domain/schedule-coordination/hooks/useScheduleViewUnit';
+import { useBoardStore } from '@/domain/schedule-coordination/store/boardStore';
+import { useScheduleStore } from '@/domain/schedule-coordination/store/scheduleStore';
+import { useScheduleViewStore } from '@/domain/schedule-coordination/store/scheduleViewStore';
+import { useTimetableStore } from '@/domain/schedule-coordination/store/timetableStore';
+import type { ScheduleBlock } from '@/domain/schedule-coordination/types';
+import { suggestScheduleBoards } from '@/domain/schedule-coordination/utils/autoSuggest';
+import { aggregateAvailability } from '@/domain/schedule-coordination/utils';
+import { MemberAvatar } from '@/domain/setlist-meeting/components/MemberAvatar';
+import { GLOBAL_MEMBER_POOL } from '@/domain/setlist-meeting/mock/memberSearchMock';
+import { useSetlistStore } from '@/domain/setlist-meeting/store/setlistStore';
+import type { Member, Song } from '@/domain/setlist-meeting/types';
+import { isReady } from '@/domain/setlist-meeting/utils';
+import { cn } from '@/lib/cn';
+
+import { ScheduleInputModal } from './ScheduleInputModal.client';
+
+type LeftTab = 'member' | 'song' | 'board';
+type SongFilter = 'mine' | 'all';
+type RightPanel =
+  | { kind: 'member'; member: Member }
+  | { kind: 'song'; song: Song }
+  | { kind: 'board'; boardId: string }
+  | null;
+
+export function SchedulingMain({ meetingId }: { meetingId: string }) {
+  const meetings = useSetlistStore((s) => s.meetings);
+  const songs = useSetlistStore((s) => s.songs);
+  const currentUserId = useSetlistStore((s) => s.currentUserId);
+  const meeting = useMemo(() => meetings.find((m) => m.id === meetingId), [meetings, meetingId]);
+  const allSongs = useMemo(
+    () => songs.filter((s) => s.meetingId === meetingId),
+    [songs, meetingId],
+  );
+
+  const isManager = meeting ? meeting.managerId === currentUserId : false;
+  const participantIds = useMemo(() => meeting?.participantUserIds ?? [], [meeting]);
+  const participants = useMemo<Member[]>(
+    () =>
+      participantIds
+        .map((id) => GLOBAL_MEMBER_POOL.find((m) => m.id === id))
+        .filter((m): m is Member => Boolean(m)),
+    [participantIds],
+  );
+
+  const schedulesAll = useScheduleStore((s) => s.schedules);
+  const memberSchedules = useMemo(
+    () =>
+      participantIds
+        .map((uid) => schedulesAll[`${meetingId}__${uid}`])
+        .filter((x): x is NonNullable<typeof x> => Boolean(x)),
+    [participantIds, schedulesAll, meetingId],
+  );
+
+  const [leftTab, setLeftTab] = useState<LeftTab>('member');
+  // 매니저 권한이 사라진 경우 board 탭은 멤버 시간표로 대체.
+  const safeLeftTab: LeftTab = !isManager && leftTab === 'board' ? 'member' : leftTab;
+  const viewMode = useScheduleViewStore((s) => s.modeByMeeting[meetingId] ?? 'weekly');
+  const setViewMode = useScheduleViewStore((s) => s.setMode);
+  const [songFilter, setSongFilter] = useState<SongFilter>('mine');
+  const focusedSongId = useScheduleViewStore((s) => s.focusedSongIdByMeeting[meetingId] ?? null);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
+  const [rightPanel, setRightPanel] = useState<RightPanel>(null);
+  const isConfirmedTimetable = useTimetableStore((s) => Boolean(s.confirmedByMeetingId[meetingId]));
+
+  const visibleSongs = useMemo<Song[]>(() => {
+    const ready = allSongs.filter((s) => isReady(s));
+    const pool = ready.length > 0 ? ready : allSongs;
+    if (songFilter === 'all') return pool;
+    return pool.filter(
+      (s) =>
+        Object.values(s.applicants).some((list) => list.includes(currentUserId)) ||
+        Object.values(s.confirmed).some((list) => list.includes(currentUserId)),
+    );
+  }, [allSongs, songFilter, currentUserId]);
+
+  /** 시간표 에디터 블록 풀 — 확정 곡만. */
+  const editorSongPool = useMemo(
+    () =>
+      allSongs
+        .filter((s) => isReady(s))
+        .map((s) => ({ id: s.id, title: s.title, artist: s.artist })),
+    [allSongs],
+  );
+
+  /** 곡별 참여 멤버 매핑 — Task 18 곡별 가용시간 모드용. confirmed sessions 의 userId 합집합. */
+  const songParticipantsMap = useMemo(() => {
+    const m: Record<string, string[]> = {};
+    for (const song of allSongs) {
+      const set = new Set<string>();
+      for (const list of Object.values(song.confirmed)) for (const id of list) set.add(id);
+      m[song.id] = Array.from(set);
+    }
+    return m;
+  }, [allSongs]);
+  /** 우측 인원 패널 scope — 곡별 가용시간 모드 시 해당 곡 참여자만 분류. */
+  const sidebarScope = useMemo<'ALL' | string[]>(
+    () => (focusedSongId ? (songParticipantsMap[focusedSongId] ?? []) : 'ALL'),
+    [focusedSongId, songParticipantsMap],
+  );
+
+  const window = meeting?.practiceWindow;
+  const view = useScheduleView({
+    from: window?.from ?? '',
+    to: window?.to ?? '',
+  });
+  const { allDays, visibleDays, isInWindow, rangeLabel, compact } = view;
+
+  // 보드 선택 시 첫 블록의 주차로 자동 점프 — 빈 주차에 갇혀 길을 잃지 않도록.
+  const selectedBoard = useBoardStore((s) =>
+    rightPanel?.kind === 'board' ? s.boards[rightPanel.boardId] : null,
+  );
+  const selectedBoardId = rightPanel?.kind === 'board' ? rightPanel.boardId : null;
+
+  // 회의 선택 시 추천 시간표가 하나라도 있으면 항상 한 개는 선택 상태로 유지.
+  // 무한 루프 방지: boards dict 를 stable ref 로 select 하고 useMemo 로 파생.
+  const allBoards = useBoardStore((s) => s.boards);
+  const meetingBoards = useMemo(
+    () => Object.values(allBoards).filter((b) => b.meetingId === meetingId),
+    [allBoards, meetingId],
+  );
+  useEffect(() => {
+    // 합주 시간표 생성 탭일 때만 보드 자동 선택. 멤버/곡 탭에선 사용자 클릭한 항목 유지.
+    if (!isManager || safeLeftTab !== 'board') return;
+    if (meetingBoards.length === 0) return;
+    if (rightPanel?.kind === 'board' && meetingBoards.some((b) => b.boardId === rightPanel.boardId))
+      return;
+    const first = meetingBoards[0]!;
+    setRightPanel({ kind: 'board', boardId: first.boardId });
+  }, [isManager, safeLeftTab, meetingBoards, rightPanel]);
+  useEffect(() => {
+    if (!selectedBoard || selectedBoard.blocks.length === 0) return;
+    const earliest = selectedBoard.blocks.reduce(
+      (acc, b) =>
+        !acc || b.date < acc.date || (b.date === acc.date && b.startSlot < acc.startSlot) ? b : acc,
+      selectedBoard.blocks[0],
+    );
+    if (earliest) view.goToDate(earliest.date);
+    // 의도적으로 boardId 변경 시에만 실행 (블록 편집 시 매번 점프하면 사용자 네비를 덮어씀).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedBoardId]);
+
+  if (!meeting) {
+    return (
+      <div className="px-s-5 py-s-6">
+        <p className="text-foreground-muted text-caption">회의를 찾을 수 없습니다.</p>
+      </div>
+    );
+  }
+
+  const completedCount = participantIds.filter(
+    (uid) => schedulesAll[`${meetingId}__${uid}`]?.completed,
+  ).length;
+
+  const tabItems = [
+    { id: 'member' as const, label: '멤버 시간표', badge: participants.length },
+    { id: 'song' as const, label: '합주곡 시간표', badge: visibleSongs.length },
+    ...(isManager ? [{ id: 'board' as const, label: '합주 시간표 생성' }] : []),
+  ];
+
+  return (
+    <div className="relative flex h-full flex-col overflow-hidden">
+      <header className="border-border px-s-5 py-s-4 border-b">
+        <div className="gap-s-3 flex items-start justify-between">
+          <div className="min-w-0 flex-1">
+            <div className="text-accent text-caption font-semibold">{meeting.bandName}</div>
+            <h1 className="text-title-lg mt-s-1 truncate font-bold">{meeting.title}</h1>
+          </div>
+          {/* '나의 스케줄 입력' — 모든 탭에서 항상 같은 자리에 표시 → 헤더 높이 고정. */}
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={() => setScheduleOpen(true)}
+            className="shrink-0"
+          >
+            <Clock3 className="h-4 w-4" /> 나의 스케줄 입력
+          </Button>
+        </div>
+        <div className="text-foreground-muted text-caption gap-s-3 mt-s-2 flex flex-wrap items-center">
+          {window && (
+            <span className="gap-s-1 inline-flex items-center">
+              <CalendarDays className="h-3.5 w-3.5" />
+              {window.from} ~ {window.to}
+            </span>
+          )}
+          <span className="gap-s-1 inline-flex items-center">
+            <Crown className="text-amber h-3.5 w-3.5" />
+            매니저 {GLOBAL_MEMBER_POOL.find((m) => m.id === meeting.managerId)?.name ?? '?'}
+          </span>
+          <span
+            className={cn(
+              'text-micro px-s-2 rounded-full py-0.5 font-bold',
+              isConfirmedTimetable ? 'bg-success-dim text-success' : 'bg-accent-dim text-accent',
+            )}
+          >
+            {isConfirmedTimetable
+              ? `시간표 확정 — ${completedCount}/${participants.length} 참여`
+              : `${completedCount}/${participants.length} 명 일정 입력 완료`}
+          </span>
+        </div>
+        <div
+          className="bg-card border-border mt-s-3 h-2 w-full max-w-md overflow-hidden rounded-full border"
+          role="progressbar"
+          aria-valuenow={
+            participants.length === 0 ? 0 : Math.round((completedCount / participants.length) * 100)
+          }
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label="일정 입력 진행도"
+        >
+          <div
+            className={cn(
+              'h-full transition-all',
+              isConfirmedTimetable ? 'bg-success' : 'bg-accent',
+            )}
+            style={{
+              width: `${
+                participants.length === 0
+                  ? 0
+                  : Math.round((completedCount / participants.length) * 100)
+              }%`,
+            }}
+          />
+        </div>
+      </header>
+
+      {/* 탭 영역 — 화면 전체 폭 사용. board 탭은 아래 영역 전체 활용. */}
+      <div className="px-s-4 pt-s-3 border-border bg-surface border-b">
+        <UnderlineTabs
+          value={safeLeftTab}
+          onChange={(t) => {
+            setLeftTab(t);
+            // 탭 전환 시 좌측 선택 종류와 우측 패널이 어긋나지 않도록 정리.
+            setRightPanel((cur) => {
+              if (!cur) return cur;
+              if (t === 'member' && cur.kind !== 'member') return null;
+              if (t === 'song' && cur.kind !== 'song') return null;
+              if (t === 'board' && cur.kind !== 'board') return null;
+              return cur;
+            });
+          }}
+          items={tabItems}
+        />
+      </div>
+
+      {safeLeftTab === 'board' && isManager ? (
+        <div className="bg-bg flex flex-1 flex-col overflow-hidden">
+          {/* 뷰 토글 — 주차별 / 매트릭스. 주차별 = 세부 슬롯 배치, 매트릭스 = 주 단위 반복 정책. */}
+          <div className="px-s-3 py-s-2 border-border gap-s-2 flex items-center border-b">
+            <ViewModeToggle value={viewMode} onChange={(m) => setViewMode(meetingId, m)} />
+            <span className="text-foreground-muted text-micro">
+              {viewMode === 'weekly'
+                ? '세부 슬롯 배치 / 자동 추천'
+                : '전체 기간 한눈에 / 주 단위 반복'}
+            </span>
+          </div>
+
+          <div className="flex flex-1 overflow-hidden p-3">
+            {viewMode === 'matrix' ? (
+              <>
+                {/* 좌측: 시안 카드 리스트 — 두 뷰 공통 고정 (PRD G2). */}
+                <aside className="w-56 shrink-0 overflow-y-auto pr-3">
+                  <ScheduleBoardList
+                    meetingId={meetingId}
+                    selectedBoardId={rightPanel?.kind === 'board' ? rightPanel.boardId : null}
+                    onSelect={(boardId) => setRightPanel({ kind: 'board', boardId })}
+                    generateRecommendations={() => {
+                      const weekDays = visibleDays.filter((d) => isInWindow(d));
+                      const scopeDates = weekDays.length > 0 ? weekDays : allDays;
+                      const variants = suggestScheduleBoards({
+                        schedules: memberSchedules,
+                        dates: scopeDates,
+                        songs: editorSongPool,
+                        variantCount: 3,
+                      });
+                      return variants.map((v, idx) =>
+                        v.blocks.map<ScheduleBlock>((b, i) => ({
+                          ...b,
+                          pinned: false,
+                          paletteIndex: idx * 100 + i,
+                        })),
+                      );
+                    }}
+                  />
+                </aside>
+                <MatrixView
+                  meetingId={meetingId}
+                  boardId={rightPanel?.kind === 'board' ? rightPanel.boardId : null}
+                  allDays={allDays}
+                  participants={participants}
+                  memberSchedules={memberSchedules}
+                  songPool={editorSongPool}
+                  songParticipantsMap={songParticipantsMap}
+                  onWeekJump={(ws) => {
+                    setViewMode(meetingId, 'weekly');
+                    view.goToDate(ws);
+                  }}
+                />
+              </>
+            ) : (
+              <>
+                {/* 좌측: 시안 카드 리스트 — 축소 */}
+                <aside className="w-56 shrink-0 overflow-y-auto pr-3">
+                  <ScheduleBoardList
+                    meetingId={meetingId}
+                    selectedBoardId={rightPanel?.kind === 'board' ? rightPanel.boardId : null}
+                    onSelect={(boardId) => setRightPanel({ kind: 'board', boardId })}
+                    generateRecommendations={() => {
+                      // Task 22 — 자동 시간표 생성은 *현재 선택된 주차* 의 일자에만 적용.
+                      // visibleDays 는 anchor~anchor+6, 이 중 회의 가용 일자만 사용.
+                      const weekDays = visibleDays.filter((d) => isInWindow(d));
+                      const scopeDates = weekDays.length > 0 ? weekDays : allDays;
+                      const variants = suggestScheduleBoards({
+                        schedules: memberSchedules,
+                        dates: scopeDates,
+                        songs: editorSongPool,
+                        variantCount: 3,
+                      });
+                      return variants.map((v, idx) =>
+                        v.blocks.map<ScheduleBlock>((b, i) => ({
+                          ...b,
+                          pinned: false,
+                          paletteIndex: idx * 100 + i,
+                        })),
+                      );
+                    }}
+                  />
+                </aside>
+                {/* 중앙+우측: 시간표 에디터 — 우측 사이드바(블럭 풀+가용 인원) 내장. */}
+                <div className="min-w-0 flex-1">
+                  {rightPanel?.kind === 'board' ? (
+                    <ScheduleBoardEditor
+                      boardId={rightPanel.boardId}
+                      days={visibleDays}
+                      isInWindow={isInWindow}
+                      rangeLabel={rangeLabel}
+                      compact={compact}
+                      onPrev={view.prev}
+                      onNext={view.next}
+                      onToday={view.today}
+                      canPrev={view.canPrev}
+                      canNext={view.canNext}
+                      songPool={editorSongPool}
+                      songParticipantsMap={songParticipantsMap}
+                      participants={participants}
+                      memberSchedules={memberSchedules}
+                      allDays={allDays}
+                    />
+                  ) : (
+                    <p className="text-foreground-muted px-s-4 py-s-6 text-caption text-center">
+                      좌측에서 시안을 선택하거나 ‘시간표 생성’으로 추천 안을 만들어 보세요.
+                    </p>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-1 flex-col overflow-hidden md:flex-row">
+          {/* 좌측: 멤버/곡 명단 — 화면 절반이 아닌 고정 폭으로 컴팩트하게. */}
+          <section className="border-border flex w-full shrink-0 flex-col md:w-72 md:border-r">
+            <div className="flex-1 overflow-y-auto" id={`tabpanel-${leftTab}`} role="tabpanel">
+              {safeLeftTab === 'member' && (
+                <MemberListPane
+                  participants={participants}
+                  meetingId={meetingId}
+                  currentUserId={currentUserId}
+                  schedulesAll={schedulesAll}
+                  onPick={(m) => setRightPanel({ kind: 'member', member: m })}
+                />
+              )}
+              {safeLeftTab === 'song' && (
+                <SongListPane
+                  songs={visibleSongs}
+                  filter={songFilter}
+                  onFilterChange={setSongFilter}
+                  onPick={(song) => setRightPanel({ kind: 'song', song })}
+                />
+              )}
+            </div>
+          </section>
+          {/* 중앙: 선택된 항목의 시간표 시각화 — 셀 클릭 시 우측 패널 갱신. */}
+          <section className="bg-bg flex min-w-0 flex-1 flex-col overflow-hidden">
+            <RightVisualization
+              panel={rightPanel}
+              onClose={() => setRightPanel(null)}
+              meetingId={meetingId}
+              visibleDays={visibleDays}
+              participants={participants}
+              memberSchedules={memberSchedules}
+              view={view}
+            />
+          </section>
+          {/* 우측 사이드바: 매트릭스의 가용 인원 패널 재사용 — 클릭한 셀의 인원 표시. */}
+          <aside className="border-border hidden w-56 shrink border-l p-3 md:block lg:w-64 xl:w-72">
+            <HoveredAvailabilityPanel
+              meetingId={meetingId}
+              participants={participants}
+              memberSchedules={memberSchedules}
+              scopeUserIds={sidebarScope}
+              days={allDays}
+              className="h-full"
+            />
+          </aside>
+        </div>
+      )}
+
+      {scheduleOpen && (
+        <ScheduleInputModal
+          meetingId={meetingId}
+          userId={currentUserId}
+          allDays={allDays}
+          open={scheduleOpen}
+          onOpenChange={setScheduleOpen}
+        />
+      )}
+    </div>
+  );
+}
+
+function ViewModeToggle({
+  value,
+  onChange,
+}: {
+  value: 'weekly' | 'matrix';
+  onChange: (v: 'weekly' | 'matrix') => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="시간표 뷰 모드"
+      className="bg-card border-border inline-flex rounded-md border p-0.5"
+    >
+      {(['weekly', 'matrix'] as const).map((m) => (
+        <button
+          key={m}
+          type="button"
+          role="tab"
+          aria-selected={value === m}
+          onClick={() => onChange(m)}
+          className={cn(
+            'text-micro px-s-3 rounded py-1 font-bold transition-colors',
+            value === m
+              ? 'bg-accent text-foreground'
+              : 'text-foreground-muted hover:text-foreground',
+          )}
+        >
+          {m === 'weekly' ? '주차별' : '매트릭스'}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function MemberListPane({
+  participants,
+  meetingId,
+  currentUserId,
+  schedulesAll,
+  onPick,
+}: {
+  participants: Member[];
+  meetingId: string;
+  currentUserId: string;
+  schedulesAll: ReturnType<typeof useScheduleStore.getState>['schedules'];
+  onPick: (m: Member) => void;
+}) {
+  return (
+    <ul>
+      {participants.map((m) => {
+        const sched = schedulesAll[`${meetingId}__${m.id}`];
+        const completed = sched?.completed === true;
+        const partial = !!sched && !completed;
+        return (
+          <li key={m.id}>
+            <button
+              type="button"
+              onClick={() => onPick(m)}
+              className="hover:bg-card border-border px-s-4 py-s-3 gap-s-3 flex w-full items-center border-b text-left"
+            >
+              <MemberAvatar member={m} size="sm" />
+              <div className="min-w-0 flex-1">
+                <div className="text-caption truncate font-semibold">
+                  {m.name}
+                  {m.id === currentUserId && (
+                    <span className="text-accent text-micro ml-s-2 font-bold">나</span>
+                  )}
+                </div>
+                <div className="text-foreground-muted text-micro truncate">{m.email ?? m.role}</div>
+              </div>
+              <span
+                className={cn(
+                  'text-micro px-s-2 shrink-0 rounded-full py-0.5 font-bold',
+                  completed
+                    ? 'bg-success-dim text-success'
+                    : partial
+                      ? 'bg-warn-dim text-warn'
+                      : 'bg-card text-foreground-muted',
+                )}
+              >
+                {completed ? '완료' : partial ? '입력 중' : '미입력'}
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function SongListPane({
+  songs,
+  filter,
+  onFilterChange,
+  onPick,
+}: {
+  songs: Song[];
+  filter: SongFilter;
+  onFilterChange: (v: SongFilter) => void;
+  onPick: (s: Song) => void;
+}) {
+  return (
+    <div>
+      <div className="border-border px-s-4 py-s-2 border-b">
+        <UnderlineTabs<SongFilter>
+          value={filter}
+          onChange={onFilterChange}
+          items={[
+            { id: 'mine', label: '내 합주곡' },
+            { id: 'all', label: '전체' },
+          ]}
+        />
+      </div>
+      <ul>
+        {songs.length === 0 ? (
+          <li className="text-foreground-muted py-s-8 text-caption text-center">
+            {filter === 'mine' ? '내가 참여한 합주곡이 없습니다.' : '합주곡이 없습니다.'}
+          </li>
+        ) : (
+          songs.map((song) => (
+            <li key={song.id}>
+              <button
+                type="button"
+                onClick={() => onPick(song)}
+                className="hover:bg-card border-border px-s-4 py-s-3 gap-s-3 flex w-full items-center border-b text-left"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-caption truncate font-bold">{song.title}</div>
+                  <div className="text-foreground-muted text-micro truncate">
+                    {song.artist}
+                    {song.duration ? ` · ${song.duration}` : ''}
+                  </div>
+                </div>
+                {isReady(song) && (
+                  <span className="bg-success-dim text-success text-micro px-s-2 shrink-0 rounded-full py-0.5 font-bold">
+                    합주 가능
+                  </span>
+                )}
+              </button>
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function RightVisualization({
+  panel,
+  onClose,
+  meetingId,
+  visibleDays,
+  participants,
+  memberSchedules,
+  view,
+}: {
+  panel: RightPanel;
+  onClose: () => void;
+  meetingId: string;
+  visibleDays: string[];
+  participants: Member[];
+  memberSchedules: ReturnType<typeof useScheduleStore.getState>['schedules'][string][];
+  view: ReturnType<typeof useScheduleView>;
+}) {
+  if (!panel) {
+    return (
+      <div className="text-foreground-muted px-s-6 py-s-8 m-auto max-w-md text-center">
+        <p className="text-body font-bold">좌측에서 항목을 선택하세요</p>
+        <p className="text-caption mt-s-2">
+          멤버 또는 합주곡을 선택하면 우측에 시각화가 표시됩니다.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-border px-s-5 py-s-3 gap-s-3 flex items-start justify-between border-b">
+        <div className="min-w-0">
+          <div className="text-foreground-muted text-micro font-bold uppercase">
+            {panel.kind === 'member' ? '멤버 일정' : '곡 합주 가능 매트릭스'}
+          </div>
+          <div className="text-subtitle mt-s-1 truncate font-bold">
+            {panel.kind === 'member'
+              ? panel.member.name
+              : panel.kind === 'song'
+                ? panel.song.title
+                : ''}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-foreground-muted hover:text-foreground rounded-md p-1"
+          aria-label="닫기"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </header>
+      <div className="px-s-5 py-s-3 border-border border-b">
+        <DateRangeNav
+          rangeLabel={view.rangeLabel}
+          compact={view.compact}
+          onPrev={view.prev}
+          onNext={view.next}
+          onToday={view.today}
+          canPrev={view.canPrev}
+          canNext={view.canNext}
+        />
+      </div>
+      <div className="px-s-3 py-s-3 flex-1 overflow-hidden">
+        {panel.kind === 'member' ? (
+          <MemberSchedulePanel
+            member={panel.member}
+            meetingId={meetingId}
+            visibleDays={visibleDays}
+            isInWindow={view.isInWindow}
+          />
+        ) : (
+          <SongMatrixPanel
+            meetingId={meetingId}
+            memberSchedules={memberSchedules}
+            participants={participants}
+            visibleDays={visibleDays}
+            isInWindow={view.isInWindow}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MemberSchedulePanel({
+  member,
+  meetingId,
+  visibleDays,
+  isInWindow,
+}: {
+  member: Member;
+  meetingId: string;
+  visibleDays: string[];
+  isInWindow: (date: string) => boolean;
+}) {
+  const sched = useScheduleStore((s) => s.schedules[`${meetingId}__${member.id}`]);
+  const setHoveredCell = useScheduleViewStore((s) => s.setHoveredCell);
+  return (
+    <div className="flex h-full flex-col gap-3">
+      {sched ? (
+        <WeeklyScheduleGrid
+          days={visibleDays}
+          slotStart={18}
+          slotEnd={44}
+          isInWindow={isInWindow}
+          onCellClick={(date, slot) => setHoveredCell(meetingId, { date, slot })}
+          cellClassName={(d, s, inWindow) => {
+            if (!inWindow) return undefined;
+            if (!sched.availableDates.includes(d)) return undefined;
+            const mask = sched.blocks[d];
+            if (mask?.[s]) return 'bg-accent/70';
+            return undefined;
+          }}
+        />
+      ) : (
+        <p className="text-foreground-muted text-caption px-s-3">
+          {member.name}님은 아직 일정을 입력하지 않았습니다.
+        </p>
+      )}
+      {sched?.note && (
+        <div className="bg-card border-border px-s-3 py-s-2 rounded-md border">
+          <div className="text-foreground-muted text-micro mb-1 font-bold uppercase">특이사항</div>
+          <p className="text-foreground text-caption leading-relaxed whitespace-pre-wrap">
+            {sched.note}
+          </p>
+        </div>
+      )}
+      {sched && (
+        <div className="text-foreground-muted text-micro px-s-1">
+          {sched.completed ? '입력 완료' : '입력 중'} · 갱신{' '}
+          {sched.updatedAt.slice(0, 16).replace('T', ' ')}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SongMatrixPanel({
+  meetingId,
+  memberSchedules,
+  participants,
+  visibleDays,
+  isInWindow,
+}: {
+  meetingId: string;
+  memberSchedules: ReturnType<typeof useScheduleStore.getState>['schedules'][string][];
+  participants: Member[];
+  visibleDays: string[];
+  isInWindow: (date: string) => boolean;
+}) {
+  const setHoveredCell = useScheduleViewStore((s) => s.setHoveredCell);
+  const aggregate = useMemo(
+    () => aggregateAvailability(memberSchedules, visibleDays),
+    [memberSchedules, visibleDays],
+  );
+  const total = participants.length;
+  const colorOf = (count: number): string | undefined => {
+    if (count === 0) return undefined;
+    const ratio = total === 0 ? 0 : count / total;
+    if (ratio < 0.3) return 'bg-warn/40';
+    if (ratio < 0.6) return 'bg-warn/70';
+    if (ratio < 0.9) return 'bg-accent/70';
+    return 'bg-success';
+  };
+  return (
+    <div className="flex h-full flex-col gap-3">
+      <p className="text-foreground-muted text-caption px-s-1">
+        참여 {total}명 기준 동시 가능 시간 — 셀 클릭 시 우측 사이드바에 가능/불가 인원 표시.
+      </p>
+      <WeeklyScheduleGrid
+        days={visibleDays}
+        slotStart={18}
+        slotEnd={44}
+        isInWindow={isInWindow}
+        onCellClick={(date, slot) => setHoveredCell(meetingId, { date, slot })}
+        cellClassName={(d, s, inWindow) => {
+          if (!inWindow) return undefined;
+          const c = aggregate[d]?.[s] ?? 0;
+          return colorOf(c);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(main)/track-selections/scheduling/[selectionId]/page.tsx
+++ b/src/app/(main)/track-selections/scheduling/[selectionId]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+import { SchedulingMain } from './SchedulingMain.client';
+
+export const metadata: Metadata = {
+  title: '합주 일정 조율 | Bandage',
+};
+
+export default async function SchedulingDetailPage({
+  params,
+}: {
+  params: Promise<{ selectionId: string }>;
+}) {
+  const { selectionId } = await params;
+  return <SchedulingMain meetingId={selectionId} />;
+}

--- a/src/app/(main)/track-selections/scheduling/page.tsx
+++ b/src/app/(main)/track-selections/scheduling/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from 'next/navigation';
+
+import { SEED_MEETINGS } from '@/domain/setlist-meeting/mock/seed';
+import { ROUTES } from '@/global/config/routes';
+
+/** /track-selections/scheduling — 첫 회의로 자동 redirect. 빈 회의일 경우 안내. */
+export default function SchedulingIndexPage() {
+  const first = SEED_MEETINGS[0];
+  if (first) redirect(ROUTES.TRACK_SELECTION_SCHEDULING_DETAIL(first.id));
+  return (
+    <div className="px-s-5 py-s-6">
+      <p className="text-foreground-muted text-caption">
+        조율할 선곡 회의가 없습니다. 먼저 회의를 만들어주세요.
+      </p>
+    </div>
+  );
+}

--- a/src/domain/setlist-meeting/api/index.ts
+++ b/src/domain/setlist-meeting/api/index.ts
@@ -1,5 +1,5 @@
 /**
- * 선곡 회의 BE API fetcher 모음 — API_SPEC §7.
+ * 선곡 조율 BE API fetcher 모음 — API_SPEC §7.
  *
  * 현재 FE 의 메인 흐름은 Zustand mock(`store/setlistStore.ts`) 을 사용.
  * 이 fetcher 들은 BE 도입 단계에서 store action 을 점진적으로 교체하기 위해 미리 준비된 표면이다.
@@ -10,14 +10,14 @@ import type { CursorResponse } from '@/global/types';
 import type {
   ConfirmSessionRequest,
   CreateChatMessageRequest,
-  CreateSetlistItemRequest,
-  CreateSetlistMeetingRequest,
-  SetlistItemChatMessageResponse,
-  SetlistItemResponse,
-  SetlistMeetingDetailResponse,
-  SetlistMeetingResponse,
-  UpdateSetlistItemRequest,
-  UpdateSetlistMeetingRequest,
+  CreateSelectionItemRequest,
+  CreateSelectionMeetingRequest,
+  SelectionItemChatMessageResponse,
+  SelectionItemResponse,
+  SelectionMeetingDetailResponse,
+  SelectionMeetingResponse,
+  UpdateSelectionItemRequest,
+  UpdateSelectionMeetingRequest,
 } from '../types/api';
 
 const PREFIX = '/api/v1/setlist-meetings';
@@ -25,77 +25,80 @@ const PREFIX = '/api/v1/setlist-meetings';
 // ─── 회의 ─────────────────────────────────────────────────────────────
 
 /** §7-1. */
-export function createSetlistMeeting(
-  body: CreateSetlistMeetingRequest,
-): Promise<SetlistMeetingResponse> {
-  return apiClient.post<SetlistMeetingResponse>(PREFIX, body);
+export function createSelectionMeeting(
+  body: CreateSelectionMeetingRequest,
+): Promise<SelectionMeetingResponse> {
+  return apiClient.post<SelectionMeetingResponse>(PREFIX, body);
 }
 
 /** §7-2. */
-export function getMySetlistMeetings(params?: {
+export function getMySelectionMeetings(params?: {
   lastId?: string;
   pageSize?: number;
-}): Promise<CursorResponse<SetlistMeetingResponse, string>> {
-  return apiClient.get<CursorResponse<SetlistMeetingResponse, string>>(`${PREFIX}/me`, {
+}): Promise<CursorResponse<SelectionMeetingResponse, string>> {
+  return apiClient.get<CursorResponse<SelectionMeetingResponse, string>>(`${PREFIX}/me`, {
     query: params,
   });
 }
 
 /** §7-3. */
-export function getSetlistMeeting(meetingId: string): Promise<SetlistMeetingDetailResponse> {
-  return apiClient.get<SetlistMeetingDetailResponse>(`${PREFIX}/${meetingId}`);
+export function getSelectionMeeting(meetingId: string): Promise<SelectionMeetingDetailResponse> {
+  return apiClient.get<SelectionMeetingDetailResponse>(`${PREFIX}/${meetingId}`);
 }
 
 /** §7-4. */
-export function updateSetlistMeeting(
+export function updateSelectionMeeting(
   meetingId: string,
-  body: UpdateSetlistMeetingRequest,
-): Promise<SetlistMeetingResponse> {
-  return apiClient.patch<SetlistMeetingResponse>(`${PREFIX}/${meetingId}`, body);
+  body: UpdateSelectionMeetingRequest,
+): Promise<SelectionMeetingResponse> {
+  return apiClient.patch<SelectionMeetingResponse>(`${PREFIX}/${meetingId}`, body);
 }
 
 /** §7-5. */
-export function deleteSetlistMeeting(meetingId: string): Promise<void> {
+export function deleteSelectionMeeting(meetingId: string): Promise<void> {
   return apiClient.delete<void>(`${PREFIX}/${meetingId}`);
 }
 
 // ─── 곡(Item) ─────────────────────────────────────────────────────────
 
 /** §7-6. */
-export function getSetlistItems(
+export function getSelectionItems(
   meetingId: string,
   params?: { lastId?: string; pageSize?: number },
-): Promise<CursorResponse<SetlistItemResponse, string>> {
-  return apiClient.get<CursorResponse<SetlistItemResponse, string>>(
+): Promise<CursorResponse<SelectionItemResponse, string>> {
+  return apiClient.get<CursorResponse<SelectionItemResponse, string>>(
     `${PREFIX}/${meetingId}/items`,
     { query: params },
   );
 }
 
 /** §7-7. */
-export function getSetlistItem(meetingId: string, itemId: string): Promise<SetlistItemResponse> {
-  return apiClient.get<SetlistItemResponse>(`${PREFIX}/${meetingId}/items/${itemId}`);
+export function getSelectionItem(
+  meetingId: string,
+  itemId: string,
+): Promise<SelectionItemResponse> {
+  return apiClient.get<SelectionItemResponse>(`${PREFIX}/${meetingId}/items/${itemId}`);
 }
 
 /** §7-8. */
-export function createSetlistItem(
+export function createSelectionItem(
   meetingId: string,
-  body: CreateSetlistItemRequest,
-): Promise<SetlistItemResponse> {
-  return apiClient.post<SetlistItemResponse>(`${PREFIX}/${meetingId}/items`, body);
+  body: CreateSelectionItemRequest,
+): Promise<SelectionItemResponse> {
+  return apiClient.post<SelectionItemResponse>(`${PREFIX}/${meetingId}/items`, body);
 }
 
 /** §7-9. */
-export function updateSetlistItem(
+export function updateSelectionItem(
   meetingId: string,
   itemId: string,
-  body: UpdateSetlistItemRequest,
-): Promise<SetlistItemResponse> {
-  return apiClient.patch<SetlistItemResponse>(`${PREFIX}/${meetingId}/items/${itemId}`, body);
+  body: UpdateSelectionItemRequest,
+): Promise<SelectionItemResponse> {
+  return apiClient.patch<SelectionItemResponse>(`${PREFIX}/${meetingId}/items/${itemId}`, body);
 }
 
 /** §7-10. */
-export function deleteSetlistItem(meetingId: string, itemId: string): Promise<void> {
+export function deleteSelectionItem(meetingId: string, itemId: string): Promise<void> {
   return apiClient.delete<void>(`${PREFIX}/${meetingId}/items/${itemId}`);
 }
 
@@ -106,8 +109,8 @@ export function applySession(
   meetingId: string,
   itemId: string,
   sessionId: string,
-): Promise<SetlistItemResponse> {
-  return apiClient.post<SetlistItemResponse>(
+): Promise<SelectionItemResponse> {
+  return apiClient.post<SelectionItemResponse>(
     `${PREFIX}/${meetingId}/items/${itemId}/sessions/${sessionId}/applicants`,
     {},
   );
@@ -131,8 +134,8 @@ export function patchConfirmations(
   itemId: string,
   sessionId: string,
   body: ConfirmSessionRequest,
-): Promise<SetlistItemResponse> {
-  return apiClient.patch<SetlistItemResponse>(
+): Promise<SelectionItemResponse> {
+  return apiClient.patch<SelectionItemResponse>(
     `${PREFIX}/${meetingId}/items/${itemId}/sessions/${sessionId}/confirmations`,
     body,
   );
@@ -145,8 +148,8 @@ export function getItemChat(
   meetingId: string,
   itemId: string,
   params?: { lastId?: string; pageSize?: number },
-): Promise<CursorResponse<SetlistItemChatMessageResponse, string>> {
-  return apiClient.get<CursorResponse<SetlistItemChatMessageResponse, string>>(
+): Promise<CursorResponse<SelectionItemChatMessageResponse, string>> {
+  return apiClient.get<CursorResponse<SelectionItemChatMessageResponse, string>>(
     `${PREFIX}/${meetingId}/items/${itemId}/chat`,
     { query: params },
   );
@@ -157,8 +160,8 @@ export function postItemChat(
   meetingId: string,
   itemId: string,
   body: CreateChatMessageRequest,
-): Promise<SetlistItemChatMessageResponse> {
-  return apiClient.post<SetlistItemChatMessageResponse>(
+): Promise<SelectionItemChatMessageResponse> {
+  return apiClient.post<SelectionItemChatMessageResponse>(
     `${PREFIX}/${meetingId}/items/${itemId}/chat`,
     body,
   );
@@ -167,11 +170,11 @@ export function postItemChat(
 // ─── 잠금/해제 ────────────────────────────────────────────────────────
 
 /** §7-16. */
-export function lockSetlistMeeting(meetingId: string): Promise<SetlistMeetingResponse> {
-  return apiClient.post<SetlistMeetingResponse>(`${PREFIX}/${meetingId}/lock`, {});
+export function lockSelectionMeeting(meetingId: string): Promise<SelectionMeetingResponse> {
+  return apiClient.post<SelectionMeetingResponse>(`${PREFIX}/${meetingId}/lock`, {});
 }
 
 /** §7-17. */
-export function unlockSetlistMeeting(meetingId: string): Promise<SetlistMeetingResponse> {
-  return apiClient.post<SetlistMeetingResponse>(`${PREFIX}/${meetingId}/unlock`, {});
+export function unlockSelectionMeeting(meetingId: string): Promise<SelectionMeetingResponse> {
+  return apiClient.post<SelectionMeetingResponse>(`${PREFIX}/${meetingId}/unlock`, {});
 }

--- a/src/domain/setlist-meeting/components/AddSongModal.client.tsx
+++ b/src/domain/setlist-meeting/components/AddSongModal.client.tsx
@@ -20,6 +20,10 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/cn';
 import { useToast } from '@/hooks/useToast';
+import { useCreateTrackSelectionItem } from '@/domain/track-selection/hooks/useCreateTrackSelectionItem';
+import { useUpdateTrackSelectionItem } from '@/domain/track-selection/hooks/useUpdateTrackSelectionItem';
+import { mmSsToSeconds } from '@/domain/track-selection/utils/toSong';
+import type { SessionDefDto } from '@/domain/track-selection/types/req';
 
 import { searchMockSongs, type SongSearchResult } from '../mock/songSearchMock';
 import { useSetlistStore } from '../store/setlistStore';
@@ -158,10 +162,11 @@ export function AddSongModal({
   const ssInputRef = useRef<HTMLInputElement | null>(null);
   const titleRef = useRef<HTMLInputElement | null>(null);
 
-  const addSong = useSetlistStore((s) => s.addSong);
   const updateSong = useSetlistStore((s) => s.updateSong);
-  const currentUserId = useSetlistStore((s) => s.currentUserId);
   const toast = useToast();
+
+  const createItem = useCreateTrackSelectionItem(meetingId);
+  const updateItem = useUpdateTrackSelectionItem(meetingId);
 
   const form = useForm<AddSongSchema>({
     resolver: zodResolver(addSongSchema),
@@ -226,32 +231,68 @@ export function AddSongModal({
 
   const canSubmit = form.formState.isValid && composedSessions.length > 0;
 
-  const onSubmit = form.handleSubmit((values) => {
+  const onSubmit = form.handleSubmit(async (values) => {
     if (composedSessions.length === 0) {
       toast.error('세션을 최소 1개 이상 선택해 주세요.');
       return;
     }
-    const duration = formatDuration(durationMm, durationSs);
-    const payload = {
-      title: values.title,
-      artist: values.artist,
-      album: values.album,
-      duration: duration === '00:00' ? undefined : duration,
-      note: values.note,
-      sessions: composedSessions,
-    };
+    const durationStr = formatDuration(durationMm, durationSs);
+    const duration = mmSsToSeconds(durationStr);
+
+    const sessionDtos: SessionDefDto[] = composedSessions.map((s) => ({
+      custom: s.custom ?? false,
+      label: s.label,
+      need: s.need,
+      sessionId: s.id,
+      short: s.short,
+    }));
+
     if (song) {
-      updateSong(song.id, payload);
-      toast.success('곡 정보가 수정되었습니다.');
-      setOpen(false);
+      try {
+        await updateItem.mutateAsync({
+          itemId: song.id,
+          body: {
+            title: values.title,
+            artist: values.artist || undefined,
+            album: values.album || undefined,
+            duration,
+            note: values.note || undefined,
+            sessions: sessionDtos,
+          },
+        });
+        updateSong(song.id, {
+          title: values.title,
+          artist: values.artist,
+          album: values.album || undefined,
+          duration: durationStr !== '00:00' ? durationStr : undefined,
+          note: values.note || undefined,
+          sessions: composedSessions,
+        });
+        toast.success('곡 정보가 수정되었습니다.');
+        setOpen(false);
+      } catch {
+        toast.error('곡 수정에 실패했습니다.');
+      }
       return;
     }
-    addSong(meetingId, { ...payload, proposerId: currentUserId });
-    toast.success('곡이 추가되었습니다.');
-    if (keepOpen) {
-      resetForNext();
-    } else {
-      setOpen(false);
+
+    try {
+      await createItem.mutateAsync({
+        title: values.title,
+        artist: values.artist,
+        album: values.album || undefined,
+        duration,
+        note: values.note || undefined,
+        sessions: sessionDtos,
+      });
+      toast.success('곡이 추가되었습니다.');
+      if (keepOpen) {
+        resetForNext();
+      } else {
+        setOpen(false);
+      }
+    } catch {
+      toast.error('곡 추가에 실패했습니다.');
     }
   });
 

--- a/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
+++ b/src/domain/setlist-meeting/components/MeetingChatBox.client.tsx
@@ -11,30 +11,38 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 
+import { createChatMessage } from '@/domain/track-selection/api/createChatMessage';
+import { useChatMessages } from '@/domain/track-selection/hooks/useChatMessages';
+import { resolveMemberId } from '@/domain/track-selection/utils/resolveMemberId';
+import { useMe } from '@/domain/member/hooks/useMe';
+import { formatKst } from '@/lib/date';
 import { cn } from '@/lib/cn';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/global/config/queryKeys';
 
 import { useSetlistStore } from '../store/setlistStore';
-
 import { MemberAvatar } from './MemberAvatar';
 
 export interface MeetingChatBoxProps {
+  selectionId: string;
   songId: string;
 }
 
-// 채팅 박스 높이 — 드래그로 위로만 늘어남. 기본/최소 280px, 최대는 viewport-200 (런타임 계산).
 const DEFAULT_HEIGHT = 280;
 const MIN_HEIGHT = DEFAULT_HEIGHT;
 
-export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
-  // selector 내부 find 가 매 렌더마다 새 참조 → 무한 루프. 배열 select + useMemo 로 분리.
+export function MeetingChatBox({ selectionId, songId }: MeetingChatBoxProps) {
   const songs = useSetlistStore((s) => s.songs);
   const song = useMemo(() => songs.find((x) => x.id === songId), [songs, songId]);
-  const members = useSetlistStore((s) => s.members);
-  const currentUserId = useSetlistStore((s) => s.currentUserId);
-  const sendChat = useSetlistStore((s) => s.sendChat);
+  const { data: me } = useMe();
+
+  const { data: chatData } = useChatMessages(selectionId, songId);
+  const messages = chatData?.content ?? [];
+  const qc = useQueryClient();
 
   const listRef = useRef<HTMLDivElement | null>(null);
   const [draft, setDraft] = useState('');
+  const [sending, setSending] = useState(false);
 
   const [height, setHeight] = useState(DEFAULT_HEIGHT);
   const dragRef = useRef<{ y: number; h: number } | null>(null);
@@ -50,12 +58,11 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
     [height],
   );
 
-  // 전역 pointermove/up — 드래그 시작 후 핸들 밖으로 벗어나도 추적.
   useEffect(() => {
     const onMove = (e: PointerEvent) => {
       const start = dragRef.current;
       if (!start) return;
-      const delta = start.y - e.clientY; // 위로 끌면 +
+      const delta = start.y - e.clientY;
       const max = Math.max(MIN_HEIGHT, window.innerHeight - 200);
       const next = Math.min(Math.max(start.h + delta, MIN_HEIGHT), max);
       setHeight(next);
@@ -79,29 +86,32 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
   const isExpanded = height !== DEFAULT_HEIGHT;
   const resetHeight = () => setHeight(DEFAULT_HEIGHT);
 
-  // 새 메시지 추가 시 자동 스크롤.
   useEffect(() => {
     const el = listRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-  }, [song?.chat.length]);
+  }, [messages.length]);
 
   if (!song) return null;
 
-  const submit = () => {
+  const submit = async () => {
     const text = draft.trim();
-    if (!text) return;
-    sendChat(song.id, currentUserId, text);
-    setDraft('');
+    if (!text || sending) return;
+    setSending(true);
+    try {
+      await createChatMessage(selectionId, songId, { message: text });
+      setDraft('');
+      await qc.invalidateQueries({ queryKey: queryKeys.trackSelection.chat(selectionId, songId) });
+    } finally {
+      setSending(false);
+    }
   };
 
   const onKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    // 한글 등 IME 조합 중에는 Enter 가 글자 확정용으로 쓰여 e.key 가 'Enter' 로 들어옴.
-    // 그대로 submit 하면 마지막 글자가 한 번 더 메시지로 전송되는 버그 발생 → 조합 중이면 무시.
     if (e.nativeEvent.isComposing || e.keyCode === 229) return;
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      submit();
+      void submit();
     }
   };
 
@@ -112,7 +122,6 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
       style={{ height }}
       aria-label={`${song.title} 의견 채팅`}
     >
-      {/* 드래그 핸들 — 상단 1px 영역. 위/아래로 끌어 채팅 높이 조절. */}
       <div
         role="separator"
         aria-orientation="horizontal"
@@ -126,7 +135,7 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
       <header className="border-border px-s-5 py-s-2 gap-s-2 flex items-center border-b">
         <MessageSquare className="text-foreground-muted h-4 w-4" />
         <span className="text-caption font-bold">{song.title}</span>
-        <span className="text-foreground-muted text-micro">의견 {song.chat.length}개</span>
+        <span className="text-foreground-muted text-micro">의견 {messages.length}개</span>
         {isExpanded && (
           <button
             type="button"
@@ -140,21 +149,34 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
       </header>
 
       <div ref={listRef} className="px-s-5 py-s-3 flex-1 overflow-y-auto">
-        {song.chat.length === 0 ? (
+        {messages.length === 0 ? (
           <div className="text-foreground-muted py-s-6 text-caption text-center">
             첫 의견을 남겨주세요.
           </div>
         ) : (
           <ul className="gap-s-3 flex flex-col">
-            {song.chat.map((msg, idx) => {
-              const m = members.find((mm) => mm.id === msg.userId);
-              const mine = msg.userId === currentUserId;
+            {messages.map((msg, idx) => {
+              const senderId = resolveMemberId(msg);
+              const mine = me?.id !== undefined && me.id === senderId;
+              const displayName = mine ? '나' : (msg.member?.name ?? `멤버 #${senderId}`);
+              const avatarMember = msg.member
+                ? {
+                    id: String(senderId),
+                    name: displayName,
+                    role: '',
+                    avatar: 'var(--color-accent)',
+                    profileImg: msg.member.profileImg,
+                  }
+                : undefined;
+              const timeLabel = msg.createdAt
+                ? formatKst(new Date(msg.createdAt), 'MM-dd HH:mm')
+                : '';
               return (
                 <li
-                  key={`${msg.userId}-${msg.at}-${idx}`}
+                  key={msg.messageId ?? idx}
                   className={cn('gap-s-2 flex items-start', mine && 'flex-row-reverse')}
                 >
-                  <MemberAvatar member={m} size="sm" />
+                  <MemberAvatar member={avatarMember} size="sm" />
                   <div className={cn('max-w-[70%]', mine && 'text-right')}>
                     <div
                       className={cn(
@@ -163,10 +185,10 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
                       )}
                     >
                       <span className="text-foreground-sub font-semibold">
-                        {m?.name ?? '?'}
+                        {displayName}
                         {mine && <span className="text-accent ml-s-1">나</span>}
                       </span>
-                      <span className="text-foreground-muted">{msg.at}</span>
+                      <span className="text-foreground-muted">{timeLabel}</span>
                     </div>
                     <div
                       className={cn(
@@ -176,7 +198,7 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
                           : 'bg-card text-foreground border-border border',
                       )}
                     >
-                      {msg.msg}
+                      {msg.message}
                     </div>
                   </div>
                 </li>
@@ -198,8 +220,8 @@ export function MeetingChatBox({ songId }: MeetingChatBoxProps) {
         />
         <button
           type="button"
-          onClick={submit}
-          disabled={!draft.trim()}
+          onClick={() => void submit()}
+          disabled={!draft.trim() || sending}
           className="bg-accent text-foreground gap-s-1 px-s-3 py-s-2 text-caption inline-flex shrink-0 items-center rounded-md font-semibold disabled:opacity-40"
           aria-label="메시지 전송"
         >

--- a/src/domain/setlist-meeting/components/ParticipantsModal.client.tsx
+++ b/src/domain/setlist-meeting/components/ParticipantsModal.client.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { Loader2, Search, UserMinus, UserPlus, X } from 'lucide-react';
+import { useState } from 'react';
+
+import { Avatar } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { useMemberSearch } from '@/domain/member/hooks/useMemberSearch';
+import { useUpdateParticipants } from '@/domain/track-selection/hooks/useUpdateParticipants';
+import type { TrackSelectionParticipant } from '@/domain/track-selection/types/res';
+import { resolveMemberId } from '@/domain/track-selection/utils/resolveMemberId';
+import { useToast } from '@/hooks/useToast';
+import { cn } from '@/lib/cn';
+
+import type { Member } from '../types';
+
+export interface ParticipantsModalProps {
+  selectionId: string;
+  bandIds: string[];
+  participants: TrackSelectionParticipant[];
+  members: Member[];
+  currentUserId: string;
+  onClose: () => void;
+}
+
+export function ParticipantsModal({
+  selectionId,
+  bandIds,
+  participants,
+  members,
+  currentUserId,
+  onClose,
+}: ParticipantsModalProps) {
+  const [memberQuery, setMemberQuery] = useState('');
+  const toast = useToast();
+  const updateParticipants = useUpdateParticipants(selectionId);
+  const { data: searchResults = [], isFetching: searching } = useMemberSearch(memberQuery);
+
+  const participantIds = new Set(
+    participants.map((p) => resolveMemberId(p)).filter((id): id is number => id !== undefined),
+  );
+
+  const handleRemove = (memberId: number) => {
+    if (memberId === Number(currentUserId)) {
+      toast.error('본인은 제거할 수 없습니다.');
+      return;
+    }
+    updateParticipants.mutate(
+      { add: [], remove: [memberId] },
+      {
+        onSuccess: () => toast.success('참여자가 제거되었습니다.'),
+        onError: () => toast.error('참여자 제거에 실패했습니다.'),
+      },
+    );
+  };
+
+  const handleAdd = (memberId: number) => {
+    updateParticipants.mutate(
+      { add: [{ memberId, bandIds }], remove: [] },
+      {
+        onSuccess: () => toast.success('참여자가 추가되었습니다.'),
+        onError: () => toast.error('참여자 추가에 실패했습니다.'),
+      },
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="bg-surface border-border w-full max-w-md rounded-xl border shadow-xl">
+        <header className="border-border px-s-5 py-s-4 flex items-center justify-between border-b">
+          <h2 className="text-title font-bold">참여자 관리</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-foreground-muted hover:text-foreground rounded-md p-1"
+            aria-label="닫기"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="px-s-5 py-s-4 space-y-s-4 max-h-[70vh] overflow-y-auto">
+          {/* 현재 참여자 목록 */}
+          <section>
+            <p className="text-foreground-muted text-micro mb-s-2 font-bold uppercase">
+              현재 참여자 ({participants.length})
+            </p>
+            <ul className="gap-s-1 flex flex-col">
+              {participants.flatMap((p) => {
+                const memberId = resolveMemberId(p);
+                if (memberId === undefined) return [];
+                const member = members.find((m) => m.id === String(memberId));
+                const name = member?.name ?? p.member?.name ?? `멤버 #${memberId}`;
+                const isSelf = String(memberId) === currentUserId;
+                return (
+                  <li
+                    key={memberId}
+                    className="bg-card border-border gap-s-3 px-s-3 py-s-2 flex items-center rounded-md border"
+                  >
+                    <Avatar
+                      src={member?.profileImg ?? p.member?.profileImg ?? undefined}
+                      fallback={name}
+                      size="sm"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <span className="text-caption font-semibold">{name}</span>
+                      {isSelf && (
+                        <span className="text-accent text-micro ml-s-2 font-bold">나</span>
+                      )}
+                    </div>
+                    {!isSelf && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(memberId)}
+                        disabled={updateParticipants.isPending}
+                        aria-label={`${name} 제거`}
+                        className={cn(
+                          'text-foreground-muted hover:text-danger rounded-md p-1 transition-colors',
+                          updateParticipants.isPending && 'cursor-not-allowed opacity-40',
+                        )}
+                      >
+                        <UserMinus className="h-4 w-4" />
+                      </button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+
+          {/* 멤버 검색으로 추가 */}
+          <section>
+            <p className="text-foreground-muted text-micro mb-s-2 font-bold uppercase">멤버 추가</p>
+            <div className="bg-card border-border gap-s-2 px-s-3 py-s-2 mb-s-2 flex items-center rounded-md border">
+              <Search className="text-foreground-muted h-4 w-4 shrink-0" />
+              <input
+                type="search"
+                value={memberQuery}
+                onChange={(e) => setMemberQuery(e.target.value)}
+                placeholder="이름 · 이메일로 검색"
+                className="text-body placeholder:text-foreground-muted w-full bg-transparent outline-none"
+                aria-label="멤버 검색"
+              />
+              {searching && <Loader2 className="text-foreground-muted h-4 w-4 animate-spin" />}
+            </div>
+
+            {memberQuery.trim() && (
+              <ul className="border-border rounded-md border">
+                {searchResults.length === 0 && !searching ? (
+                  <li className="text-foreground-muted text-caption px-s-4 py-s-3 text-center">
+                    일치하는 멤버가 없습니다.
+                  </li>
+                ) : (
+                  searchResults.map((m) => {
+                    const already = participantIds.has(m.memberId);
+                    return (
+                      <li key={m.memberId} className="border-border border-b last:border-b-0">
+                        <button
+                          type="button"
+                          onClick={() => !already && handleAdd(m.memberId)}
+                          disabled={already || updateParticipants.isPending}
+                          className="hover:bg-card gap-s-3 px-s-3 py-s-2 flex w-full items-center text-left disabled:cursor-default"
+                        >
+                          <Avatar src={m.profileImg ?? undefined} fallback={m.name} size="sm" />
+                          <div className="min-w-0 flex-1">
+                            <div className="text-caption truncate font-semibold">{m.name}</div>
+                            <div className="text-foreground-muted text-micro truncate">
+                              {m.email}
+                            </div>
+                          </div>
+                          <span
+                            className={cn(
+                              'text-micro px-s-2 shrink-0 rounded-full py-0.5 font-bold',
+                              already ? 'bg-success-dim text-success' : 'bg-accent-dim text-accent',
+                            )}
+                          >
+                            {already ? '참여 중' : <UserPlus className="h-3 w-3" />}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })
+                )}
+              </ul>
+            )}
+          </section>
+        </div>
+
+        <footer className="border-border px-s-5 py-s-3 border-t">
+          <Button variant="secondary" size="sm" onClick={onClose} className="w-full">
+            닫기
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/domain/setlist-meeting/components/SessionPanel.client.tsx
+++ b/src/domain/setlist-meeting/components/SessionPanel.client.tsx
@@ -6,6 +6,11 @@ import { useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/cn';
 
+import { useMe } from '@/domain/member/hooks/useMe';
+import { useApplyForSession } from '@/domain/track-selection/hooks/useApplyForSession';
+import { useWithdrawSession } from '@/domain/track-selection/hooks/useWithdrawSession';
+import { useUpdateSessionConfirmations } from '@/domain/track-selection/hooks/useUpdateSessionConfirmations';
+
 import { useSetlistStore } from '../store/setlistStore';
 import type { Member, SessionDef, Song } from '../types';
 import { displaySessionShort, findSession, missingCount, sessionState } from '../utils';
@@ -15,11 +20,23 @@ import { MemberAvatar } from './MemberAvatar';
 
 export interface SessionPanelProps {
   songId: string;
+  /** 실 API 기반 선곡 ID (meetingId와 동일). 세션 지원/철회/확정 API 호출에 필요. */
+  selectionId: string;
+  /** 밴드 멤버 목록 — MeetingDetail에서 TanStack Query로 패치 후 전달. */
+  members: Member[];
+  /** 실 API 기준 매니저 여부 — 미전달 시 mock store fallback */
+  isManager?: boolean;
   /** 모바일에서 닫기 버튼 노출용. 데스크톱은 항상 노출. */
   onClose?: () => void;
 }
 
-export function SessionPanel({ songId, onClose }: SessionPanelProps) {
+export function SessionPanel({
+  songId,
+  selectionId,
+  members: rawMembers,
+  isManager: isManagerProp,
+  onClose,
+}: SessionPanelProps) {
   // 배열 자체(stable ref) 만 select 하고 find 는 useMemo 로 — selector 내부 find/filter 는 매 렌더마다 새 참조라 무한 루프.
   const songs = useSetlistStore((s) => s.songs);
   const meetings = useSetlistStore((s) => s.meetings);
@@ -28,17 +45,34 @@ export function SessionPanel({ songId, onClose }: SessionPanelProps) {
     () => (song ? (meetings.find((m) => m.id === song.meetingId) ?? null) : null),
     [meetings, song],
   );
-  const members = useSetlistStore((s) => s.members);
   const currentUserId = useSetlistStore((s) => s.currentUserId);
   const focusedSessionId = useSetlistStore((s) => s.focusedSessionId);
+  const { data: me } = useMe();
+  // 실 유저가 전달된 members에 없을 때 임시 Member 합성 (아바타·이름 표시용)
+  const members: Member[] = useMemo(() => {
+    if (!currentUserId || rawMembers.some((m) => m.id === currentUserId)) return rawMembers;
+    const meMember: Member = {
+      id: currentUserId,
+      name: me?.name ?? '나',
+      role: '',
+      avatar: 'var(--color-accent)',
+      profileImg: me?.profileImg ?? undefined,
+    };
+    return [...rawMembers, meMember];
+  }, [rawMembers, currentUserId, me]);
   const setFocusedSession = useSetlistStore((s) => s.setFocusedSession);
   const applySession = useSetlistStore((s) => s.applySession);
   const withdrawSession = useSetlistStore((s) => s.withdrawSession);
   const confirmSession = useSetlistStore((s) => s.confirmSession);
   const unconfirmSession = useSetlistStore((s) => s.unconfirmSession);
+
+  const applyMutation = useApplyForSession(selectionId);
+  const withdrawMutation = useWithdrawSession(selectionId);
+  const confirmMutation = useUpdateSessionConfirmations(selectionId);
+
   const toast = useToast();
 
-  const isManager = meeting ? meeting.managerId === currentUserId : false;
+  const isManager = isManagerProp ?? (meeting ? meeting.managerId === currentUserId : false);
   const focused = song && focusedSessionId ? findSession(song, focusedSessionId) : undefined;
 
   if (!song) {
@@ -87,19 +121,55 @@ export function SessionPanel({ songId, onClose }: SessionPanelProps) {
             onBack={() => setFocusedSession(null)}
             onApply={() => {
               applySession(song.id, focused.id, currentUserId);
-              toast.success('세션에 지원했습니다.');
+              applyMutation.mutate(
+                { itemId: song.id, sessionId: focused.id },
+                {
+                  onSuccess: () => toast.success('세션에 지원했습니다.'),
+                  onError: () => {
+                    withdrawSession(song.id, focused.id, currentUserId);
+                    toast.error('지원에 실패했습니다.');
+                  },
+                },
+              );
             }}
             onWithdraw={() => {
               withdrawSession(song.id, focused.id, currentUserId);
-              toast.info('지원을 취소했습니다.');
+              withdrawMutation.mutate(
+                { itemId: song.id, sessionId: focused.id, userId: Number(currentUserId) },
+                {
+                  onSuccess: () => toast.info('지원을 취소했습니다.'),
+                  onError: () => {
+                    applySession(song.id, focused.id, currentUserId);
+                    toast.error('지원 취소에 실패했습니다.');
+                  },
+                },
+              );
             }}
             onConfirm={(uid) => {
               confirmSession(song.id, focused.id, uid);
-              toast.success('세션이 확정되었습니다.');
+              confirmMutation.mutate(
+                { itemId: song.id, sessionId: focused.id, confirm: [Number(uid)], unconfirm: [] },
+                {
+                  onSuccess: () => toast.success('세션이 확정되었습니다.'),
+                  onError: () => {
+                    unconfirmSession(song.id, focused.id, uid);
+                    toast.error('확정에 실패했습니다.');
+                  },
+                },
+              );
             }}
             onUnconfirm={(uid) => {
               unconfirmSession(song.id, focused.id, uid);
-              toast.info('확정이 해제되었습니다.');
+              confirmMutation.mutate(
+                { itemId: song.id, sessionId: focused.id, confirm: [], unconfirm: [Number(uid)] },
+                {
+                  onSuccess: () => toast.info('확정이 해제되었습니다.'),
+                  onError: () => {
+                    confirmSession(song.id, focused.id, uid);
+                    toast.error('확정 해제에 실패했습니다.');
+                  },
+                },
+              );
             }}
           />
         ) : (
@@ -159,13 +229,18 @@ function OverviewSessionView({
                 : 'border-border bg-card';
           // 카드의 정체성: 누가 이 세션을 맡는지 한눈에 보여주는 것.
           // 1순위: 확정자(이름·아바타). 2순위: 지원자 미니 그룹. 3순위: '미확정'.
-          const confirmedMembers = conf
-            .map((uid) => members.find((m) => m.id === uid))
-            .filter((m): m is Member => Boolean(m));
+          const fallback = (uid: string): Member => ({
+            id: uid,
+            name: `멤버 #${uid}`,
+            role: '',
+            avatar: 'var(--color-accent)',
+          });
+          const confirmedMembers = conf.map(
+            (uid) => members.find((m) => m.id === uid) ?? fallback(uid),
+          );
           const applicantMembers = apps
             .filter((uid) => !conf.includes(uid))
-            .map((uid) => members.find((m) => m.id === uid))
-            .filter((m): m is Member => Boolean(m));
+            .map((uid) => members.find((m) => m.id === uid) ?? fallback(uid));
           return (
             <li key={s.id}>
               <button

--- a/src/domain/setlist-meeting/components/SongTable.client.tsx
+++ b/src/domain/setlist-meeting/components/SongTable.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowDown, ArrowUp, ArrowUpDown, Check, Pencil, Trash2 } from 'lucide-react';
+import { ArrowDown, ArrowUp, ArrowUpDown, Check, Pencil, Star, Trash2 } from 'lucide-react';
 
 import { cn } from '@/lib/cn';
 
@@ -30,9 +30,12 @@ export interface SongTableProps {
   onSelectSong: (songId: string) => void;
   onEditSong?: (songId: string) => void;
   onDeleteSong?: (songId: string) => void;
+  /** 매니저가 잠금 상태에서 최종 선곡 확정/해제. */
+  onToggleSelection?: (songId: string, selected: boolean) => void;
 }
 
-function memberName(members: Member[], id: string): string {
+function memberName(members: Member[], id: string, currentUserId?: string): string {
+  if (currentUserId && id === currentUserId) return '나';
   return members.find((m) => m.id === id)?.name ?? '?';
 }
 
@@ -59,6 +62,7 @@ export function SongTable({
   onSelectSong,
   onEditSong,
   onDeleteSong,
+  onToggleSelection,
 }: SongTableProps) {
   if (songs.length === 0) {
     return (
@@ -213,7 +217,7 @@ export function SongTable({
                   {song.note ? (
                     <span className="block truncate" title={song.note}>
                       <span className="text-foreground-sub font-semibold">
-                        {memberName(members, song.proposerId)} ·{' '}
+                        {memberName(members, song.proposerId, currentUserId)} ·{' '}
                       </span>
                       {song.note}
                     </span>
@@ -223,7 +227,48 @@ export function SongTable({
                 </td>
                 <td className="px-s-3 py-s-2 align-middle">
                   {(() => {
-                    // 잠긴 회의는 모든 멤버에 대해 수정/삭제 비활성.
+                    // 잠금 전: 매니저에게 최종 선곡 토글 표시 (백엔드는 잠금 후 isSelected 변경 거부).
+                    if (!isLocked && isManager && onToggleSelection) {
+                      return (
+                        <div className="flex items-center justify-end">
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onToggleSelection(song.id, !song.isSelected);
+                            }}
+                            aria-label={song.isSelected ? '셋리스트 선택 해제' : '셋리스트에 추가'}
+                            title={song.isSelected ? '셋리스트 선택 해제' : '셋리스트에 추가'}
+                            className={cn(
+                              'inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors',
+                              song.isSelected
+                                ? 'text-warn'
+                                : 'text-foreground-muted hover:text-warn',
+                            )}
+                          >
+                            <Star
+                              className="h-4 w-4"
+                              fill={song.isSelected ? 'currentColor' : 'none'}
+                            />
+                          </button>
+                        </div>
+                      );
+                    }
+                    // 잠긴 후: 선택된 곡은 읽기 전용 별표로 표시.
+                    if (isLocked && song.isSelected) {
+                      return (
+                        <div className="flex items-center justify-end">
+                          <span
+                            aria-label="셋리스트 선택됨"
+                            title="셋리스트에 포함된 곡"
+                            className="text-warn inline-flex h-7 w-7 items-center justify-center"
+                          >
+                            <Star className="h-4 w-4" fill="currentColor" />
+                          </span>
+                        </div>
+                      );
+                    }
+                    // 잠긴 회의는 수정/삭제 비활성.
                     if (isLocked) return null;
                     const canMutate = isManager || song.proposerId === currentUserId;
                     if (!canMutate) return null;

--- a/src/domain/setlist-meeting/mock/seed.ts
+++ b/src/domain/setlist-meeting/mock/seed.ts
@@ -69,15 +69,6 @@ export const SEED_SONGS: Song[] = [
     sessions: STANDARD_SESSIONS,
     applicants: { V: ['u4'], G: ['u1', 'u3'], B: ['u2'], D: [] },
     confirmed: { V: ['u4'], G: ['u1'], B: ['u2'], D: [] },
-    chat: [
-      {
-        userId: 'u3',
-        at: '04-22 10:14',
-        msg: 'Pull Me Under 인트로부터 너무 강력해서 1번 트랙 어떨까요?',
-      },
-      { userId: 'u4', at: '04-22 11:02', msg: '보컬 음역 빡셈. 키 반음 내릴지 고민됨.' },
-      { userId: 'u1', at: '04-22 14:30', msg: '기타 솔로 분리해서 합주 잡고 싶음.' },
-    ],
   },
   {
     id: 's2',
@@ -91,10 +82,6 @@ export const SEED_SONGS: Song[] = [
     sessions: STANDARD_SESSIONS,
     applicants: { V: ['u4'], G: ['u3', 'u1'], B: ['u2'], D: ['u5', 'u7'] },
     confirmed: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'] },
-    chat: [
-      { userId: 'u1', at: '04-20 09:00', msg: 'Take the Time 라이브에서 진짜 좋을 듯.' },
-      { userId: 'u5', at: '04-20 10:15', msg: '드럼 그루브 좋아요.' },
-    ],
   },
   {
     id: 's3',
@@ -108,9 +95,6 @@ export const SEED_SONGS: Song[] = [
     sessions: STANDARD_SESSIONS,
     applicants: { V: ['u4'], G: ['u1'], B: ['u2'], D: [] },
     confirmed: { V: [], G: [], B: [], D: [] },
-    chat: [
-      { userId: 'u4', at: '04-21 16:00', msg: '솔로가 진짜 명연이라 합주에서 살릴 만합니다.' },
-    ],
   },
   {
     id: 's4',
@@ -127,10 +111,6 @@ export const SEED_SONGS: Song[] = [
     ],
     applicants: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'], PERC: [] },
     confirmed: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'], PERC: [] },
-    chat: [
-      { userId: 'u4', at: '04-23 13:20', msg: '키보드 패드는 임지수님 맡아주시면 좋겠어요.' },
-      { userId: 'u6', at: '04-23 14:00', msg: 'OK! 사운드 미리 준비할게요.' },
-    ],
   },
   {
     id: 's5',
@@ -144,7 +124,6 @@ export const SEED_SONGS: Song[] = [
     sessions: STANDARD_SESSIONS,
     applicants: { V: [], G: ['u1', 'u3'], B: ['u2'], D: ['u5'] },
     confirmed: { V: [], G: ['u1'], B: ['u2'], D: ['u5'] },
-    chat: [{ userId: 'u2', at: '04-24 11:00', msg: 'Erotomania 베이스 패턴 진짜 멋있음.' }],
   },
   {
     id: 's6',
@@ -161,10 +140,6 @@ export const SEED_SONGS: Song[] = [
     ],
     applicants: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], D2: ['u7'] },
     confirmed: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], D2: ['u7'] },
-    chat: [
-      { userId: 'u5', at: '04-24 19:00', msg: '후반부 트윈 드럼 어떨까요? 최홍석님이랑 같이.' },
-      { userId: 'u7', at: '04-24 19:20', msg: '좋아요! 패턴 분담 정해봅시다.' },
-    ],
   },
   {
     id: 's7',
@@ -178,7 +153,6 @@ export const SEED_SONGS: Song[] = [
     sessions: STANDARD_SESSIONS,
     applicants: { V: [], G: ['u3', 'u1'], B: [], D: [] },
     confirmed: { V: [], G: [], B: [], D: [] },
-    chat: [{ userId: 'u3', at: '04-25 09:15', msg: '난이도 최상. 시간 많이 필요할 것 같아요.' }],
   },
 
   // ─── 추가 13곡 — 시간표 풀 가독성 검증용 (총 20곡). ─────────────────
@@ -194,7 +168,6 @@ export const SEED_SONGS: Song[] = [
     sessions: STANDARD_SESSIONS,
     applicants: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'] },
     confirmed: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'] },
-    chat: [],
   },
   {
     id: 's9',
@@ -208,7 +181,6 @@ export const SEED_SONGS: Song[] = [
     sessions: KEYS_SESSIONS,
     applicants: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'], K: ['u6'] },
     confirmed: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'], K: ['u6'] },
-    chat: [],
   },
   {
     id: 's10',
@@ -222,7 +194,6 @@ export const SEED_SONGS: Song[] = [
     sessions: STANDARD_SESSIONS,
     applicants: { V: ['u4'], G: ['u3'], B: [], D: [] },
     confirmed: { V: ['u4'], G: [], B: [], D: [] },
-    chat: [],
   },
   {
     id: 's11',
@@ -236,7 +207,6 @@ export const SEED_SONGS: Song[] = [
     sessions: STANDARD_SESSIONS,
     applicants: { V: ['u4'], G: ['u1', 'u3'], B: ['u2'], D: ['u5'] },
     confirmed: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'] },
-    chat: [],
   },
   {
     id: 's12',
@@ -250,7 +220,6 @@ export const SEED_SONGS: Song[] = [
     sessions: KEYS_SESSIONS,
     applicants: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'] },
     confirmed: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'] },
-    chat: [],
   },
   {
     id: 's13',
@@ -264,7 +233,6 @@ export const SEED_SONGS: Song[] = [
     sessions: KEYS_SESSIONS,
     applicants: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'] },
     confirmed: { V: [], G: [], B: [], D: [], K: [] },
-    chat: [],
   },
   {
     id: 's14',
@@ -278,7 +246,6 @@ export const SEED_SONGS: Song[] = [
     sessions: KEYS_SESSIONS,
     applicants: { V: [], G: ['u1', 'u3'], B: ['u2'], D: ['u5'], K: ['u6'] },
     confirmed: { V: [], G: ['u1'], B: ['u2'], D: ['u5'], K: ['u6'] },
-    chat: [],
   },
   {
     id: 's15',
@@ -292,7 +259,6 @@ export const SEED_SONGS: Song[] = [
     sessions: KEYS_SESSIONS,
     applicants: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'] },
     confirmed: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'] },
-    chat: [],
   },
   {
     id: 's16',
@@ -306,7 +272,6 @@ export const SEED_SONGS: Song[] = [
     sessions: KEYS_SESSIONS,
     applicants: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'], K: ['u6'] },
     confirmed: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'], K: ['u6'] },
-    chat: [],
   },
   {
     id: 's17',
@@ -320,7 +285,6 @@ export const SEED_SONGS: Song[] = [
     sessions: KEYS_SESSIONS,
     applicants: { V: ['u4'], G: ['u3'], B: [], D: [], K: [] },
     confirmed: { V: [], G: [], B: [], D: [], K: [] },
-    chat: [],
   },
   {
     id: 's18',
@@ -334,7 +298,6 @@ export const SEED_SONGS: Song[] = [
     sessions: STANDARD_SESSIONS,
     applicants: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'] },
     confirmed: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'] },
-    chat: [],
   },
   {
     id: 's19',
@@ -348,7 +311,6 @@ export const SEED_SONGS: Song[] = [
     sessions: KEYS_SESSIONS,
     applicants: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'] },
     confirmed: { V: ['u4'], G: ['u3'], B: ['u2'], D: ['u5'], K: ['u6'] },
-    chat: [],
   },
   {
     id: 's20',
@@ -362,7 +324,6 @@ export const SEED_SONGS: Song[] = [
     sessions: KEYS_SESSIONS,
     applicants: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'], K: ['u6'] },
     confirmed: { V: ['u4'], G: ['u1'], B: ['u2'], D: ['u5'], K: ['u6'] },
-    chat: [],
   },
 ];
 

--- a/src/domain/setlist-meeting/store/setlistStore.test.ts
+++ b/src/domain/setlist-meeting/store/setlistStore.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { SEED_SONGS } from '../mock/seed';
 import { useSetlistStore } from './setlistStore';
 
 beforeEach(() => {
   useSetlistStore.getState().reset();
+  useSetlistStore.setState({ songs: SEED_SONGS });
 });
 
 describe('setlistStore — application/withdraw', () => {
@@ -38,16 +40,7 @@ describe('setlistStore — application/withdraw', () => {
   });
 });
 
-describe('setlistStore — chat / addSong / addCustomSession', () => {
-  it('sendChat 은 채팅 배열에 메시지를 append', () => {
-    const { sendChat } = useSetlistStore.getState();
-    const before = useSetlistStore.getState().songs.find((s) => s.id === 's1')!.chat.length;
-    sendChat('s1', 'u1', '테스트 메시지', '04-26 12:00');
-    const after = useSetlistStore.getState().songs.find((s) => s.id === 's1')!.chat;
-    expect(after.length).toBe(before + 1);
-    expect(after.at(-1)).toMatchObject({ userId: 'u1', msg: '테스트 메시지' });
-  });
-
+describe('setlistStore — addSong / addCustomSession', () => {
   it('addSong 은 빈 applicants/confirmed 버킷을 초기화', () => {
     const { addSong } = useSetlistStore.getState();
     const id = addSong('mt1', {

--- a/src/domain/setlist-meeting/store/setlistStore.ts
+++ b/src/domain/setlist-meeting/store/setlistStore.ts
@@ -1,14 +1,8 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-import {
-  DEFAULT_SESSIONS,
-  SEED_CURRENT_USER_ID,
-  SEED_MEETINGS,
-  SEED_MEMBERS,
-  SEED_SONGS,
-} from '../mock/seed';
-import type { ChatMessage, Meeting, Member, SessionDef, Song } from '../types';
+import { DEFAULT_SESSIONS, SEED_CURRENT_USER_ID, SEED_MEETINGS } from '../mock/seed';
+import type { Meeting, SessionDef, Song } from '../types';
 
 const noopStorage = {
   getItem: () => null,
@@ -19,7 +13,6 @@ const noopStorage = {
 type State = {
   meetings: Meeting[];
   songs: Song[];
-  members: Member[];
   currentUserId: string;
   selectedMeetingId: string | null;
   selectedSongId: string | null;
@@ -35,7 +28,6 @@ type Actions = {
   withdrawSession: (songId: string, sessionId: string, userId: string) => void;
   confirmSession: (songId: string, sessionId: string, userId: string) => void;
   unconfirmSession: (songId: string, sessionId: string, userId: string) => void;
-  sendChat: (songId: string, userId: string, msg: string, at?: string) => void;
   addSong: (
     meetingId: string,
     song: Pick<Song, 'title' | 'artist' | 'album' | 'duration' | 'note' | 'proposerId'> & {
@@ -50,6 +42,8 @@ type Actions = {
     },
   ) => void;
   addCustomSession: (songId: string, session: SessionDef) => void;
+  /** 실 API 응답으로 특정 meetingId 의 곡 목록을 통째로 교체. */
+  setSongs: (meetingId: string, songs: Song[]) => void;
   addMeeting: (
     meeting: Omit<
       Meeting,
@@ -68,19 +62,12 @@ export type SetlistStore = State & Actions;
 
 const initial: State = {
   meetings: SEED_MEETINGS,
-  songs: SEED_SONGS,
-  members: SEED_MEMBERS,
+  songs: [],
   currentUserId: SEED_CURRENT_USER_ID,
-  selectedMeetingId: SEED_MEETINGS[0]?.id ?? null,
-  selectedSongId: SEED_SONGS[0]?.id ?? null,
+  selectedMeetingId: null,
+  selectedSongId: null,
   focusedSessionId: null,
 };
-
-function nowMMDDHHmm(): string {
-  const d = new Date();
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
 
 function updateSong(songs: Song[], songId: string, updater: (song: Song) => Song): Song[] {
   return songs.map((s) => (s.id === songId ? updater(s) : s));
@@ -148,14 +135,6 @@ export const useSetlistStore = create<SetlistStore>()(
           })),
         })),
 
-      sendChat: (songId, userId, msg, at) =>
-        set((state) => ({
-          songs: updateSong(state.songs, songId, (song) => ({
-            ...song,
-            chat: [...song.chat, { userId, msg, at: at ?? nowMMDDHHmm() } satisfies ChatMessage],
-          })),
-        })),
-
       addSong: (meetingId, draft) => {
         const id = `s_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
         const sessions = draft.sessions ?? DEFAULT_SESSIONS;
@@ -174,7 +153,6 @@ export const useSetlistStore = create<SetlistStore>()(
           sessions,
           applicants: empty,
           confirmed: { ...empty },
-          chat: [],
         };
         set((state) => ({ songs: [...state.songs, next] }));
         return id;
@@ -222,6 +200,18 @@ export const useSetlistStore = create<SetlistStore>()(
                   confirmed: { ...song.confirmed, [session.id]: [] },
                 },
           ),
+        })),
+
+      setSongs: (meetingId, incoming) =>
+        set((state) => ({
+          songs: [...state.songs.filter((s) => s.meetingId !== meetingId), ...incoming],
+          // 현재 선택 곡이 삭제된 경우 선택 해제.
+          selectedSongId: incoming.some((s) => s.id === state.selectedSongId)
+            ? state.selectedSongId
+            : null,
+          focusedSessionId: incoming.some((s) => s.id === state.selectedSongId)
+            ? state.focusedSessionId
+            : null,
         })),
 
       addMeeting: (meeting) => {

--- a/src/domain/setlist-meeting/types.ts
+++ b/src/domain/setlist-meeting/types.ts
@@ -1,9 +1,3 @@
-/**
- * 선곡 회의 (Setlist Meeting) — FE-only mock 도메인.
- * 백엔드 미구현 단계: Zustand persist(sessionStorage)로만 상태 보관.
- * design/web/setlist_web.jsx 의 데이터 모델과 1:1 대응.
- */
-
 export type SessionDef = {
   id: string;
   label: string;
@@ -16,13 +10,6 @@ export type SessionDef = {
 export type Applicant = {
   userId: string;
   appliedAt: string;
-};
-
-export type ChatMessage = {
-  userId: string;
-  /** 'MM-DD HH:mm' 또는 ISO. mock 은 design 원본 표기 유지. */
-  at: string;
-  msg: string;
 };
 
 export type Member = {
@@ -53,7 +40,8 @@ export type Song = {
   applicants: Record<string, string[]>;
   /** sessionId → userId[]. confirmed.length >= need 면 full. */
   confirmed: Record<string, string[]>;
-  chat: ChatMessage[];
+  /** 매니저가 최종 선곡으로 확정한 항목. */
+  isSelected?: boolean;
 };
 
 export type MeetingPurpose = 'performance' | 'general';

--- a/src/domain/setlist-meeting/types/api.ts
+++ b/src/domain/setlist-meeting/types/api.ts
@@ -6,7 +6,7 @@
 export type ApiMeetingPurpose = 'PERFORMANCE' | 'GENERAL';
 
 /** §7-1 / §7-3 응답. */
-export interface SetlistMeetingResponse {
+export interface SelectionMeetingResponse {
   meetingId: string;
   bandId: string;
   title: string;
@@ -19,12 +19,12 @@ export interface SetlistMeetingResponse {
 }
 
 /** §7-3 단건 조회 응답 — 참여자 포함. */
-export interface SetlistMeetingDetailResponse extends SetlistMeetingResponse {
+export interface SelectionMeetingDetailResponse extends SelectionMeetingResponse {
   participantUserIds: number[];
 }
 
 /** §7 곡(Item) 의 세션 정의 + 지원/확정 임베디드. */
-export interface SetlistItemSessionResponse {
+export interface SelectionItemSessionResponse {
   sessionId: string;
   label: string;
   short: string;
@@ -35,7 +35,7 @@ export interface SetlistItemSessionResponse {
 }
 
 /** §7-7 / §7-8 / §7-9 응답. */
-export interface SetlistItemResponse {
+export interface SelectionItemResponse {
   setlistItemId: string;
   meetingId: string;
   title: string;
@@ -46,13 +46,13 @@ export interface SetlistItemResponse {
   note: string | null;
   /** 매니저 잠금 시 매핑되는 합주곡 ID. */
   practiceSongId: string | null;
-  sessions: SetlistItemSessionResponse[];
+  sessions: SelectionItemSessionResponse[];
   createdAt: string;
   updatedAt: string;
 }
 
 /** §7-14 채팅 메시지 응답. (실서버 검증 결과 BE 는 `memberId` 필드명 사용 — spec 와 다름) */
-export interface SetlistItemChatMessageResponse {
+export interface SelectionItemChatMessageResponse {
   messageId: string;
   setlistItemId: string;
   /** 작성자 회원 ID. spec 표기는 userId 였으나 실제 응답은 memberId. */
@@ -63,7 +63,7 @@ export interface SetlistItemChatMessageResponse {
 
 // ─── Request 바디 타입 ───────────────────────────────────────────────────
 
-export interface CreateSetlistMeetingRequest {
+export interface CreateSelectionMeetingRequest {
   title: string;
   purpose: ApiMeetingPurpose;
   performanceId?: string | null;
@@ -72,12 +72,12 @@ export interface CreateSetlistMeetingRequest {
   participantUserIds: number[];
 }
 
-export interface UpdateSetlistMeetingRequest {
+export interface UpdateSelectionMeetingRequest {
   title?: string;
   managerId?: number;
 }
 
-export interface SetlistItemSessionDefRequest {
+export interface SelectionItemSessionDefRequest {
   sessionId: string;
   label: string;
   short: string;
@@ -85,22 +85,22 @@ export interface SetlistItemSessionDefRequest {
   custom?: boolean;
 }
 
-export interface CreateSetlistItemRequest {
+export interface CreateSelectionItemRequest {
   title: string;
   artist: string;
   album?: string;
   duration?: string;
   note?: string;
-  sessions: SetlistItemSessionDefRequest[];
+  sessions: SelectionItemSessionDefRequest[];
 }
 
-export interface UpdateSetlistItemRequest {
+export interface UpdateSelectionItemRequest {
   title?: string;
   artist?: string;
   album?: string;
   duration?: string;
   note?: string;
-  sessions?: SetlistItemSessionDefRequest[];
+  sessions?: SelectionItemSessionDefRequest[];
 }
 
 export interface ConfirmSessionRequest {

--- a/src/domain/setlist/hooks/useCreateJamsFromSetlist.ts
+++ b/src/domain/setlist/hooks/useCreateJamsFromSetlist.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { createJamsFromSetlist } from '../api';
+import type { SetlistToJamRequest } from '../types/req';
+
+export function useCreateJamsFromSetlist(setlistId: string) {
+  return useMutation({
+    mutationFn: (body: SetlistToJamRequest) => createJamsFromSetlist(setlistId, body),
+  });
+}

--- a/src/domain/setlist/hooks/useCreateSetlist.ts
+++ b/src/domain/setlist/hooks/useCreateSetlist.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { createSetlist } from '../api';
+import type { SetlistCreateRequest } from '../types/req';
+
+export function useCreateSetlist() {
+  return useMutation({
+    mutationFn: (body: SetlistCreateRequest) => createSetlist(body),
+  });
+}

--- a/src/domain/setlist/hooks/useDeleteSetlistTrack.ts
+++ b/src/domain/setlist/hooks/useDeleteSetlistTrack.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deleteSetlistTrack } from '../api';
+
+export function useDeleteSetlistTrack(setlistId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (trackId: string) => deleteSetlistTrack(setlistId, trackId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.setlist.tracks(setlistId) });
+    },
+  });
+}

--- a/src/domain/setlist/hooks/useSetlist.ts
+++ b/src/domain/setlist/hooks/useSetlist.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+
+import { getSetlist } from '../api';
+
+export function useSetlist(setlistId: string) {
+  const authenticated = useIsAuthenticated();
+  return useQuery({
+    queryKey: queryKeys.setlist.detail(setlistId),
+    queryFn: () => getSetlist(setlistId),
+    enabled: authenticated && Boolean(setlistId),
+  });
+}

--- a/src/domain/setlist/hooks/useUpdateSetlist.ts
+++ b/src/domain/setlist/hooks/useUpdateSetlist.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateSetlist } from '../api';
+
+export function useUpdateSetlist(setlistId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (title: string) => updateSetlist(setlistId, { title }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.setlist.detail(setlistId) });
+      void qc.invalidateQueries({ queryKey: queryKeys.setlist.my() });
+    },
+  });
+}

--- a/src/domain/setlist/hooks/useUpdateSetlistTrack.ts
+++ b/src/domain/setlist/hooks/useUpdateSetlistTrack.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateSetlistTrack } from '../api';
+import type { SetlistTrackUpdateRequest } from '../types/req';
+
+export function useUpdateSetlistTrack(setlistId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ trackId, body }: { trackId: string; body: SetlistTrackUpdateRequest }) =>
+      updateSetlistTrack(setlistId, trackId, body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.setlist.tracks(setlistId) });
+    },
+  });
+}

--- a/src/domain/track-selection/api/applyForSession.ts
+++ b/src/domain/track-selection/api/applyForSession.ts
@@ -1,0 +1,11 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function applyForSession(
+  selectionId: string,
+  itemId: string,
+  sessionId: string,
+): Promise<void> {
+  await apiClient.post<null>(
+    `/api/v1/track-selections/${selectionId}/items/${itemId}/sessions/${sessionId}/applicants`,
+  );
+}

--- a/src/domain/track-selection/api/createChatMessage.ts
+++ b/src/domain/track-selection/api/createChatMessage.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { SetlistChatMessageResponse } from './getChatMessages';
+
+export async function createChatMessage(
+  selectionId: string,
+  itemId: string,
+  body: { message: string },
+): Promise<SetlistChatMessageResponse> {
+  return apiClient.post<SetlistChatMessageResponse>(
+    `/api/v1/track-selections/${selectionId}/items/${itemId}/chat`,
+    body,
+  );
+}

--- a/src/domain/track-selection/api/createTrackSelection.ts
+++ b/src/domain/track-selection/api/createTrackSelection.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { CreateTrackSelectionRequest } from '../types/req';
+import type { TrackSelectionResponse } from '../types/res';
+
+export async function createTrackSelection(
+  body: CreateTrackSelectionRequest,
+): Promise<TrackSelectionResponse> {
+  return apiClient.post<TrackSelectionResponse>('/api/v1/track-selections', body);
+}

--- a/src/domain/track-selection/api/createTrackSelectionItem.ts
+++ b/src/domain/track-selection/api/createTrackSelectionItem.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { TrackSelectionItemCreateRequest } from '../types/req';
+import type { TrackSelectionItemResponse } from '../types/res';
+
+export async function createTrackSelectionItem(
+  selectionId: string,
+  body: TrackSelectionItemCreateRequest,
+): Promise<TrackSelectionItemResponse> {
+  return apiClient.post<TrackSelectionItemResponse>(
+    `/api/v1/track-selections/${selectionId}/items`,
+    body,
+  );
+}

--- a/src/domain/track-selection/api/deleteTrackSelectionItem.ts
+++ b/src/domain/track-selection/api/deleteTrackSelectionItem.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function deleteTrackSelectionItem(selectionId: string, itemId: string): Promise<void> {
+  await apiClient.delete<null>(`/api/v1/track-selections/${selectionId}/items/${itemId}`);
+}

--- a/src/domain/track-selection/api/getChatMessages.ts
+++ b/src/domain/track-selection/api/getChatMessages.ts
@@ -1,0 +1,29 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+export interface ChatMemberInfo {
+  memberId: number;
+  name?: string;
+  profileImg?: string;
+}
+
+export interface SetlistChatMessageResponse {
+  messageId: string;
+  trackSelectionItemId: string;
+  /** @deprecated BE가 더 이상 필수로 내려주지 않음. member.memberId 를 사용할 것. */
+  memberId?: number;
+  member?: ChatMemberInfo;
+  message: string;
+  createdAt?: string;
+}
+
+export async function getChatMessages(
+  selectionId: string,
+  itemId: string,
+  params?: { lastId?: string; pageSize?: number },
+): Promise<CursorResponse<SetlistChatMessageResponse, string>> {
+  return apiClient.get<CursorResponse<SetlistChatMessageResponse, string>>(
+    `/api/v1/track-selections/${selectionId}/items/${itemId}/chat`,
+    { query: params },
+  );
+}

--- a/src/domain/track-selection/api/getMyTrackSelections.ts
+++ b/src/domain/track-selection/api/getMyTrackSelections.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { TrackSelectionResponse } from '../types/res';
+
+type GetMyTrackSelectionsParams = {
+  lastId?: string;
+  pageSize: number;
+};
+
+export async function getMyTrackSelections(
+  params: GetMyTrackSelectionsParams,
+): Promise<CursorResponse<TrackSelectionResponse, string>> {
+  const data = await apiClient.get<CursorResponse<TrackSelectionResponse, string> | null>(
+    '/api/v1/track-selections/me',
+    { query: { lastId: params.lastId, pageSize: params.pageSize } },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/track-selection/api/getTrackSelection.ts
+++ b/src/domain/track-selection/api/getTrackSelection.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { TrackSelectionDetailResponse } from '../types/res';
+
+export async function getTrackSelection(
+  selectionId: string,
+): Promise<TrackSelectionDetailResponse> {
+  return apiClient.get<TrackSelectionDetailResponse>(`/api/v1/track-selections/${selectionId}`);
+}

--- a/src/domain/track-selection/api/getTrackSelectionItems.ts
+++ b/src/domain/track-selection/api/getTrackSelectionItems.ts
@@ -1,0 +1,17 @@
+import { apiClient } from '@/global/api/apiClient';
+import type { CursorResponse } from '@/global/types';
+
+import type { TrackSelectionItemResponse } from '../types/res';
+
+type Params = { lastId?: string; pageSize: number };
+
+export async function getTrackSelectionItems(
+  selectionId: string,
+  params: Params,
+): Promise<CursorResponse<TrackSelectionItemResponse, string>> {
+  const data = await apiClient.get<CursorResponse<TrackSelectionItemResponse, string> | null>(
+    `/api/v1/track-selections/${selectionId}/items`,
+    { query: { lastId: params.lastId, pageSize: params.pageSize } },
+  );
+  return data ?? { content: [], nextCursor: null, hasNext: false };
+}

--- a/src/domain/track-selection/api/lockSelection.ts
+++ b/src/domain/track-selection/api/lockSelection.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function lockSelection(selectionId: string): Promise<void> {
+  await apiClient.post<null>(`/api/v1/track-selections/${selectionId}/lock`);
+}
+
+export async function unlockSelection(selectionId: string): Promise<void> {
+  await apiClient.post<null>(`/api/v1/track-selections/${selectionId}/unlock`);
+}

--- a/src/domain/track-selection/api/updateItemSelection.ts
+++ b/src/domain/track-selection/api/updateItemSelection.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { TrackSelectionItemResponse } from '../types/res';
+
+export async function updateItemSelection(
+  selectionId: string,
+  itemId: string,
+  body: { selected: boolean },
+): Promise<TrackSelectionItemResponse> {
+  return apiClient.patch<TrackSelectionItemResponse>(
+    `/api/v1/track-selections/${selectionId}/items/${itemId}/selection`,
+    body,
+  );
+}

--- a/src/domain/track-selection/api/updateParticipants.ts
+++ b/src/domain/track-selection/api/updateParticipants.ts
@@ -1,0 +1,23 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { TrackSelectionDetailResponse } from '../types/res';
+
+export interface ParticipantAddDto {
+  memberId: number;
+  bandIds: string[];
+}
+
+export interface UpdateParticipantsRequest {
+  add: ParticipantAddDto[];
+  remove: number[];
+}
+
+export async function updateParticipants(
+  selectionId: string,
+  body: UpdateParticipantsRequest,
+): Promise<TrackSelectionDetailResponse> {
+  return apiClient.patch<TrackSelectionDetailResponse>(
+    `/api/v1/track-selections/${selectionId}/participants`,
+    body,
+  );
+}

--- a/src/domain/track-selection/api/updateSessionConfirmations.ts
+++ b/src/domain/track-selection/api/updateSessionConfirmations.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/global/api/apiClient';
+
+type Body = { confirm: number[]; unconfirm: number[] };
+
+export async function updateSessionConfirmations(
+  selectionId: string,
+  itemId: string,
+  sessionId: string,
+  body: Body,
+): Promise<void> {
+  await apiClient.patch<null>(
+    `/api/v1/track-selections/${selectionId}/items/${itemId}/sessions/${sessionId}/confirmations`,
+    body,
+  );
+}

--- a/src/domain/track-selection/api/updateTrackSelectionItem.ts
+++ b/src/domain/track-selection/api/updateTrackSelectionItem.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/global/api/apiClient';
+
+import type { TrackSelectionItemUpdateRequest } from '../types/req';
+import type { TrackSelectionItemResponse } from '../types/res';
+
+export async function updateTrackSelectionItem(
+  selectionId: string,
+  itemId: string,
+  body: TrackSelectionItemUpdateRequest,
+): Promise<TrackSelectionItemResponse> {
+  return apiClient.patch<TrackSelectionItemResponse>(
+    `/api/v1/track-selections/${selectionId}/items/${itemId}`,
+    body,
+  );
+}

--- a/src/domain/track-selection/api/withdrawSessionApplication.ts
+++ b/src/domain/track-selection/api/withdrawSessionApplication.ts
@@ -1,0 +1,12 @@
+import { apiClient } from '@/global/api/apiClient';
+
+export async function withdrawSessionApplication(
+  selectionId: string,
+  itemId: string,
+  sessionId: string,
+  userId: number,
+): Promise<void> {
+  await apiClient.delete<null>(
+    `/api/v1/track-selections/${selectionId}/items/${itemId}/sessions/${sessionId}/applicants/${userId}`,
+  );
+}

--- a/src/domain/track-selection/hooks/useApplyForSession.ts
+++ b/src/domain/track-selection/hooks/useApplyForSession.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { applyForSession } from '../api/applyForSession';
+
+export function useApplyForSession(selectionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ itemId, sessionId }: { itemId: string; sessionId: string }) =>
+      applyForSession(selectionId, itemId, sessionId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.trackSelection.items(selectionId) });
+    },
+  });
+}

--- a/src/domain/track-selection/hooks/useChatMessages.ts
+++ b/src/domain/track-selection/hooks/useChatMessages.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useIsAuthenticated } from '@/global/store/authStore';
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { getChatMessages } from '../api/getChatMessages';
+
+export function useChatMessages(selectionId: string, itemId: string) {
+  const authenticated = useIsAuthenticated();
+  return useQuery({
+    queryKey: queryKeys.trackSelection.chat(selectionId, itemId),
+    queryFn: () => getChatMessages(selectionId, itemId, { pageSize: 100 }),
+    enabled: authenticated && Boolean(selectionId) && Boolean(itemId),
+    refetchInterval: 5000,
+  });
+}

--- a/src/domain/track-selection/hooks/useCreateTrackSelectionItem.ts
+++ b/src/domain/track-selection/hooks/useCreateTrackSelectionItem.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { createTrackSelectionItem } from '../api/createTrackSelectionItem';
+import type { TrackSelectionItemCreateRequest } from '../types/req';
+
+export function useCreateTrackSelectionItem(selectionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: TrackSelectionItemCreateRequest) =>
+      createTrackSelectionItem(selectionId, body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.trackSelection.items(selectionId) });
+    },
+  });
+}

--- a/src/domain/track-selection/hooks/useDeleteTrackSelectionItem.ts
+++ b/src/domain/track-selection/hooks/useDeleteTrackSelectionItem.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { deleteTrackSelectionItem } from '../api/deleteTrackSelectionItem';
+
+export function useDeleteTrackSelectionItem(selectionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (itemId: string) => deleteTrackSelectionItem(selectionId, itemId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.trackSelection.items(selectionId) });
+    },
+  });
+}

--- a/src/domain/track-selection/hooks/useMyTrackSelections.ts
+++ b/src/domain/track-selection/hooks/useMyTrackSelections.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+import { useInfiniteCursor } from '@/hooks/useInfiniteCursor';
+
+import { getMyTrackSelections } from '../api/getMyTrackSelections';
+import type { TrackSelectionResponse } from '../types/res';
+
+export function useMyTrackSelections(pageSize: number = 20) {
+  const authenticated = useIsAuthenticated();
+  return useInfiniteCursor<TrackSelectionResponse, string>(
+    queryKeys.trackSelection.my(),
+    ({ lastId, pageSize: size }) => getMyTrackSelections({ lastId, pageSize: size }),
+    pageSize,
+    { enabled: authenticated },
+  );
+}

--- a/src/domain/track-selection/hooks/useTrackSelection.ts
+++ b/src/domain/track-selection/hooks/useTrackSelection.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+import { useIsAuthenticated } from '@/global/store/authStore';
+
+import { getTrackSelection } from '../api/getTrackSelection';
+import type { TrackSelectionDetailResponse } from '../types/res';
+
+export function useTrackSelection(selectionId: string) {
+  const authenticated = useIsAuthenticated();
+  return useQuery<TrackSelectionDetailResponse, Error>({
+    queryKey: queryKeys.trackSelection.detail(selectionId),
+    queryFn: () => getTrackSelection(selectionId),
+    enabled: authenticated && Boolean(selectionId),
+  });
+}

--- a/src/domain/track-selection/hooks/useTrackSelectionItems.ts
+++ b/src/domain/track-selection/hooks/useTrackSelectionItems.ts
@@ -1,0 +1,16 @@
+import { useIsAuthenticated } from '@/global/store/authStore';
+import { queryKeys } from '@/global/config/queryKeys';
+import { useInfiniteCursor } from '@/hooks/useInfiniteCursor';
+
+import { getTrackSelectionItems } from '../api/getTrackSelectionItems';
+import type { TrackSelectionItemResponse } from '../types/res';
+
+export function useTrackSelectionItems(selectionId: string, pageSize = 50) {
+  const authenticated = useIsAuthenticated();
+  return useInfiniteCursor<TrackSelectionItemResponse, string>(
+    queryKeys.trackSelection.items(selectionId),
+    ({ lastId, pageSize: size }) => getTrackSelectionItems(selectionId, { lastId, pageSize: size }),
+    pageSize,
+    { enabled: authenticated && Boolean(selectionId) },
+  );
+}

--- a/src/domain/track-selection/hooks/useUpdateItemSelection.ts
+++ b/src/domain/track-selection/hooks/useUpdateItemSelection.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateItemSelection } from '../api/updateItemSelection';
+
+export function useUpdateItemSelection(selectionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ itemId, selected }: { itemId: string; selected: boolean }) =>
+      updateItemSelection(selectionId, itemId, { selected }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.trackSelection.items(selectionId) });
+    },
+  });
+}

--- a/src/domain/track-selection/hooks/useUpdateParticipants.ts
+++ b/src/domain/track-selection/hooks/useUpdateParticipants.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateParticipants, type UpdateParticipantsRequest } from '../api/updateParticipants';
+
+export function useUpdateParticipants(selectionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UpdateParticipantsRequest) => updateParticipants(selectionId, body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.trackSelection.detail(selectionId) });
+    },
+  });
+}

--- a/src/domain/track-selection/hooks/useUpdateSessionConfirmations.ts
+++ b/src/domain/track-selection/hooks/useUpdateSessionConfirmations.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateSessionConfirmations } from '../api/updateSessionConfirmations';
+
+type Args = { itemId: string; sessionId: string; confirm: number[]; unconfirm: number[] };
+
+export function useUpdateSessionConfirmations(selectionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ itemId, sessionId, confirm, unconfirm }: Args) =>
+      updateSessionConfirmations(selectionId, itemId, sessionId, { confirm, unconfirm }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.trackSelection.items(selectionId) });
+    },
+  });
+}

--- a/src/domain/track-selection/hooks/useUpdateTrackSelectionItem.ts
+++ b/src/domain/track-selection/hooks/useUpdateTrackSelectionItem.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { updateTrackSelectionItem } from '../api/updateTrackSelectionItem';
+import type { TrackSelectionItemUpdateRequest } from '../types/req';
+
+export function useUpdateTrackSelectionItem(selectionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ itemId, body }: { itemId: string; body: TrackSelectionItemUpdateRequest }) =>
+      updateTrackSelectionItem(selectionId, itemId, body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.trackSelection.items(selectionId) });
+    },
+  });
+}

--- a/src/domain/track-selection/hooks/useWithdrawSession.ts
+++ b/src/domain/track-selection/hooks/useWithdrawSession.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { queryKeys } from '@/global/config/queryKeys';
+
+import { withdrawSessionApplication } from '../api/withdrawSessionApplication';
+
+export function useWithdrawSession(selectionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      itemId,
+      sessionId,
+      userId,
+    }: {
+      itemId: string;
+      sessionId: string;
+      userId: number;
+    }) => withdrawSessionApplication(selectionId, itemId, sessionId, userId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.trackSelection.items(selectionId) });
+    },
+  });
+}

--- a/src/domain/track-selection/types/req.ts
+++ b/src/domain/track-selection/types/req.ts
@@ -1,0 +1,38 @@
+export interface CreateTrackSelectionRequest {
+  title: string;
+  bandIds: string[];
+  managerId: number;
+  participantUserIds: number[];
+  practiceWindow?: {
+    from: string;
+    to: string;
+  };
+}
+
+export interface SessionDefDto {
+  custom: boolean;
+  label: string;
+  need: number;
+  sessionId: string;
+  short: string;
+}
+
+export interface TrackSelectionItemCreateRequest {
+  title: string;
+  artist: string;
+  album?: string;
+  duration?: number;
+  note?: string;
+  reference?: string;
+  sessions: SessionDefDto[];
+}
+
+export interface TrackSelectionItemUpdateRequest {
+  title?: string;
+  artist?: string;
+  album?: string;
+  duration?: number;
+  note?: string;
+  reference?: string;
+  sessions?: SessionDefDto[];
+}

--- a/src/domain/track-selection/types/res.ts
+++ b/src/domain/track-selection/types/res.ts
@@ -1,0 +1,62 @@
+export interface TrackSelectionResponse {
+  selectionId: string;
+  title: string;
+  bandIds: string[];
+  managerId: number;
+  practiceWindow: { from: string; to: string };
+  createdAt?: string;
+  lockedAt?: string;
+  updatedAt?: string;
+}
+
+export interface ParticipantMemberInfo {
+  memberId: number;
+  name?: string;
+  profileImg?: string;
+}
+
+export interface TrackSelectionParticipant {
+  /** @deprecated BE가 더 이상 필수로 내려주지 않음. member.memberId 를 사용할 것. */
+  memberId?: number;
+  bandIds: string[];
+  member?: ParticipantMemberInfo;
+  isManager: boolean;
+}
+
+export interface TrackSelectionDetailResponse extends TrackSelectionResponse {
+  participants: TrackSelectionParticipant[];
+}
+
+export interface SessionParticipantInfo {
+  memberId: number;
+  name?: string;
+  profileImg?: string;
+}
+
+export interface SessionDefResponse {
+  applicants: SessionParticipantInfo[];
+  confirmed: SessionParticipantInfo[];
+  custom: boolean;
+  label: string;
+  need: number;
+  sessionId: string;
+  short: string;
+}
+
+export interface TrackSelectionItemResponse {
+  trackSelectionItemId: string;
+  selectionId: string;
+  title: string;
+  artist: string;
+  album?: string;
+  duration?: number;
+  note?: string;
+  reference?: string;
+  /** @deprecated BE가 더 이상 필수로 내려주지 않음. proposer.memberId 를 사용할 것. */
+  proposerId?: number;
+  proposer?: SessionParticipantInfo;
+  sessions: SessionDefResponse[];
+  selected: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}

--- a/src/domain/track-selection/utils/resolveMemberId.ts
+++ b/src/domain/track-selection/utils/resolveMemberId.ts
@@ -1,0 +1,10 @@
+/**
+ * BE가 참여자/채팅 응답의 최상위 memberId 필드를 member.memberId 로 이관 중이라
+ * 과도기 호환을 위해 둘 다 확인한다.
+ */
+export function resolveMemberId(entity: {
+  memberId?: number;
+  member?: { memberId: number };
+}): number | undefined {
+  return entity.member?.memberId ?? entity.memberId;
+}

--- a/src/domain/track-selection/utils/toSong.ts
+++ b/src/domain/track-selection/utils/toSong.ts
@@ -1,0 +1,43 @@
+import type { SessionDef, Song } from '@/domain/setlist-meeting/types';
+
+import type { TrackSelectionItemResponse } from '../types/res';
+
+function secondsToMmSs(totalSeconds: number): string {
+  const mm = Math.floor(totalSeconds / 60);
+  const ss = totalSeconds % 60;
+  return `${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
+}
+
+export function mmSsToSeconds(mmss: string | undefined): number | undefined {
+  if (!mmss) return undefined;
+  const [mm = '0', ss = '0'] = mmss.split(':');
+  const total = parseInt(mm, 10) * 60 + parseInt(ss, 10);
+  return total === 0 ? undefined : total;
+}
+
+export function toSong(item: TrackSelectionItemResponse): Song {
+  return {
+    id: item.trackSelectionItemId,
+    meetingId: item.selectionId,
+    title: item.title,
+    artist: item.artist,
+    album: item.album,
+    duration: item.duration != null ? secondsToMmSs(item.duration) : undefined,
+    note: item.note,
+    proposerId: String(item.proposer?.memberId ?? item.proposerId ?? ''),
+    sessions: item.sessions.map<SessionDef>((s) => ({
+      id: s.sessionId,
+      label: s.label,
+      short: s.short,
+      need: s.need,
+      custom: s.custom,
+    })),
+    applicants: Object.fromEntries(
+      item.sessions.map((s) => [s.sessionId, s.applicants.map((p) => String(p.memberId))]),
+    ),
+    confirmed: Object.fromEntries(
+      item.sessions.map((s) => [s.sessionId, s.confirmed.map((p) => String(p.memberId))]),
+    ),
+    isSelected: item.selected,
+  };
+}

--- a/src/lib/domain-icons.tsx
+++ b/src/lib/domain-icons.tsx
@@ -3,20 +3,20 @@ import { CalendarDays, Guitar, ListMusic, Music, type LucideIcon } from 'lucide-
 import type { IconTileTone } from '@/components/ui/icon-tile';
 import type { ListItemSelectedTone } from '@/lib/list-item-styles';
 
-export type DomainType = 'band' | 'practice' | 'performance' | 'setlist-meeting';
+export type DomainType = 'band' | 'practice' | 'performance' | 'track-selection';
 
 export const DOMAIN_ICONS: Record<DomainType, LucideIcon> = {
   band: Guitar,
   practice: Music,
   performance: CalendarDays,
-  'setlist-meeting': ListMusic,
+  'track-selection': ListMusic,
 };
 
 export const DOMAIN_TONES: Record<DomainType, IconTileTone> = {
   band: 'accent',
   practice: 'success',
   performance: 'blue',
-  'setlist-meeting': 'accent',
+  'track-selection': 'accent',
 };
 
 /** 리스트 선택 상태 톤은 design/dist/css/screens.css 기준으로 accent / amber 두 가지만 사용. */
@@ -24,5 +24,5 @@ export const DOMAIN_LIST_SELECTED_TONES: Record<DomainType, ListItemSelectedTone
   band: 'accent',
   practice: 'accent',
   performance: 'amber',
-  'setlist-meeting': 'accent',
+  'track-selection': 'accent',
 };


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-97](https://sunwoo1137.atlassian.net/browse/BD-97)

📌 **작업 내용 및 특이사항**

- `setlist-meeting`에서 분리된 `track-selection` 도메인 API/훅/타입 전체 추가 (선곡회의 CRUD, 세션 지원/확정, 채팅, 참여자 관리) — 실제 서버 엔드포인트는 `/api/v1/track-selections`
- BE가 참여자/세션 지원자·확정자/채팅 발신자 정보를 "memberId 단독 필드"에서 "member 객체(memberId+name+profileImg)"로 이관하면서 발생한 breaking change에 대응 — `resolveMemberId` 헬퍼 도입해 세션 담당자·채팅 발신자 이름이 "멤버 #undefined"로 깨지던 문제 수정
- 선곡 목록(`/track-selections`), 셋리스트 목록(`/setlists`, 신규) 페이지를 기존 합주 목록과 동일한 패턴(오버레이 사이드패널 제거 → 단일 리스트 페이지)으로 재구성. 두 기능 모두 PC 전용이라 모바일에서는 안내 문구만 노출
- 셋리스트 상세 페이지 우측에 트랙 기반 합주 시간표 미리보기 패널(`SetlistScheduleBoard`) 추가 — 기존 `schedule-coordination`의 `WeeklyScheduleGrid`를 재사용한 로컬 배치 미리보기이며, 실제 자동배치 API(`/performances/{id}/schedule-boards/...`)는 공연 단위라 셋리스트 상세 페이지와 스코프가 안 맞아 이번 범위에서는 제외
- 신규 도메인 훅(`setlist`: `useCreateSetlist`/`useUpdateSetlist`/`useDeleteSetlistTrack` 등) 및 밴드/합주 생성 페이지 보강

📚 **참고사항**

- `src/middleware.ts` 변경은 별도 관리 대상이라 이번 커밋에서 제외함
- 공연 단위 시간표 자동배치(`schedule-boards`/`schedule-blocks`/`schedule-auto-place`) API 연동은 별도 태스크로 진행 필요 — 셋리스트가 여러 공연에 연결될 수 있어 "어느 공연 기준으로 보여줄지" 결정 필요

[BD-97]: https://sunwoo1137.atlassian.net/browse/BD-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ