### PR TITLE
[BD-190] fix: 공연 포스터 등록 API 연동 버그 수정

### DIFF
--- a/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
+++ b/src/app/(main)/performances/[performanceId]/PerformanceDetailContent.client.tsx
@@ -147,13 +147,13 @@ export function PerformanceDetailContent({
     try {
       const ext = extFromMime(file.type);
       if (!ext) throw new Error('지원하지 않는 이미지 형식입니다.');
-      const presign = await issuePerformancePosterPresignedUrl({
+      const presign = await issuePerformancePosterPresignedUrl(performanceId, {
         contentType: file.type,
         contentLength: file.size,
         ext,
       });
       await uploadToPresignedUrl(presign.uploadUrl, file);
-      await createPerformancePoster({ performanceId, objectKey: presign.objectKey });
+      await createPerformancePoster({ performanceId, imageKey: presign.objectKey });
       await queryClient.invalidateQueries({
         queryKey: queryKeys.performancePoster.list(performanceId),
       });

--- a/src/domain/performance-poster/api/index.ts
+++ b/src/domain/performance-poster/api/index.ts
@@ -10,11 +10,13 @@ import type { PerformancePosterPresignResponse, PerformancePosterResponse } from
 const PREFIX = '/api/v1/performance-posters';
 
 export async function issuePerformancePosterPresignedUrl(
+  performanceId: string,
   req: PerformancePosterPresignRequest,
 ): Promise<PerformancePosterPresignResponse> {
   const data = await apiClient.post<PerformancePosterPresignResponse>(
     `${PREFIX}/presigned-url`,
     req,
+    { query: { performanceId } },
   );
   if (!data) throw new Error('presigned URL 응답이 비어 있습니다.');
   return data;

--- a/src/domain/performance-poster/types/req.ts
+++ b/src/domain/performance-poster/types/req.ts
@@ -6,7 +6,7 @@ export interface PerformancePosterPresignRequest {
 
 export interface CreatePerformancePosterRequest {
   performanceId: string;
-  objectKey: string;
+  imageKey: string;
   description?: string;
 }
 


### PR DESCRIPTION
## 🛠️ Issue Number
### closes [BD-190](https://sunwoo1137.atlassian.net/browse/BD-190)

📌 **작업 내용 및 특이사항**

- `POST /performance-posters/presigned-url` 호출 시 `performanceId` 쿼리 파라미터가 누락되어 있었음. 이 엔드포인트는 OWNER/MANAGER 권한 체크를 위해 `performanceId`가 필요한데, 이게 안 넘어가서 401 `UNAUTHORIZED`("인증되지 않은 회원입니다")가 발생 → `issuePerformancePosterPresignedUrl(performanceId, req)`로 시그니처 변경, `query: { performanceId }`로 전달하도록 수정
- `POST /performance-posters`(포스터 등록) 요청 바디 필드명이 실제 API 스펙(`imageKey`)과 다르게 `objectKey`로 되어 있어 400 Bad Request 발생 → `CreatePerformancePosterRequest.objectKey` → `imageKey`로 수정
- 실제 사용자 리포트(Swagger 응답 캡처)로 재현 확인 후 수정, presigned URL 발급까지는 200 확인됨

📚 **참고사항**

- `performance-poster` 영역은 `fe-areas.json`에 `specPending: true`로 표시돼 있어(openapi 스냅샷 미반영) 이번 필드명 불일치도 스펙 동기화 문제였음. 스냅샷이 갱신되면 재확인 필요

[BD-190]: https://sunwoo1137.atlassian.net/browse/BD-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ